### PR TITLE
Screen API: back button leads back to the previous Activity

### DIFF
--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
@@ -98,6 +98,16 @@ public class CameraScreenTest {
         Espresso.onView(ViewMatchers.withId(R.id.gv_onboarding_viewpager))
                 .check(ViewAssertions.matches(ViewMatchers.isDisplayed()));
     }
+
+    @NonNull
+    private Intent getCameraActivityIntent() {
+        Intent intent = new Intent(Intent.ACTION_MAIN);
+        CameraActivity.setReviewActivityExtra(intent, InstrumentationRegistry.getTargetContext(),
+                ReviewActivityTestStub.class);
+        CameraActivity.setAnalysisActivityExtra(intent, InstrumentationRegistry.getTargetContext(),
+                AnalysisActivityTestStub.class);
+        return intent;
+    }
     
     @Test
     public void should_notShowOnboarding_onFirstLaunch_ifDisabled() {
@@ -105,6 +115,13 @@ public class CameraScreenTest {
 
         Espresso.onView(ViewMatchers.withId(R.id.gv_onboarding_viewpager))
                 .check(ViewAssertions.doesNotExist());
+    }
+
+    @NonNull
+    private CameraActivity startCameraActivityWithoutOnboarding() {
+        Intent intent = getCameraActivityIntent();
+        intent.putExtra(CameraActivity.EXTRA_IN_SHOW_ONBOARDING_AT_FIRST_RUN, false);
+        return mIntentsTestRule.launchActivity(intent);
     }
 
     @Test
@@ -238,29 +255,5 @@ public class CameraScreenTest {
         Intents.intended(
                 IntentMatchers.hasExtra(Matchers.equalTo(ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY),
                         hasComponent(AnalysisActivityTestStub.class.getName())));
-
-    }
-
-    @NonNull
-    private CameraActivity startCameraActivity() {
-        Intent intent = getCameraActivityIntent();
-        return mIntentsTestRule.launchActivity(intent);
-    }
-
-    @NonNull
-    private CameraActivity startCameraActivityWithoutOnboarding() {
-        Intent intent = getCameraActivityIntent();
-        intent.putExtra(CameraActivity.EXTRA_IN_SHOW_ONBOARDING_AT_FIRST_RUN, false);
-        return mIntentsTestRule.launchActivity(intent);
-    }
-
-    @NonNull
-    private Intent getCameraActivityIntent() {
-        Intent intent = new Intent(Intent.ACTION_MAIN);
-        CameraActivity.setReviewActivityExtra(intent, InstrumentationRegistry.getTargetContext(),
-                ReviewActivityTestStub.class);
-        CameraActivity.setAnalysisActivityExtra(intent, InstrumentationRegistry.getTargetContext(),
-                AnalysisActivityTestStub.class);
-        return intent;
     }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
@@ -265,7 +265,7 @@ public class CameraScreenTest {
 
     @Test
     public void should_notFinish_whenReceivingActivityResult_withResultCodeCancelled_fromReviewActivity() {
-        CameraActivity cameraActivitySpy = Mockito.spy(new CameraActivity());
+        final CameraActivity cameraActivitySpy = Mockito.spy(new CameraActivity());
 
         cameraActivitySpy.onActivityResult(CameraActivity.REVIEW_DOCUMENT_REQUEST,
                 Activity.RESULT_CANCELED, new Intent());
@@ -279,11 +279,11 @@ public class CameraScreenTest {
         intentAllowBackButtonToClose.putExtra(
                 CameraActivity.EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY, true);
 
-        CameraActivity cameraActivity = new CameraActivity();
+        final CameraActivity cameraActivity = new CameraActivity();
         cameraActivity.setIntent(intentAllowBackButtonToClose);
         cameraActivity.readExtras();
 
-        CameraActivity cameraActivitySpy = Mockito.spy(cameraActivity);
+        final CameraActivity cameraActivitySpy = Mockito.spy(cameraActivity);
 
         cameraActivitySpy.onActivityResult(CameraActivity.REVIEW_DOCUMENT_REQUEST,
                 Activity.RESULT_CANCELED, new Intent());

--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
@@ -274,7 +274,7 @@ public class CameraScreenTest {
     }
 
     @Test
-    public void should_finishIfRequestedByClient_whenReceivingActivityResult_withResultCodeCancelled_fromReviewActivity() {
+    public void should_finishIfEnabledByClient_whenReceivingActivityResult_withResultCodeCancelled_fromReviewActivity() {
         final Intent intentAllowBackButtonToClose = getCameraActivityIntent();
         intentAllowBackButtonToClose.putExtra(
                 CameraActivity.EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY, true);

--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
@@ -2,9 +2,14 @@ package net.gini.android.vision.camera;
 
 import static net.gini.android.vision.OncePerInstallEventStoreHelper.clearOnboardingWasShownPreference;
 import static net.gini.android.vision.OncePerInstallEventStoreHelper.setOnboardingWasShownPreference;
+
 import static net.gini.android.vision.test.EspressoMatchers.hasComponent;
 import static net.gini.android.vision.test.Helpers.prepareLooper;
 
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import android.app.Activity;
 import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
@@ -37,6 +42,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 
@@ -108,7 +114,7 @@ public class CameraScreenTest {
                 AnalysisActivityTestStub.class);
         return intent;
     }
-    
+
     @Test
     public void should_notShowOnboarding_onFirstLaunch_ifDisabled() {
         startCameraActivityWithoutOnboarding();
@@ -255,5 +261,33 @@ public class CameraScreenTest {
         Intents.intended(
                 IntentMatchers.hasExtra(Matchers.equalTo(ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY),
                         hasComponent(AnalysisActivityTestStub.class.getName())));
+    }
+
+    @Test
+    public void should_notFinish_whenReceivingActivityResult_withResultCodeCancelled_fromReviewActivity() {
+        CameraActivity cameraActivitySpy = Mockito.spy(new CameraActivity());
+
+        cameraActivitySpy.onActivityResult(CameraActivity.REVIEW_DOCUMENT_REQUEST,
+                Activity.RESULT_CANCELED, new Intent());
+
+        verify(cameraActivitySpy, never()).finish();
+    }
+
+    @Test
+    public void should_finishIfRequestedByClient_whenReceivingActivityResult_withResultCodeCancelled_fromReviewActivity() {
+        final Intent intentAllowBackButtonToClose = getCameraActivityIntent();
+        intentAllowBackButtonToClose.putExtra(
+                CameraActivity.EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY, true);
+
+        CameraActivity cameraActivity = new CameraActivity();
+        cameraActivity.setIntent(intentAllowBackButtonToClose);
+        cameraActivity.readExtras();
+
+        CameraActivity cameraActivitySpy = Mockito.spy(cameraActivity);
+
+        cameraActivitySpy.onActivityResult(CameraActivity.REVIEW_DOCUMENT_REQUEST,
+                Activity.RESULT_CANCELED, new Intent());
+
+        verify(cameraActivitySpy).finish();
     }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
@@ -80,6 +80,17 @@ public class ReviewScreenTest {
         assertThat(activity.getFragment().getFragmentImpl().getImageDocument().getRotation()).isWithin(0.0f).of(180);
     }
 
+    private ReviewActivityTestStub startReviewActivity(byte[] jpeg, int orientation) {
+        Intent intent = getReviewActivityIntent();
+        intent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, createDocument(jpeg, orientation));
+        intent.putExtra(ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY, new Intent(InstrumentationRegistry.getTargetContext(), AnalysisActivityTestStub.class));
+        return mActivityTestRule.launchActivity(intent);
+    }
+
+    private Intent getReviewActivityIntent() {
+        return new Intent(InstrumentationRegistry.getTargetContext(), ReviewActivityTestStub.class);
+    }
+
     @Test
     public void should_rotatePreview_whenRotateButton_isClicked() throws IOException, InterruptedException {
         ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 90);
@@ -329,16 +340,5 @@ public class ReviewScreenTest {
         InstrumentationRegistry.getInstrumentation().waitForIdleSync();
 
         verify(listenerHook).onDocumentWasRotated(any(Document.class), eq(0), eq(90));
-    }
-
-    private ReviewActivityTestStub startReviewActivity(byte[] jpeg, int orientation) {
-        Intent intent = getReviewActivityIntent();
-        intent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, createDocument(jpeg, orientation));
-        intent.putExtra(ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY, new Intent(InstrumentationRegistry.getTargetContext(), AnalysisActivityTestStub.class));
-        return mActivityTestRule.launchActivity(intent);
-    }
-
-    private Intent getReviewActivityIntent() {
-        return new Intent(InstrumentationRegistry.getTargetContext(), ReviewActivityTestStub.class);
     }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
@@ -358,7 +358,7 @@ public class ReviewScreenTest {
     }
 
     @Test
-    public void should_finishIfRequiredByClient_whenReceivingActivityResult_withResultCodeCancelled_fromAnalysisActivity() {
+    public void should_finishIfEnabledByClient_whenReceivingActivityResult_withResultCodeCancelled_fromAnalysisActivity() {
         prepareLooper();
 
         final Intent intentAllowBackButtonToClose = getReviewActivityIntent(TEST_JPEG, 0);

--- a/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
@@ -349,7 +349,7 @@ public class ReviewScreenTest {
     public void should_notFinish_whenReceivingActivityResult_withResultCodeCancelled_fromAnalysisActivity() {
         prepareLooper();
 
-        ReviewActivity reviewActivitySpy = Mockito.spy(new ReviewActivityTestStub());
+        final ReviewActivity reviewActivitySpy = Mockito.spy(new ReviewActivityTestStub());
 
         reviewActivitySpy.onActivityResult(ReviewActivity.ANALYSE_DOCUMENT_REQUEST,
                 Activity.RESULT_CANCELED, new Intent());
@@ -365,11 +365,11 @@ public class ReviewScreenTest {
         intentAllowBackButtonToClose.putExtra(
                 ReviewActivity.EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY, true);
 
-        ReviewActivity reviewActivity = new ReviewActivityTestStub();
+        final ReviewActivity reviewActivity = new ReviewActivityTestStub();
         reviewActivity.setIntent(intentAllowBackButtonToClose);
         reviewActivity.readExtras();
 
-        ReviewActivity reviewActivitySpy = Mockito.spy(reviewActivity);
+        final ReviewActivity reviewActivitySpy = Mockito.spy(reviewActivity);
 
         reviewActivitySpy.onActivityResult(ReviewActivity.ANALYSE_DOCUMENT_REQUEST,
                 Activity.RESULT_CANCELED, new Intent());

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
@@ -1,5 +1,6 @@
 package net.gini.android.vision.camera;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -388,6 +389,10 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == REVIEW_DOCUMENT_REQUEST) {
+            if (resultCode == Activity.RESULT_CANCELED) {
+                // Do nothing, since the review was cancelled (closed with the back button)
+                return;
+            }
             setResult(resultCode, data);
             finish();
         } else if (requestCode == ONBOARDING_REQUEST) {

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
@@ -48,6 +48,7 @@ import java.util.ArrayList;
  *         <li>{@link CameraActivity#EXTRA_IN_SHOW_ONBOARDING_AT_FIRST_RUN} - the Onboarding Screen is shown by default the first time the Gini Vision Library is started. You may disable it by setting this extra to {@code false} - we highly recommend keeping the default behavior</li>
  *         <li>{@link CameraActivity#EXTRA_IN_SHOW_ONBOARDING} - if set to {@code true} the Onboarding Screen is shown when the Gini Vision Library is started</li>
  *         <li>{@link CameraActivity#EXTRA_IN_ONBOARDING_PAGES} - custom pages for the Onboarding Screen as an {@link ArrayList} containing {@link OnboardingPage} objects</li>
+ *         <li>{@link CameraActivity#EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY} - if set to {@code true} the back button closes the Gini Vision Library from any of its activities with result code {@link CameraActivity#RESULT_CANCELED}</li>
  *     </ul>
  * </p>
  * <p>

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
@@ -227,7 +227,8 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
      */
     public static final int RESULT_ERROR = RESULT_FIRST_USER + 1;
 
-    private static final int REVIEW_DOCUMENT_REQUEST = 1;
+    @VisibleForTesting
+    static final int REVIEW_DOCUMENT_REQUEST = 1;
     private static final int ONBOARDING_REQUEST = 2;
 
     private ArrayList<OnboardingPage> mOnboardingPages;

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
@@ -204,6 +204,16 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
 
     /**
      * <p>
+     *     Optional extra wich must contain a boolean and indicates whether the back button should close the Gini Vision Library.
+     * </p>
+     * <p>
+     *     Default value is {@code false}.
+     * </p>
+     */
+    public static final String EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY = "GV_EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY";
+
+    /**
+     * <p>
      *     Returned when the result code is {@link CameraActivity#RESULT_ERROR} and contains a {@link GiniVisionError} object detailing what went wrong.
      * </p>
      */
@@ -225,6 +235,7 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
     private boolean mShowOnboarding = false;
     private boolean mShowOnboardingAtFirstRun = true;
     private boolean mOnboardingShown = false;
+    private boolean mBackButtonShouldCloseLibrary = false;
     private GiniVisionCoordinator mGiniVisionCoordinator;
     private Document mDocument;
 
@@ -310,6 +321,7 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
             mAnalyzeDocumentActivityIntent = extras.getParcelable(EXTRA_IN_ANALYSIS_ACTIVITY);
             mShowOnboarding = extras.getBoolean(EXTRA_IN_SHOW_ONBOARDING, false);
             mShowOnboardingAtFirstRun = extras.getBoolean(EXTRA_IN_SHOW_ONBOARDING_AT_FIRST_RUN, true);
+            mBackButtonShouldCloseLibrary = extras.getBoolean(EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY, false);
         }
         checkRequiredExtras();
     }
@@ -375,6 +387,8 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
         // Start ReviewActivity
         mReviewDocumentActivityIntent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, document);
         mReviewDocumentActivityIntent.putExtra(EXTRA_IN_ANALYSIS_ACTIVITY, mAnalyzeDocumentActivityIntent);
+        mReviewDocumentActivityIntent.putExtra(ReviewActivity.EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY,
+                mBackButtonShouldCloseLibrary);
         startActivityForResult(mReviewDocumentActivityIntent, REVIEW_DOCUMENT_REQUEST);
     }
 
@@ -389,17 +403,16 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == REVIEW_DOCUMENT_REQUEST) {
-            if (resultCode == Activity.RESULT_CANCELED) {
-                // Do nothing, since the review was cancelled (closed with the back button)
-                return;
+            if (mBackButtonShouldCloseLibrary
+                    || resultCode != Activity.RESULT_CANCELED) {
+                setResult(resultCode, data);
+                finish();
+                clearMemory();
             }
-            setResult(resultCode, data);
-            finish();
         } else if (requestCode == ONBOARDING_REQUEST) {
             mOnboardingShown = false;
             showCornersAndTrigger();
         }
-        clearMemory();
     }
 
     private void showCornersAndTrigger() {

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
@@ -147,7 +147,8 @@ public abstract class ReviewActivity extends AppCompatActivity implements Review
      */
     public static final int RESULT_ERROR = RESULT_FIRST_USER + 1;
 
-    private static final int ANALYSE_DOCUMENT_REQUEST = 1;
+    @VisibleForTesting
+    static final int ANALYSE_DOCUMENT_REQUEST = 1;
 
     private static final String REVIEW_FRAGMENT = "REVIEW_FRAGMENT";
 

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
@@ -132,6 +132,10 @@ public abstract class ReviewActivity extends AppCompatActivity implements Review
     /**
      * @exclude
      */
+    public static final String EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY = "GV_EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY";
+    /**
+     * @exclude
+     */
     public static final String EXTRA_OUT_DOCUMENT = "GV_EXTRA_OUT_DOCUMENT";
     /**
      * @exclude
@@ -150,6 +154,7 @@ public abstract class ReviewActivity extends AppCompatActivity implements Review
     private ReviewFragmentCompat mFragment;
     private Document mDocument;
     private String mDocumentAnalysisErrorMessage;
+    private boolean mBackButtonShouldCloseLibrary = false;
 
     private Intent mAnalyzeDocumentActivityIntent;
 
@@ -196,6 +201,7 @@ public abstract class ReviewActivity extends AppCompatActivity implements Review
         if (extras != null) {
             mDocument = extras.getParcelable(EXTRA_IN_DOCUMENT);
             mAnalyzeDocumentActivityIntent = extras.getParcelable(EXTRA_IN_ANALYSIS_ACTIVITY);
+            mBackButtonShouldCloseLibrary = extras.getBoolean(EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY, false);
         }
         checkRequiredExtras();
     }
@@ -309,13 +315,12 @@ public abstract class ReviewActivity extends AppCompatActivity implements Review
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == ANALYSE_DOCUMENT_REQUEST) {
-            if (resultCode == Activity.RESULT_CANCELED) {
-                // Do nothing, since the analysis was cancelled (closed with the back button)
-                return;
+            if (mBackButtonShouldCloseLibrary
+                    || resultCode != Activity.RESULT_CANCELED) {
+                setResult(resultCode, data);
+                finish();
+                clearMemory();
             }
-            setResult(resultCode, data);
-            finish();
         }
-        clearMemory();
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
@@ -1,12 +1,9 @@
 package net.gini.android.vision.review;
 
-import net.gini.android.vision.Document;
-import net.gini.android.vision.GiniVisionError;
-import net.gini.android.vision.R;
-import net.gini.android.vision.analysis.AnalysisActivity;
-import net.gini.android.vision.camera.CameraActivity;
-import net.gini.android.vision.onboarding.OnboardingActivity;
+import static net.gini.android.vision.internal.util.ActivityHelper.enableHomeAsUp;
+import static net.gini.android.vision.internal.util.ActivityHelper.handleMenuItemPressedForHomeButton;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -15,8 +12,12 @@ import android.support.annotation.VisibleForTesting;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
-import static net.gini.android.vision.internal.util.ActivityHelper.enableHomeAsUp;
-import static net.gini.android.vision.internal.util.ActivityHelper.handleMenuItemPressedForHomeButton;
+import net.gini.android.vision.Document;
+import net.gini.android.vision.GiniVisionError;
+import net.gini.android.vision.R;
+import net.gini.android.vision.analysis.AnalysisActivity;
+import net.gini.android.vision.camera.CameraActivity;
+import net.gini.android.vision.onboarding.OnboardingActivity;
 
 /**
  * <h3>Screen API</h3>
@@ -308,6 +309,10 @@ public abstract class ReviewActivity extends AppCompatActivity implements Review
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == ANALYSE_DOCUMENT_REQUEST) {
+            if (resultCode == Activity.RESULT_CANCELED) {
+                // Do nothing, since the analysis was cancelled (closed with the back button)
+                return;
+            }
             setResult(resultCode, data);
             finish();
         }

--- a/screenapiexample/gradle.properties
+++ b/screenapiexample/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.2
+version=1.0.3
 buildNumber=DEBUG
 
 releaseKeystoreFile=screen_api_example.jks

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
@@ -92,6 +92,10 @@ public class MainActivity extends AppCompatActivity {
         // Set EXTRA_IN_SHOW_ONBOARDING to true, to show the OnboardingActivity when the CameraActivity starts
         //intent.putExtra(CameraActivity.EXTRA_IN_SHOW_ONBOARDING, true);
 
+        // Set EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY to true, to close library on pressing the back
+        // button from any Activity in the library
+        //intent.putExtra(CameraActivity.EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY, true);
+
         // Set your ReviewActivity subclass
         CameraActivity.setReviewActivityExtra(intent, this, ReviewActivity.class);
 


### PR DESCRIPTION
One of our clients rightfully noticed, that our back button (either on the bottom or on the ActionBar) closes the library in the Screen API instead of leading back to the previous Activity.

We fixed this now and also added a boolean extra to the `CameraActivity` to revert to the previous behaviour, if required.

### How to test
Run the Screen API example app and test the back button functionality. Both the bottom back button and the one on the ActionBar should be tested.

To test the previous behaviour uncomment in the `MainActivity#startGiniVisionLibrary()` method the line containing the `EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY`.

### Merging
Nothing special.

### Ticket 
https://tickets.i.gini.net/issue/MOBILE-701
