### PR TITLE
Feature auto focus run if no cont focus

### DIFF
--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/api/CameraControllerWithMockableCamera.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/api/CameraControllerWithMockableCamera.java
@@ -1,0 +1,28 @@
+package net.gini.android.vision.internal.camera.api;
+
+import android.app.Activity;
+import android.hardware.Camera;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+public class CameraControllerWithMockableCamera extends CameraController {
+
+    private Camera mMockCamera;
+
+    public CameraControllerWithMockableCamera(@NonNull Activity activity) {
+        super(activity);
+    }
+
+    public void setMockCamera(Camera mockCamera) {
+        this.mMockCamera = mockCamera;
+    }
+
+    @Nullable
+    @Override
+    protected Camera openCamera() {
+        if (mMockCamera != null) {
+            return mMockCamera;
+        }
+        return super.openCamera();
+    }
+}

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/api/CameraControllerWithMockedFocusingAndPictureTaking.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/api/CameraControllerWithMockedFocusingAndPictureTaking.java
@@ -1,0 +1,28 @@
+package net.gini.android.vision.internal.camera.api;
+
+import android.app.Activity;
+import android.hardware.Camera;
+import android.support.annotation.NonNull;
+
+import jersey.repackaged.jsr166e.CompletableFuture;
+
+public class CameraControllerWithMockedFocusingAndPictureTaking extends
+        CameraControllerWithMockableCamera {
+
+    public CameraControllerWithMockedFocusingAndPictureTaking(@NonNull final Activity activity) {
+        super(activity);
+    }
+
+    @NonNull
+    @Override
+    public CompletableFuture<Boolean> focus() {
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
+        future.complete(true);
+        return future;
+    }
+
+    @Override
+    protected void takePicture(final Camera.PictureCallback callback) {
+        callback.onPictureTaken(new byte[]{0}, getCamera());
+    }
+}

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
@@ -1,5 +1,10 @@
 package net.gini.android.vision.internal.camera.api;
 
+import static net.gini.android.vision.internal.camera.api.CameraParametersHelper
+        .isFlashModeSupported;
+import static net.gini.android.vision.internal.camera.api.CameraParametersHelper
+        .isFocusModeSupported;
+import static net.gini.android.vision.internal.camera.api.CameraParametersHelper.isUsingFocusMode;
 import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper
         .getLargestSizeWithSameAspectRatio;
 import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper.getLargestSize;
@@ -58,12 +63,10 @@ public class CameraController implements CameraInterface {
                 return;
             }
             Camera.Parameters parameters = mCamera.getParameters();
