### PR TITLE
Release 2.1

### DIFF
--- a/componentapiexample/build.gradle
+++ b/componentapiexample/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "net.gini.android.vision.componentapiexample"
-        minSdkVersion 17
+        minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode buildNumber == 'DEBUG' ? 1 : buildNumber.toInteger()
         versionName "${version} (${buildNumber})"

--- a/componentapiexample/gradle.properties
+++ b/componentapiexample/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.1
+version=1.0.2
 buildNumber=DEBUG
 
 releaseKeystoreFile=component_api_example.jks

--- a/componentapiexample/src/main/java/net/gini/android/vision/component/MainActivity.java
+++ b/componentapiexample/src/main/java/net/gini/android/vision/component/MainActivity.java
@@ -2,6 +2,7 @@ package net.gini.android.vision.component;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -60,6 +61,12 @@ public class MainActivity extends Activity {
     }
 
     private void startGiniVisionStandard() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            Toast.makeText(this, "Component API Standard requires API Level 17 or higher",
+                    Toast.LENGTH_SHORT).show();
+            return;
+        }
+
         // Uncomment to enable requirements check.
         // NOTE: on Android 6.0 and later the camera permission is required before checking the requirements
 //        RequirementsReport report = GiniVisionRequirements.checkRequirements(this);

--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
@@ -2,7 +2,6 @@ package net.gini.android.vision.camera;
 
 import static net.gini.android.vision.OncePerInstallEventStoreHelper.clearOnboardingWasShownPreference;
 import static net.gini.android.vision.OncePerInstallEventStoreHelper.setOnboardingWasShownPreference;
-
 import static net.gini.android.vision.test.EspressoMatchers.hasComponent;
 import static net.gini.android.vision.test.Helpers.prepareLooper;
 
@@ -24,6 +23,7 @@ import android.support.test.espresso.intent.Intents;
 import android.support.test.espresso.intent.matcher.IntentMatchers;
 import android.support.test.espresso.intent.rule.IntentsTestRule;
 import android.support.test.espresso.matcher.ViewMatchers;
+import android.support.test.filters.RequiresDevice;
 import android.support.test.filters.SdkSuppress;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.test.uiautomator.UiDevice;
@@ -183,6 +183,7 @@ public class CameraScreenTest {
         Intents.intended(IntentMatchers.hasComponent(OnboardingActivity.class.getName()));
     }
 
