### PR TITLE
More lenient preview resolution selection

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
@@ -1,6 +1,6 @@
 package net.gini.android.vision.internal.camera.api;
 
-import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper.getLargestSizeWithSameAspectRatio;
+import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper.getLargestSizeWithSimilarAspectRatio;
 import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper.getLargestSize;
 
 import android.app.Activity;
@@ -359,7 +359,7 @@ public class CameraController implements CameraInterface {
 
     private void selectPreviewSize(final Camera.Parameters params) {
         List<Camera.Size> previewSizes = params.getSupportedPreviewSizes();
-        Size previewSize = getLargestSizeWithSameAspectRatio(previewSizes, mPictureSize);
+        Size previewSize = getLargestSizeWithSimilarAspectRatio(previewSizes, mPictureSize);
         if (previewSize != null) {
             mPreviewSize = previewSize;
             params.setPreviewSize(mPreviewSize.width, mPreviewSize.height);

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper.java
@@ -26,7 +26,7 @@ public final class SizeSelectionHelper {
     }
 
     @Nullable
-    public static Size getLargestSizeWithSameAspectRatio(
+    public static Size getLargestSizeWithSimilarAspectRatio(
             @NonNull final List<Camera.Size> sizes, @NonNull final Size referenceSize) {
         List<Camera.Size> sameAspectSizes = getSameAspectRatioSizes(sizes, referenceSize);
         return getLargestSize(sameAspectSizes);
@@ -40,16 +40,16 @@ public final class SizeSelectionHelper {
         List<Camera.Size> sameAspectSizes = new ArrayList<>();
         for (final Camera.Size size : sizes) {
             final float aspectRatio = (float) size.width / (float) size.height;
-            if (isSameAspectRatio(aspectRatio, referenceAspectRatio)) {
+            if (isSimilarAspectRatio(aspectRatio, referenceAspectRatio)) {
                 sameAspectSizes.add(size);
             }
         }
         return sameAspectSizes;
     }
 
-    private static boolean isSameAspectRatio(final float aspectRatio,
+    private static boolean isSimilarAspectRatio(final float aspectRatio,
             final float referenceAspectRatio) {
-        return Math.abs(aspectRatio - referenceAspectRatio) < 0.01f;
+        return Math.abs(aspectRatio - referenceAspectRatio) < 0.1f;
     }
 
     private static long getArea(final Camera.Size size) {

--- a/ginivision/src/main/java/net/gini/android/vision/requirements/CameraResolutionRequirement.java
+++ b/ginivision/src/main/java/net/gini/android/vision/requirements/CameraResolutionRequirement.java
@@ -45,7 +45,7 @@ class CameraResolutionRequirement implements Requirement {
                     return new RequirementReport(getId(), result, details);
                 }
 
-                Size previewSize = SizeSelectionHelper.getLargestSizeWithSameAspectRatio(
+                Size previewSize = SizeSelectionHelper.getLargestSizeWithSimilarAspectRatio(
                         parameters.getSupportedPreviewSizes(), pictureSize);
                 if (previewSize == null) {
                     result = false;

--- a/ginivision/src/test/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper_GetLargestSizeWithSameAspectRatioTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper_GetLargestSizeWithSameAspectRatioTest.java
@@ -25,27 +25,43 @@ public class SizeSelectionHelper_GetLargestSizeWithSameAspectRatioTest {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][]{
-                // 16:9
+                // 16:9, (~1.77)
                 {"Largest 16:9 from decreasing resolutions", DECREASING_RESOLUTIONS,
                         new int[]{16, 9}, new int[]{4096, 2304}},
                 {"Largest 16:9 from increasing resolutions", INCREASING_RESOLUTIONS,
                         new int[]{16, 9}, new int[]{4096, 2304}},
                 {"Largest 16:9 from unsorted resolutions", UNSORTED_RESOLUTIONS,
                         new int[]{16, 9}, new int[]{4096, 2304}},
-                // 4:3
+                // 4:3, (~1.33)
                 {"Largest 4:3 from decreasing resolutions", DECREASING_RESOLUTIONS,
                         new int[]{4, 3}, new int[]{4096, 3072}},
                 {"Largest 4:3 from increasing resolutions", INCREASING_RESOLUTIONS,
                         new int[]{4, 3}, new int[]{4096, 3072}},
                 {"Largest 4:3 from unsorted resolutions", UNSORTED_RESOLUTIONS,
                         new int[]{4, 3}, new int[]{4096, 3072}},
-                // 14:9
+                // 14:9 (~1.55)
                 {"Largest 14:9 from decreasing resolutions", DECREASING_RESOLUTIONS,
                         new int[]{376, 240}, new int[]{3200, 2048}},
                 {"Largest 14:9 from increasing resolutions", INCREASING_RESOLUTIONS,
                         new int[]{376, 240}, new int[]{3200, 2048}},
                 {"Largest 14:9 from unsorted resolutions", UNSORTED_RESOLUTIONS,
-                        new int[]{376, 240}, new int[]{3200, 2048}}
+                        new int[]{376, 240}, new int[]{3200, 2048}},
+                // No exact matching aspect ratio for 4224x3136 (~1.346939) but should still find
+                // a similar resolution
+                {"Largest similar for 4224x3136 from decreasing resolutions", DECREASING_RESOLUTIONS,
+                        new int[]{4224, 3136}, new int[]{4096, 3072}},
+                {"Largest similar for 4224x3136 from increasing resolutions", INCREASING_RESOLUTIONS,
+                        new int[]{4224, 3136}, new int[]{4096, 3072}},
+                {"Largest similar for 4224x3136 from unsorted resolutions", UNSORTED_RESOLUTIONS,
+                        new int[]{4224, 3136}, new int[]{4096, 3072}},
+                // No exact matching aspect ratio for 5376x3752 (~1.432836) but should still find
+                // a similar resolution
+                {"Largest similar for 5376x3752 from decreasing resolutions", DECREASING_RESOLUTIONS,
+                        new int[]{5376, 3752}, new int[]{4096, 3072}},
+                {"Largest similar for 5376x3752 from increasing resolutions", INCREASING_RESOLUTIONS,
+                        new int[]{5376, 3752}, new int[]{4096, 3072}},
+                {"Largest similar for 5376x3752 from unsorted resolutions", UNSORTED_RESOLUTIONS,
+                        new int[]{5376, 3752}, new int[]{4096, 3072}},
         });
     }
 
@@ -66,7 +82,7 @@ public class SizeSelectionHelper_GetLargestSizeWithSameAspectRatioTest {
     @Test
     public void should_returnLargestSameAspectRatioSize() {
         List<Camera.Size> sizes = toSizesList(resolutions);
-        Size largestSize = SizeSelectionHelper.getLargestSizeWithSameAspectRatio(sizes,
+        Size largestSize = SizeSelectionHelper.getLargestSizeWithSimilarAspectRatio(sizes,
                 toSize(referenceResolution));
         assertSizeEqualsResolution(largestSize, expectedResolution);
     }


### PR DESCRIPTION
Loosened the preview resolution to picture resolution aspect ratio matching. On devices like the HTC One E8 or HTC One M9 no matching preview resolution could be found.

### How to test
Run the tests in `ginivision/src/test`.

You can also run the `ginivision/src/androidTest/java/net/gini/android/vision/requirements/GiniVisionRequirementsTest.java`on a device to, but since all our device worked before this can be omitted.

### Merging
Merge after PR #28. `SizeSelectionHelper#getLargestSizeWithSameAspectRatio()`was renamed to `getLargestSizeWithSimilarAspectRatio()`and a test from #28 needs to be updated to use the new name.

### Ticket 
No ticket.