### PR TITLE
Bugfix mobile 671 fix crash

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisActivity.java
@@ -1,7 +1,11 @@
 package net.gini.android.vision.analysis;
 
-import static net.gini.android.vision.internal.util.ActivityHelper.enableHomeAsUp;
-import static net.gini.android.vision.internal.util.ActivityHelper.handleMenuItemPressedForHomeButton;
+import net.gini.android.vision.Document;
+import net.gini.android.vision.GiniVisionError;
+import net.gini.android.vision.R;
+import net.gini.android.vision.camera.CameraActivity;
+import net.gini.android.vision.onboarding.OnboardingActivity;
+import net.gini.android.vision.review.ReviewActivity;
 
 import android.content.Context;
 import android.content.Intent;
@@ -12,12 +16,8 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.View;
 
-import net.gini.android.vision.Document;
-import net.gini.android.vision.GiniVisionError;
-import net.gini.android.vision.R;
-import net.gini.android.vision.camera.CameraActivity;
-import net.gini.android.vision.onboarding.OnboardingActivity;
-import net.gini.android.vision.review.ReviewActivity;
+import static net.gini.android.vision.internal.util.ActivityHelper.enableHomeAsUp;
+import static net.gini.android.vision.internal.util.ActivityHelper.handleMenuItemPressedForHomeButton;
 
 /**
  * <h3>Screen API</h3>
@@ -153,9 +153,11 @@ public abstract class AnalysisActivity extends AppCompatActivity implements Anal
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.gv_activity_analysis);
+        readExtras();
         if (savedInstanceState == null) {
-            readExtras();
             initFragment();
+        } else {
+            retainFragment();
         }
         enableHomeAsUp(this);
     }
@@ -207,6 +209,10 @@ public abstract class AnalysisActivity extends AppCompatActivity implements Anal
 
     private void createFragment() {
         mFragment = AnalysisFragmentCompat.createInstance(mDocument, mAnalysisErrorMessage);
+    }
+
+    private void retainFragment() {
+        mFragment = (AnalysisFragmentCompat) getSupportFragmentManager().findFragmentByTag(ANALYSIS_FRAGMENT);
     }
 
     private void showFragment() {

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
@@ -161,8 +161,8 @@ public abstract class ReviewActivity extends AppCompatActivity implements Review
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.gv_activity_review);
+        readExtras();
         if (savedInstanceState == null) {
-            readExtras();
             initFragment();
         } else {
             retainFragment();
@@ -208,10 +208,6 @@ public abstract class ReviewActivity extends AppCompatActivity implements Review
         }
     }
 
-    private void retainFragment() {
-        mFragment = (ReviewFragmentCompat) getSupportFragmentManager().findFragmentByTag(REVIEW_FRAGMENT);
-    }
-
     private void initFragment() {
         if (!isFragmentShown()) {
             createFragment();
@@ -225,6 +221,10 @@ public abstract class ReviewActivity extends AppCompatActivity implements Review
 
     private void createFragment() {
         mFragment = ReviewFragmentCompat.createInstance(mDocument);
+    }
+
+    private void retainFragment() {
+        mFragment = (ReviewFragmentCompat) getSupportFragmentManager().findFragmentByTag(REVIEW_FRAGMENT);
     }
 
     private void showFragment() {

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
@@ -1,7 +1,11 @@
 package net.gini.android.vision.review;
 
-import static net.gini.android.vision.internal.util.ActivityHelper.enableHomeAsUp;
-import static net.gini.android.vision.internal.util.ActivityHelper.handleMenuItemPressedForHomeButton;
+import net.gini.android.vision.Document;
+import net.gini.android.vision.GiniVisionError;
+import net.gini.android.vision.R;
+import net.gini.android.vision.analysis.AnalysisActivity;
+import net.gini.android.vision.camera.CameraActivity;
+import net.gini.android.vision.onboarding.OnboardingActivity;
 
 import android.content.Context;
 import android.content.Intent;
@@ -11,12 +15,8 @@ import android.support.annotation.VisibleForTesting;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
-import net.gini.android.vision.Document;
-import net.gini.android.vision.GiniVisionError;
-import net.gini.android.vision.R;
-import net.gini.android.vision.analysis.AnalysisActivity;
-import net.gini.android.vision.camera.CameraActivity;
-import net.gini.android.vision.onboarding.OnboardingActivity;
+import static net.gini.android.vision.internal.util.ActivityHelper.enableHomeAsUp;
+import static net.gini.android.vision.internal.util.ActivityHelper.handleMenuItemPressedForHomeButton;
 
 /**
  * <h3>Screen API</h3>
@@ -164,6 +164,8 @@ public abstract class ReviewActivity extends AppCompatActivity implements Review
         if (savedInstanceState == null) {
             readExtras();
             initFragment();
+        } else {
+            retainFragment();
         }
         enableHomeAsUp(this);
     }
@@ -204,6 +206,10 @@ public abstract class ReviewActivity extends AppCompatActivity implements Review
         if (mAnalyzeDocumentActivityIntent == null) {
             throw new IllegalStateException("ReviewActivity requires an AnalyzeDocumentActivity class. Call setAnalyzeDocumentActivityExtra() to set it.");
         }
+    }
+
+    private void retainFragment() {
+        mFragment = (ReviewFragmentCompat) getSupportFragmentManager().findFragmentByTag(REVIEW_FRAGMENT);
     }
 
     private void initFragment() {


### PR DESCRIPTION
## Fixed Crash when activity goes to background
## Information
When the activity goes to the background in the review/analyse screen and the system "kills" it(due to resource allocations), or "Don't keep activities" in the developer options are activate, the screen library crashes. This PR fixes it, since the fragment was only created and not retained when `Activity#onCreate()` was called with a saved instance.
## How to test
Go to the review screen and bring the app to the back- and then foreground. Enable/disable the developer option "Don't keep Activities".