### PR TITLE
Camera trigger is aligned to the preview’s bottom

### DIFF
--- a/ginivision/src/main/res/layout/gv_fragment_camera.xml
+++ b/ginivision/src/main/res/layout/gv_fragment_camera.xml
@@ -35,7 +35,7 @@
         android:id="@+id/gv_button_camera_trigger"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
+        android:layout_alignBottom="@+id/gv_camera_preview"
         android:layout_centerHorizontal="true"
         android:layout_marginBottom="@dimen/gv_camera_button_vertical_margin"
         android:background="@null"


### PR DESCRIPTION
For a nicer UI we align the camera trigger button to the bottom of the preview view.

### How to test
Run the Screen or Component API example apps on different devices.

### Merging
Nothing special.

### Ticket 
No ticket.