+    @RequiresDevice
     @SdkSuppress(minSdkVersion = 23)
     @Test
     public void a_should_showNoPermissionView_ifNoCameraPermission() {
@@ -194,6 +195,7 @@ public class CameraScreenTest {
                 .check(ViewAssertions.matches(ViewMatchers.isDisplayed()));
     }
 
+    @RequiresDevice
     @SdkSuppress(minSdkVersion = 23)
     @Test
     public void b_should_showCameraPreview_afterCameraPermission_wasGranted()
@@ -228,6 +230,7 @@ public class CameraScreenTest {
                 .check(ViewAssertions.matches(ViewMatchers.isDisplayed()));
     }
 
+    @RequiresDevice
     @Test
     public void should_showReviewScreen_afterPictureWasTaken() throws InterruptedException {
         startCameraActivityWithoutOnboarding();
@@ -241,6 +244,7 @@ public class CameraScreenTest {
         Intents.intended(IntentMatchers.hasComponent(ReviewActivityTestStub.class.getName()));
     }
 
+    @RequiresDevice
     @Test
     public void should_takeOnlyOnePicture_ifTrigger_wasPressedMultipleTimes()
             throws InterruptedException {
@@ -255,6 +259,7 @@ public class CameraScreenTest {
         Intents.intended(IntentMatchers.hasComponent(ReviewActivityTestStub.class.getName()));
     }
 
+    @RequiresDevice
     @Test
     public void should_passAnalysisActivityIntent_toReviewActivity() throws InterruptedException {
         startCameraActivityWithoutOnboarding();

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/api/CameraControllerTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/api/CameraControllerTest.java
@@ -129,6 +129,7 @@ public class CameraControllerTest {
 
     @Test
     public void should_useAutoFocusMode_ifContinuousFocusMode_isNotAvailable() {
+        assumeTrue("Camera supports auto focus mode", hasCameraAutoFocusMode());
         mCameraController =
                 new CameraControllerWithMockableCamera(createNoOpActivity());
         Camera cameraSpy = openCameraAndGetCameraSpyWithSupportedFocusModes(
@@ -137,6 +138,14 @@ public class CameraControllerTest {
 
         Camera.Parameters usedParameters = cameraSpy.getParameters();
         assertThat(usedParameters.getFocusMode()).isEqualTo(Camera.Parameters.FOCUS_MODE_AUTO);
+    }
+
+    private boolean hasCameraAutoFocusMode() {
+        Camera camera = Camera.open();
+        boolean autoFocusMode = camera.getParameters().getSupportedFocusModes().contains(
+                Camera.Parameters.FOCUS_MODE_AUTO);
+        camera.release();
+        return autoFocusMode;
     }
 
     @Test
@@ -153,7 +162,7 @@ public class CameraControllerTest {
     }
 
     @Test
-    public void should_notDoAutoFocusRun_beforeTakingPicture_ifContinuousFocusMode() {
+    public void should_notDoAutoFocusRun_beforeTakingPicture_ifUsingContinuousFocusMode() {
         assumeTrue("Camera supports continuous focus mode", hasCameraContinuousFocusMode());
         mCameraController =
                 spy(new CameraControllerWithMockedFocusingAndPictureTaking(createNoOpActivity()));

--- a/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
@@ -20,6 +20,7 @@ import android.support.test.espresso.Espresso;
 import android.support.test.espresso.action.ViewActions;
 import android.support.test.espresso.intent.rule.IntentsTestRule;
 import android.support.test.espresso.matcher.ViewMatchers;
+import android.support.test.filters.RequiresDevice;
 import android.support.test.runner.AndroidJUnit4;
 import android.support.test.uiautomator.UiDevice;
 
@@ -94,6 +95,7 @@ public class ReviewScreenTest {
         return intent;
     }
 
+    @RequiresDevice
     @Test
     public void should_rotatePreview_whenRotateButton_isClicked() throws IOException, InterruptedException {
         ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 90);
@@ -146,6 +148,7 @@ public class ReviewScreenTest {
         assertThat(documentToAnalyze.get().getJpeg().length).isLessThan(TEST_JPEG.length);
     }
 
+    @RequiresDevice
     @Test
     public void should_onlyInvokeProceedToAnalysis_whenNextButton_wasClicked_ifDocument_wasModified_andNotAnalyzed() throws InterruptedException {
         ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 0);
@@ -180,6 +183,7 @@ public class ReviewScreenTest {
         assertThat(addDataToResultInvoked.get()).isFalse();
     }
 
+    @RequiresDevice
     @Test
     public void should_onlyInvokeProceedToAnalysis_whenNextButton_wasClicked_ifDocument_wasModified_andAnalyzed() throws InterruptedException {
         final ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 0);
@@ -329,6 +333,7 @@ public class ReviewScreenTest {
         verify(listenerHook, never()).onProceedToAnalysisScreen(any(Document.class));
     }
 
+    @RequiresDevice
     @Test
     public void should_invokeDocumentWasRotated_whenRotateButton_wasClicked() throws InterruptedException {
         final ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 0);

--- a/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(AndroidJUnit4.class)
+@RequiresDevice
 public class ReviewScreenTest {
 
     private static final int PAUSE_DURATION = 500;
@@ -95,7 +96,6 @@ public class ReviewScreenTest {
         return intent;
     }
 
-    @RequiresDevice
     @Test
     public void should_rotatePreview_whenRotateButton_isClicked() throws IOException, InterruptedException {
         ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 90);
@@ -148,7 +148,6 @@ public class ReviewScreenTest {
         assertThat(documentToAnalyze.get().getJpeg().length).isLessThan(TEST_JPEG.length);
     }
 
-    @RequiresDevice
     @Test
     public void should_onlyInvokeProceedToAnalysis_whenNextButton_wasClicked_ifDocument_wasModified_andNotAnalyzed() throws InterruptedException {
         ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 0);
@@ -183,7 +182,6 @@ public class ReviewScreenTest {
         assertThat(addDataToResultInvoked.get()).isFalse();
     }
 
-    @RequiresDevice
     @Test
     public void should_onlyInvokeProceedToAnalysis_whenNextButton_wasClicked_ifDocument_wasModified_andAnalyzed() throws InterruptedException {
         final ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 0);
@@ -333,7 +331,6 @@ public class ReviewScreenTest {
         verify(listenerHook, never()).onProceedToAnalysisScreen(any(Document.class));
     }
 
-    @RequiresDevice
     @Test
     public void should_invokeDocumentWasRotated_whenRotateButton_wasClicked() throws InterruptedException {
         final ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 0);

--- a/ginivision/src/doc/source/changelog.rst
+++ b/ginivision/src/doc/source/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+2.1.0 (2017-01-30)
+==================
+
+- Removed the 4:3 aspect ratio camera resolution requirement. Only a minimum of 8MP is required.
+- Removed the continuous-focus mode requirement. Only auto-focus is required.
+- If no continuous-focus mode is available the camera is requested to do an auto-focus run before taking a picture.
+- Trigger button is aligned to the preview's bottom.
+- The back button in the ReviewActivity and AnalysisActivity (in the navigation bar and in the ActionBar) leads back to the previous Activity instead of closing the library. The previous behavior can be requested by setting the `CameraActivity#EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY` to `true`.
+
 2.0.1 (2016-10-18)
 ==================
 

--- a/ginivision/src/doc/source/changelog.rst
+++ b/ginivision/src/doc/source/changelog.rst
@@ -5,10 +5,10 @@ Changelog
 2.1.0 (2017-01-30)
 ==================
 
-- Removed the 4:3 aspect ratio camera resolution requirement. Only a minimum of 8MP is required.
+- Removed the 4:3 aspect ratio requirement for photos. The default camera aspect ratio will be used from now on. An 8MP minimum resolution is still required.
 - Removed the continuous-focus mode requirement. Only auto-focus is required.
-- If no continuous-focus mode is available the camera is requested to do an auto-focus run before taking a picture.
-- Trigger button is aligned to the preview's bottom.
+- If no continuous-focus mode is available then an auto-focus run is triggered when the user activates the capture button.
+- Trigger button is aligned to the bottom of the preview area.
 - The back button in the ReviewActivity and AnalysisActivity (in the navigation bar and in the ActionBar) leads back to the previous Activity instead of closing the library. The previous behavior can be requested by setting the `CameraActivity#EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY` to `true`.
 - Fixed an issue regarding ReviewActivity and AnalysisActivity restart in the Screen API after the app had been killed while in the background.
 

--- a/ginivision/src/doc/source/changelog.rst
+++ b/ginivision/src/doc/source/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 - If no continuous-focus mode is available the camera is requested to do an auto-focus run before taking a picture.
 - Trigger button is aligned to the preview's bottom.
 - The back button in the ReviewActivity and AnalysisActivity (in the navigation bar and in the ActionBar) leads back to the previous Activity instead of closing the library. The previous behavior can be requested by setting the `CameraActivity#EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY` to `true`.
+- Fixed an issue regarding ReviewActivity and AnalysisActivity restart in the Screen API after the app had been killed while in the background.
 
 2.0.1 (2016-10-18)
 ==================

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
@@ -277,6 +277,11 @@ public class CameraController implements CameraInterface {
             return CompletableFuture.completedFuture(false);
         }
 
+        if (!CameraParametersHelper.isFocusModeSupported(Camera.Parameters.FOCUS_MODE_AUTO, mCamera)) {
+            LOG.error("Cannot focus: auto-focus mode not supported");
+            return CompletableFuture.completedFuture(false);
+        }
+
         final CompletableFuture<Boolean> completed = new CompletableFuture<>();
         do {
             // Checking whether a completable is already available in which case focusing is in

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 
-version=2.0.1
+version=2.1.0
 buildNumber=SNAPSHOT
 
 groupId=net.gini


### PR DESCRIPTION
Updated the version number and the changelog.

Also modified the Component API example app a bit by supporting the same minSdkVersion as the library, but allowing the Standard Component API to be run only on API Level 17+.

### How to test
Run the example apps. Read the changelog.

### Merging
After merging into `develop`, needs to be merged into master, too.

### Ticket 
https://tickets.i.gini.net/issue/MOBILE-695