-            if (!parameters.getFocusMode().equals(
-                    Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
-                if (parameters.getSupportedFocusModes().contains(
-                        Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
-                    parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
-                }
+            if (!isUsingFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE, mCamera)
+                    && isFocusModeSupported(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE,
+                    mCamera)) {
+                parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
             }
             mCamera.setParameters(parameters);
         }
@@ -206,11 +209,9 @@ public class CameraController implements CameraInterface {
                             focusRect.top, focusRect.right, focusRect.bottom);
 
                     Camera.Parameters parameters = mCamera.getParameters();
-                    if (!parameters.getFocusMode().equals(Camera.Parameters.FOCUS_MODE_AUTO)) {
-                        if (parameters.getSupportedFocusModes().contains(
-                                Camera.Parameters.FOCUS_MODE_AUTO)) {
-                            parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_AUTO);
-                        }
+                    if (!isUsingFocusMode(Camera.Parameters.FOCUS_MODE_AUTO, mCamera)
+                            && isFocusModeSupported(Camera.Parameters.FOCUS_MODE_AUTO, mCamera)) {
+                        parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_AUTO);
                     }
                     if (parameters.getMaxNumFocusAreas() > 0) {
                         List<Camera.Area> mylist = new ArrayList<Camera.Area>();
@@ -386,8 +387,7 @@ public class CameraController implements CameraInterface {
     }
 
     private void selectFocusMode(final Camera.Parameters params) {
-        if (params.getSupportedFocusModes().contains(
-                Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
+        if (isFocusModeSupported(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE, mCamera)) {
             params.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
             LOG.debug("Focus mode continuous picture");
         } else {
@@ -396,9 +396,7 @@ public class CameraController implements CameraInterface {
     }
 
     private void selectFlashMode(final Camera.Parameters params) {
-        List<String> supportedFlashModes = params.getSupportedFlashModes();
-        if (supportedFlashModes != null && supportedFlashModes.contains(
-                Camera.Parameters.FLASH_MODE_ON)) {
+        if (isFlashModeSupported(Camera.Parameters.FLASH_MODE_ON, mCamera)) {
             params.setFlashMode(Camera.Parameters.FLASH_MODE_ON);
             LOG.debug("Flash on");
         } else {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
@@ -1,13 +1,10 @@
 package net.gini.android.vision.internal.camera.api;
 
-import static net.gini.android.vision.internal.camera.api.CameraParametersHelper
-        .isFlashModeSupported;
-import static net.gini.android.vision.internal.camera.api.CameraParametersHelper
-        .isFocusModeSupported;
+import static net.gini.android.vision.internal.camera.api.CameraParametersHelper.isFlashModeSupported;
+import static net.gini.android.vision.internal.camera.api.CameraParametersHelper.isFocusModeSupported;
 import static net.gini.android.vision.internal.camera.api.CameraParametersHelper.isUsingFocusMode;
 import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper.getLargestSize;
-import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper
-        .getLargestSizeWithSimilarAspectRatio;
+import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper.getLargestSizeWithSimilarAspectRatio;
 
 import android.app.Activity;
 import android.graphics.Matrix;
@@ -94,7 +91,7 @@ public class CameraController implements CameraInterface {
             return CompletableFuture.completedFuture(null);
         }
         try {
-            mCamera = Camera.open();
+            mCamera = openCamera();
             if (mCamera != null) {
                 configureCamera(mActivity);
                 LOG.info("Camera opened");
@@ -107,6 +104,12 @@ public class CameraController implements CameraInterface {
             LOG.error("Cannot start camera", e);
             return failedFuture(e);
         }
+    }
+
+    @VisibleForTesting
+    @Nullable
+    protected Camera openCamera() {
+        return Camera.open();
     }
 
     @Override
@@ -340,7 +343,7 @@ public class CameraController implements CameraInterface {
         focusFuture.handle(new CompletableFuture.BiFun<Boolean, Throwable, Void>() {
             @Override
             public Void apply(final Boolean aBoolean, final Throwable throwable) {
-                mCamera.takePicture(null, null, new Camera.PictureCallback() {
+                takePicture(new Camera.PictureCallback() {
                     @Override
                     public void onPictureTaken(final byte[] bytes, Camera camera) {
                         mTakingPictureFuture.set(null);
@@ -354,6 +357,14 @@ public class CameraController implements CameraInterface {
         });
 
         return pictureTaken;
+    }
+
+    @VisibleForTesting
+    protected void takePicture(Camera.PictureCallback callback) {
+        if (mCamera == null) {
+            return;
+        }
+        mCamera.takePicture(null, null, callback);
     }
 
     @NonNull

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
@@ -1,6 +1,7 @@
 package net.gini.android.vision.internal.camera.api;
 
-import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper.getLargestSizeWithSameAspectRatio;
+import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper
+        .getLargestSizeWithSameAspectRatio;
 import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper.getLargestSize;
 
 import android.app.Activity;
@@ -41,7 +42,8 @@ public class CameraController implements CameraInterface {
 
     private boolean mPreviewRunning = false;
     private AtomicReference<CompletableFuture<Boolean>> mFocusingFuture = new AtomicReference<>();
-    private AtomicReference<CompletableFuture<Photo>> mTakingPictureFuture = new AtomicReference<>();
+    private AtomicReference<CompletableFuture<Photo>> mTakingPictureFuture =
+            new AtomicReference<>();
 
     private Size mPreviewSize = new Size(0, 0);
     private Size mPictureSize = new Size(0, 0);
@@ -170,7 +172,8 @@ public class CameraController implements CameraInterface {
     }
 
     @Override
-    public void enableTapToFocus(@NonNull View tapView, @Nullable final TapToFocusListener listener) {
+    public void enableTapToFocus(@NonNull View tapView,
+            @Nullable final TapToFocusListener listener) {
         LOG.info("Tap to focus enabled");
         tapView.setOnTouchListener(new View.OnTouchListener() {
             @Override
@@ -185,7 +188,8 @@ public class CameraController implements CameraInterface {
                     }
                     final CompletableFuture<Boolean> focused = new CompletableFuture<>();
                     do {
-                        // Checking whether a completable is already available in which case focusing is in progress
+                        // Checking whether a completable is already available in which case
+                        // focusing is in progress
                         final CompletableFuture<Boolean> inProgress = mFocusingFuture.get();
                         if (inProgress != null) {
                             LOG.info("Already focusing");
@@ -196,8 +200,10 @@ public class CameraController implements CameraInterface {
                     } while (!mFocusingFuture.compareAndSet(null, focused));
 
                     mCamera.cancelAutoFocus();
-                    Rect focusRect = calculateTapArea(x, y, getBackFacingCameraOrientation(), view.getWidth(), view.getHeight());
-                    LOG.debug("Focus rect calculated (l:{}, t:{}, r:{}, b:{})", focusRect.left, focusRect.top, focusRect.right, focusRect.bottom);
+                    Rect focusRect = calculateTapArea(x, y, getBackFacingCameraOrientation(),
+                            view.getWidth(), view.getHeight());
+                    LOG.debug("Focus rect calculated (l:{}, t:{}, r:{}, b:{})", focusRect.left,
+                            focusRect.top, focusRect.right, focusRect.bottom);
 
                     Camera.Parameters parameters = mCamera.getParameters();
                     if (!parameters.getFocusMode().equals(Camera.Parameters.FOCUS_MODE_AUTO)) {
@@ -262,7 +268,8 @@ public class CameraController implements CameraInterface {
 
         final CompletableFuture<Boolean> completed = new CompletableFuture<>();
         do {
-            // Checking whether a completable is already available in which case focusing is in progress
+            // Checking whether a completable is already available in which case focusing is in
+            // progress
             final CompletableFuture<Boolean> inProgress = mFocusingFuture.get();
             if (inProgress != null) {
                 LOG.info("Already focusing");
@@ -297,7 +304,8 @@ public class CameraController implements CameraInterface {
 
         final CompletableFuture<Photo> pictureTaken = new CompletableFuture<>();
         do {
-            // Checking whether a completable is already available in which case taking the picture is in progress
+            // Checking whether a completable is already available in which case taking the
+            // picture is in progress
             final CompletableFuture<Photo> inProgress = mTakingPictureFuture.get();
             if (inProgress != null) {
                 LOG.info("Already taking a picture");
@@ -307,7 +315,8 @@ public class CameraController implements CameraInterface {
             // Otherwise we set the new completable and exit the loop
         } while (!mTakingPictureFuture.compareAndSet(null, pictureTaken));
 
-        // Preview is stopped after the picture was taken, but for it's sufficient to declare preview
+        // Preview is stopped after the picture was taken, but for it's sufficient to declare
+        // preview
         // as being stopped before it is really stopped
         mPreviewRunning = false;
 
@@ -377,7 +386,8 @@ public class CameraController implements CameraInterface {
     }
 
     private void selectFocusMode(final Camera.Parameters params) {
-        if (params.getSupportedFocusModes().contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
+        if (params.getSupportedFocusModes().contains(
+                Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
             params.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
             LOG.debug("Focus mode continuous picture");
         } else {
@@ -387,7 +397,8 @@ public class CameraController implements CameraInterface {
 
     private void selectFlashMode(final Camera.Parameters params) {
         List<String> supportedFlashModes = params.getSupportedFlashModes();
-        if (supportedFlashModes != null && supportedFlashModes.contains(Camera.Parameters.FLASH_MODE_ON)) {
+        if (supportedFlashModes != null && supportedFlashModes.contains(
+                Camera.Parameters.FLASH_MODE_ON)) {
             params.setFlashMode(Camera.Parameters.FLASH_MODE_ON);
             LOG.debug("Flash on");
         } else {
@@ -474,9 +485,9 @@ public class CameraController implements CameraInterface {
      * |                 |                |
      * (-1000,1000)------|------(1000,1000)
      * </pre>
-     * The sensor's coordinates are not adapted to the display orientation, that means that in our case where
-     * we always show the camera preview in portrait, the coordinates are simply turned 90 degrees clockwise
-     * (for most devices, for others the calculated rect is rotated):
+     * The sensor's coordinates are not adapted to the display orientation, that means that in our
+     * case where we always show the camera preview in portrait, the coordinates are simply turned
+     * 90 degrees clockwise (for most devices, for others the calculated rect is rotated):
      * <pre>
      * (-1000,1000)---|---(-1000,-1000)
      * |              |               |
@@ -502,14 +513,13 @@ public class CameraController implements CameraInterface {
      * </pre>
      * </p>
      * <p>
-     * For easier conversion, we divided the view area into four parts (A, B, C, D) and do the conversion for each one
-     * separately.
+     * For easier conversion, we divided the view area into four parts (A, B, C, D) and do the
+     * conversion for each one separately.
      * </p>
      * <p>
-     * Calculations are made with the assumption of a 90 degree
-     * camera orientation. The real camera's orientation is normalized by subtracting 90 degrees and then the
-     * calculated
-     * rect is rotated by the normalized degrees.
+     * Calculations are made with the assumption of a 90 degree camera orientation. The real
+     * camera's orientation is normalized by subtracting 90 degrees and then the calculated rect is
+     * rotated by the normalized degrees.
      * </p>
      *
      * @param x             tap's X position in the view
@@ -518,7 +528,8 @@ public class CameraController implements CameraInterface {
      * @param tapViewWidth  the width of the tappable view
      * @param tapViewHeight the height of the tappable view
      */
-    private Rect calculateTapArea(float x, float y, int orientation, int tapViewWidth, int tapViewHeight) {
+    private Rect calculateTapArea(float x, float y, int orientation, int tapViewWidth,
+            int tapViewHeight) {
         Rect rect = new Rect(0, 0, 0, 0);
         if (x < tapViewWidth / 2.f && y < tapViewHeight / 2.f) {
             // A: x: -1000 .. 0; y: 1000 .. 0

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
@@ -56,8 +56,12 @@ public class CameraController implements CameraInterface {
                 return;
             }
             Camera.Parameters parameters = mCamera.getParameters();
-            if (!parameters.getFocusMode().equals(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
-                parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
+            if (!parameters.getFocusMode().equals(
+                    Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
+                if (parameters.getSupportedFocusModes().contains(
+                        Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
+                    parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE);
+                }
             }
             mCamera.setParameters(parameters);
         }
@@ -197,7 +201,10 @@ public class CameraController implements CameraInterface {
 
                     Camera.Parameters parameters = mCamera.getParameters();
                     if (!parameters.getFocusMode().equals(Camera.Parameters.FOCUS_MODE_AUTO)) {
-                        parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_AUTO);
+                        if (parameters.getSupportedFocusModes().contains(
+                                Camera.Parameters.FOCUS_MODE_AUTO)) {
+                            parameters.setFocusMode(Camera.Parameters.FOCUS_MODE_AUTO);
+                        }
                     }
                     if (parameters.getMaxNumFocusAreas() > 0) {
                         List<Camera.Area> mylist = new ArrayList<Camera.Area>();

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraParametersHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraParametersHelper.java
@@ -1,0 +1,27 @@
+package net.gini.android.vision.internal.camera.api;
+
+import android.hardware.Camera;
+
+import java.util.List;
+
+/**
+ * @exclude
+ */
+final class CameraParametersHelper {
+
+    private CameraParametersHelper() {
+    }
+
+    static boolean isFocusModeSupported(String focusMode, Camera camera) {
+        return camera.getParameters().getSupportedFocusModes().contains(focusMode);
+    }
+
+    static boolean isUsingFocusMode(String focusMode, Camera camera) {
+        return camera.getParameters().getFocusMode().equals(focusMode);
+    }
+
+    static boolean isFlashModeSupported(String flashMode, Camera camera) {
+        List<String> supportedFlashModes = camera.getParameters().getSupportedFlashModes();
+        return supportedFlashModes != null && supportedFlashModes.contains(flashMode);
+    }
+}

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraParametersHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraParametersHelper.java
@@ -1,6 +1,7 @@
 package net.gini.android.vision.internal.camera.api;
 
 import android.hardware.Camera;
+import android.support.annotation.NonNull;
 
 import java.util.List;
 
@@ -12,15 +13,15 @@ final class CameraParametersHelper {
     private CameraParametersHelper() {
     }
 
-    static boolean isFocusModeSupported(String focusMode, Camera camera) {
+    static boolean isFocusModeSupported(@NonNull String focusMode, @NonNull Camera camera) {
         return camera.getParameters().getSupportedFocusModes().contains(focusMode);
     }
 
-    static boolean isUsingFocusMode(String focusMode, Camera camera) {
+    static boolean isUsingFocusMode(@NonNull String focusMode, @NonNull Camera camera) {
         return camera.getParameters().getFocusMode().equals(focusMode);
     }
 
-    static boolean isFlashModeSupported(String flashMode, Camera camera) {
+    static boolean isFlashModeSupported(@NonNull String flashMode, @NonNull Camera camera) {
         List<String> supportedFlashModes = camera.getParameters().getSupportedFlashModes();
         return supportedFlashModes != null && supportedFlashModes.contains(flashMode);
     }

--- a/ginivision/src/main/java/net/gini/android/vision/requirements/CameraFocusRequirement.java
+++ b/ginivision/src/main/java/net/gini/android/vision/requirements/CameraFocusRequirement.java
@@ -29,8 +29,7 @@ class CameraFocusRequirement implements Requirement {
             Camera.Parameters parameters = mCameraHolder.getCameraParameters();
             if (parameters != null) {
                 List<String> supportedFocusModes = parameters.getSupportedFocusModes();
-                if (supportedFocusModes == null || !supportedFocusModes.contains(Camera.Parameters.FOCUS_MODE_AUTO)
-                        || !supportedFocusModes.contains(Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)) {
+                if (supportedFocusModes == null || !supportedFocusModes.contains(Camera.Parameters.FOCUS_MODE_AUTO)) {
                     fulfilled = false;
                     details = "Camera does not support auto-focus";
                 }

--- a/ginivision/src/main/java/net/gini/android/vision/requirements/RequirementId.java
+++ b/ginivision/src/main/java/net/gini/android/vision/requirements/RequirementId.java
@@ -47,7 +47,7 @@ public enum RequirementId {
     CAMERA_FLASH,
     /**
      * <p>
-     *     The camera must support continuous picture focus and auto focus modes.
+     *     The camera must support auto focus mode.
      * </p>
      */
     CAMERA_FOCUS,

--- a/ginivision/src/test/java/net/gini/android/vision/internal/camera/api/CameraParametersHelperTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/internal/camera/api/CameraParametersHelperTest.java
@@ -1,0 +1,103 @@
+package net.gini.android.vision.internal.camera.api;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.hardware.Camera;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@RunWith(JUnit4.class)
+public class CameraParametersHelperTest {
+
+    private Camera mCamera;
+    private Camera.Parameters mParameters;
+
+    @Before
+    public void setUp() throws Exception {
+        // Mock camera and parameters
+        mCamera = mock(Camera.class);
+        mParameters = mock(Camera.Parameters.class);
+        when(mCamera.getParameters()).thenReturn(mParameters);
+    }
+
+    @Test
+    public void should_verifyThatFocusMode_isSupported() {
+        // Mock supported focus modes
+        when(mParameters.getSupportedFocusModes()).thenReturn(
+                Arrays.asList(Camera.Parameters.FOCUS_MODE_AUTO,
+                        Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE));
+
+        boolean isSupported = CameraParametersHelper.isFocusModeSupported(
+                Camera.Parameters.FOCUS_MODE_AUTO, mCamera);
+
+        assertThat(isSupported).isTrue();
+    }
+
+    @Test
+    public void should_verifyThatFocusMode_isNotSupported() {
+        // Mock supported focus modes
+        when(mParameters.getSupportedFocusModes()).thenReturn(
+                Collections.singletonList(Camera.Parameters.FOCUS_MODE_AUTO));
+
+        boolean isSupported = CameraParametersHelper.isFocusModeSupported(
+                Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE, mCamera);
+
+        assertThat(isSupported).isFalse();
+    }
+
+    @Test
+    public void should_verifyThatFocusMode_isUsed() {
+        // Mock used focus mode
+        when(mParameters.getFocusMode()).thenReturn(Camera.Parameters.FOCUS_MODE_AUTO);
+
+        boolean isUsed = CameraParametersHelper.isUsingFocusMode(
+                Camera.Parameters.FOCUS_MODE_AUTO, mCamera);
+
+        assertThat(isUsed).isTrue();
+    }
+
+    @Test
+    public void should_verifyThatFocusMode_isNotUsed() {
+        // Mock used focus mode
+        when(mParameters.getFocusMode()).thenReturn(Camera.Parameters.FOCUS_MODE_AUTO);
+
+        boolean isUsed = CameraParametersHelper.isUsingFocusMode(
+                Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE, mCamera);
+
+        assertThat(isUsed).isFalse();
+    }
+
+    @Test
+    public void should_verifyThatFlashMode_isSupported() {
+        // Mock used flash mode
+        when(mParameters.getSupportedFlashModes())
+                .thenReturn(Arrays.asList(Camera.Parameters.FLASH_MODE_AUTO,
+                        Camera.Parameters.FLASH_MODE_TORCH));
+
+        boolean isSupported = CameraParametersHelper.isFlashModeSupported(
+                Camera.Parameters.FLASH_MODE_AUTO, mCamera);
+
+        assertThat(isSupported).isTrue();
+    }
+
+    @Test
+    public void should_verifyThatFlashMode_isNotSupported() {
+        // Mock used flash mode
+        when(mParameters.getSupportedFlashModes())
+                .thenReturn(Collections.singletonList(Camera.Parameters.FLASH_MODE_AUTO));
+
+        boolean isSupported = CameraParametersHelper.isFlashModeSupported(
+                Camera.Parameters.FLASH_MODE_TORCH, mCamera);
+
+        assertThat(isSupported).isFalse();
+    }
+}

--- a/ginivision/src/test/java/net/gini/android/vision/requirements/CameraFocusRequirementTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/requirements/CameraFocusRequirementTest.java
@@ -1,6 +1,7 @@
 package net.gini.android.vision.requirements;
 
 import static com.google.common.truth.Truth.assertThat;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -10,7 +11,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 @RunWith(JUnit4.class)
@@ -49,7 +49,7 @@ public class CameraFocusRequirementTest {
         when(cameraHolder.getCameraParameters()).thenReturn(parameters);
         when(parameters.getSupportedFocusModes()).thenReturn(
                 isAutoFocusSupported ?
-                        Arrays.asList(Camera.Parameters.FOCUS_MODE_AUTO, Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)
+                        Collections.singletonList(Camera.Parameters.FOCUS_MODE_AUTO)
                         : Collections.singletonList(Camera.Parameters.FOCUS_MODE_FIXED));
 
         return cameraHolder;


### PR DESCRIPTION
If the device's camera doesn't support continuous focus mode we want to make sure, that there was at least one auto-focus run. For this we do an auto-focus run before taking a picture when the user taps the trigger button.

### How to test
_I will add a test for verifying this behaviour with a mock Camera instance. But until then:_

Run the `ginivision/src/test/(...)/internal/camera/api/CameraParametersHelperTest`.
We don't have devices without cont. focus so what can be tested is that it works as before on our devices.
We will ask Katharina for her S3 Mini which doesn't have cont. focus to verify the behaviour.

### Merging
Conflicts, will be merged locally.

### Ticket 
No ticket.