### PR TITLE
Adding rotation delta to EXIF User Comment field

### DIFF
--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/ExifReaderTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/ExifReaderTest.java
@@ -36,4 +36,6 @@ public class ExifReaderTest {
         // Then
         assertThat(value).isNull();
     }
+
+
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/ExifReaderTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/ExifReaderTest.java
@@ -1,0 +1,39 @@
+package net.gini.android.vision.internal.camera.photo;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static com.google.common.truth.Truth.assertThat;
+import static net.gini.android.vision.test.Helpers.getTestJpeg;
+
+@RunWith(AndroidJUnit4.class)
+public class ExifReaderTest {
+
+    private static byte[] TEST_JPEG = null;
+
+    @BeforeClass
+    public static void setupClass() throws IOException {
+        TEST_JPEG = getTestJpeg();
+    }
+
+    @AfterClass
+    public static void teardownClass() throws IOException {
+        TEST_JPEG = null;
+    }
+
+    @Test
+    public void should_returnNull_ifKey_wasNotFound() throws Exception {
+        // Given
+        ExifReader exifReader = new ExifReader(TEST_JPEG);
+        // When
+        String value = exifReader.getValueForKeyFromUserComment("unknownKey", "no such key here");
+        // Then
+        assertThat(value).isNull();
+    }
+}

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoTest.java
@@ -88,4 +88,72 @@ public class PhotoTest {
         // Then
         assertAbout(photo()).that(photo).hasUUIDinUserComment(uuid);
     }
+
+    @Test
+    public void should_initRotationDelta_whenCreated() {
+        // When
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        // Then
+        assertThat(photo.getRotationDelta()).isEqualTo(0);
+    }
+
+    @Test
+    public void should_addRotationDelta_toExifUserComment() {
+        // Given
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        // Then
+        assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(0);
+    }
+
+    @Test
+    public void should_updateRotationDelta_afterCWRotation() {
+        // Given
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        // When
+        photo.edit().rotate(90).apply();
+        // Then
+        assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(90);
+    }
+
+    @Test
+    public void should_updateRotationDelta_afterCCWRotation() {
+        // Given
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        // When
+        photo.edit().rotate(-90).apply();
+        // Then
+        assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(270);
+    }
+
+    @Test
+    public void should_cumulateRotationDelta_afterMultipleRotations() {
+        // Given
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        // When
+        photo.edit().rotate(90).apply();
+        photo.edit().rotate(90).apply();
+        photo.edit().rotate(-90).apply();
+        // Then
+        assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(90);
+    }
+
+    @Test
+    public void should_normalizeRotationDelta_forCWRotation() {
+        // Given
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        // When
+        photo.edit().rotate(450).apply();
+        // Then
+        assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(90);
+    }
+
+    @Test
+    public void should_normalizeRotationDelta_forCCWRotation() {
+        // Given
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        // When
+        photo.edit().rotate(-270).apply();
+        // Then
+        assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(90);
+    }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoTest.java
@@ -9,6 +9,8 @@ import static net.gini.android.vision.test.PhotoSubject.photo;
 
 import android.support.test.runner.AndroidJUnit4;
 
+import net.gini.android.vision.Document;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -40,6 +42,37 @@ public class PhotoTest {
         Photo photoFromParcel = doParcelingRoundTrip(photo, Photo.CREATOR);
         // Then
         assertThat(photoFromParcel).isEqualTo(photo);
+    }
+
+    @Test
+    public void should_keepUserComment_whenCreating_fromDocument() {
+        // Given
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        // When
+        Photo fromDocument = Photo.fromDocument(Document.fromPhoto(photo));
+        // Then
+        assertAbout(photo()).that(photo).hasSameUserCommentAs(fromDocument);
+    }
+
+    @Test
+    public void should_setUUIDfromUserComment_whenCreating_fromDocument() {
+        // Given
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        // When
+        Photo fromDocument = Photo.fromDocument(Document.fromPhoto(photo));
+        // Then
+        assertThat(photo.getUUID()).isEqualTo(fromDocument.getUUID());
+    }
+
+    @Test
+    public void should_setRotationDeltafromUserComment_whenCreating_fromDocument() {
+        // Given
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        // When
+        photo.edit().rotateTo(90).apply();
+        Photo fromDocument = Photo.fromDocument(Document.fromPhoto(photo));
+        // Then
+        assertThat(photo.getRotationDelta()).isEqualTo(fromDocument.getRotationDelta());
     }
 
     @Test

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoTest.java
@@ -55,13 +55,13 @@ public class PhotoTest {
     }
 
     @Test
-    public void should_setUUIDfromUserComment_whenCreating_fromDocument() {
+    public void should_setContentIdFromUserComment_whenCreating_fromDocument() {
         // Given
         Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
         // When
         Photo fromDocument = Photo.fromDocument(Document.fromPhoto(photo));
         // Then
-        assertThat(photo.getUUID()).isEqualTo(fromDocument.getUUID());
+        assertThat(photo.getContentId()).isEqualTo(fromDocument.getContentId());
     }
 
     @Test
@@ -76,50 +76,50 @@ public class PhotoTest {
     }
 
     @Test
-    public void should_generateUUID_whenCreated() {
+    public void should_generateUUID_forContentId_whenCreated() {
         // When
         Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
         // Then
-        assertThat(UUID.fromString(photo.getUUID())).isNotNull();
+        assertThat(UUID.fromString(photo.getContentId())).isNotNull();
     }
 
     @Test
-    public void should_generate_uniqueUUIDs_forEachInstance() {
+    public void should_generate_uniqueContentIds_forEachInstance() {
         // Given
         Photo photo1 = Photo.fromJpeg(TEST_JPEG, 0);
         Photo photo2 = Photo.fromJpeg(TEST_JPEG, 0);
         // Then
-        assertThat(photo1.getUUID()).isNotEqualTo(photo2.getUUID());
+        assertThat(photo1.getContentId()).isNotEqualTo(photo2.getContentId());
     }
 
     @Test
-    public void should_addUUID_toExifUserComment() {
+    public void should_addContentId_toExifUserComment() {
         // Given
         Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
         // Then
-        assertAbout(photo()).that(photo).hasUUIDinUserComment(photo.getUUID());
+        assertAbout(photo()).that(photo).hasContentIdInUserComment(photo.getContentId());
     }
 
     @Test
-    public void should_keepUUID_afterRotation() {
+    public void should_keepContentId_afterRotation() {
         // Given
         Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
-        String uuid = photo.getUUID();
+        String contentId = photo.getContentId();
         // When
         photo.edit().rotateTo(90).apply();
         // Then
-        assertAbout(photo()).that(photo).hasUUIDinUserComment(uuid);
+        assertAbout(photo()).that(photo).hasContentIdInUserComment(contentId);
     }
 
     @Test
-    public void should_keepUUID_afterCompression() {
+    public void should_keepContentId_afterCompression() {
         // Given
         Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
-        String uuid = photo.getUUID();
+        String contentId = photo.getContentId();
         // When
         photo.edit().compressBy(10).apply();
         // Then
-        assertAbout(photo()).that(photo).hasUUIDinUserComment(uuid);
+        assertAbout(photo()).that(photo).hasContentIdInUserComment(contentId);
     }
 
     @Test

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoTest.java
@@ -73,7 +73,7 @@ public class PhotoTest {
         Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
         String uuid = photo.getUUID();
         // When
-        photo.edit().rotate(90).apply();
+        photo.edit().rotateTo(90).apply();
         // Then
         assertAbout(photo()).that(photo).hasUUIDinUserComment(uuid);
     }
@@ -84,7 +84,7 @@ public class PhotoTest {
         Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
         String uuid = photo.getUUID();
         // When
-        photo.edit().compress(10).apply();
+        photo.edit().compressBy(10).apply();
         // Then
         assertAbout(photo()).that(photo).hasUUIDinUserComment(uuid);
     }
@@ -93,6 +93,14 @@ public class PhotoTest {
     public void should_initRotationDelta_whenCreated() {
         // When
         Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        // Then
+        assertThat(photo.getRotationDelta()).isEqualTo(0);
+    }
+
+    @Test
+    public void should_initRotationDelta_whenCreated_withNonZeroOrientation() {
+        // When
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 90);
         // Then
         assertThat(photo.getRotationDelta()).isEqualTo(0);
     }
@@ -110,7 +118,7 @@ public class PhotoTest {
         // Given
         Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
         // When
-        photo.edit().rotate(90).apply();
+        photo.edit().rotateTo(90).apply();
         // Then
         assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(90);
     }
@@ -120,21 +128,9 @@ public class PhotoTest {
         // Given
         Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
         // When
-        photo.edit().rotate(-90).apply();
+        photo.edit().rotateTo(-90).apply();
         // Then
         assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(270);
-    }
-
-    @Test
-    public void should_cumulateRotationDelta_afterMultipleRotations() {
-        // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
-        // When
-        photo.edit().rotate(90).apply();
-        photo.edit().rotate(90).apply();
-        photo.edit().rotate(-90).apply();
-        // Then
-        assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(90);
     }
 
     @Test
@@ -142,7 +138,7 @@ public class PhotoTest {
         // Given
         Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
         // When
-        photo.edit().rotate(450).apply();
+        photo.edit().rotateTo(450).apply();
         // Then
         assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(90);
     }
@@ -152,8 +148,18 @@ public class PhotoTest {
         // Given
         Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
         // When
-        photo.edit().rotate(-270).apply();
+        photo.edit().rotateTo(-270).apply();
         // Then
         assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(90);
+    }
+
+    @Test
+    public void should_keepRotationDelta_afterCompression() {
+        // Given
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 90);
+        // When
+        photo.edit().compressBy(50).apply();
+        // Then
+        assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(0);
     }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/UserCommentBuilderTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/UserCommentBuilderTest.java
@@ -1,0 +1,51 @@
+package net.gini.android.vision.internal.camera.photo;
+
+import android.support.annotation.NonNull;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Created by aszotyori on 13/03/2017.
+ */
+
+@RunWith(AndroidJUnit4.class)
+public class UserCommentBuilderTest {
+
+    @Test
+    public void should_createUserComment_withPredeterminedOrder_ofKeys() throws Exception {
+        // Given
+        Exif.UserCommentBuilder builder = Exif.userCommentBuilder();
+        // When
+        builder.setRotationDelta(90)
+                .setUUID("asdasd-assd-ssdsa-sdsdss")
+                .setAddMake(true)
+                .setAddModel(true);
+        String userComment = builder.build();
+        // Then
+        List<String> keys = getListOfKeys(userComment);
+        assertThat(keys).containsExactly(Exif.USER_COMMENT_MAKE, Exif.USER_COMMENT_MODEL,
+                Exif.USER_COMMENT_PLATFORM, Exif.USER_COMMENT_OS_VERSION,
+                Exif.USER_COMMENT_GINI_VISION_VERSION, Exif.USER_COMMENT_UUID,
+                Exif.USER_COMMENT_ROTATION_DELTA).inOrder();
+    }
+
+    @NonNull
+    private List<String> getListOfKeys(String userComment) {
+        List<String> keys = new ArrayList<>();
+        String[] keyValuePairs = userComment.split(",");
+        for (String keyValuePair : keyValuePairs) {
+            String[] keyAndValue = keyValuePair.split("=");
+            if (keyAndValue.length > 0) {
+                keys.add(keyAndValue[0]);
+            }
+        }
+        return keys;
+    }
+}

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/UserCommentBuilderTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/UserCommentBuilderTest.java
@@ -24,7 +24,7 @@ public class UserCommentBuilderTest {
         Exif.UserCommentBuilder builder = Exif.userCommentBuilder();
         // When
         builder.setRotationDelta(90)
-                .setUUID("asdasd-assd-ssdsa-sdsdss")
+                .setContentId("asdasd-assd-ssdsa-sdsdss")
                 .setAddMake(true)
                 .setAddModel(true);
         String userComment = builder.build();
@@ -32,7 +32,7 @@ public class UserCommentBuilderTest {
         List<String> keys = getListOfKeys(userComment);
         assertThat(keys).containsExactly(Exif.USER_COMMENT_MAKE, Exif.USER_COMMENT_MODEL,
                 Exif.USER_COMMENT_PLATFORM, Exif.USER_COMMENT_OS_VERSION,
-                Exif.USER_COMMENT_GINI_VISION_VERSION, Exif.USER_COMMENT_UUID,
+                Exif.USER_COMMENT_GINI_VISION_VERSION, Exif.USER_COMMENT_CONTENT_ID,
                 Exif.USER_COMMENT_ROTATION_DELTA).inOrder();
     }
 

--- a/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
@@ -382,7 +382,7 @@ public class ReviewScreenTest {
     }
 
     @Test
-    public void should_returnDocuments_withSameUUID_inAnalyzeDocument_andProceedToAnalysis()
+    public void should_returnDocuments_withSameContentId_inAnalyzeDocument_andProceedToAnalysis()
             throws InterruptedException {
         final ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 90);
 
@@ -412,7 +412,7 @@ public class ReviewScreenTest {
         // Allow the activity to run a little for listeners to be invoked
         Thread.sleep(PAUSE_DURATION);
 
-        assertAbout(document()).that(documentToAnalyze.get()).hasSameUUIDinUserCommentAs(
+        assertAbout(document()).that(documentToAnalyze.get()).hasSameContentIdInUserCommentAs(
                 documentToProceedWith.get());
     }
 

--- a/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
@@ -382,8 +382,7 @@ public class ReviewScreenTest {
     }
 
     @Test
-    public void
-    should_returnDocuments_withSameUUID_inAnalyzeDocument_andProceedToAnalysis()
+    public void should_returnDocuments_withSameUUID_inAnalyzeDocument_andProceedToAnalysis()
             throws InterruptedException {
         final ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 90);
 
@@ -415,5 +414,114 @@ public class ReviewScreenTest {
 
         assertAbout(document()).that(documentToAnalyze.get()).hasSameUUIDinUserCommentAs(
                 documentToProceedWith.get());
+    }
+
+    @Test
+    public void should_returnDocument_withZeroRotationDelta_inAnalyzeDocument()
+            throws InterruptedException {
+        final ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 180);
+
+        final AtomicReference<Document> documentToAnalyze = new AtomicReference<>();
+
+        activity.setListenerHook(new ReviewActivityTestStub.ListenerHook() {
+            @Override
+            public void onShouldAnalyzeDocument(@NonNull Document document) {
+                documentToAnalyze.set(document);
+            }
+        });
+
+        // Allow the activity to run a little for listeners to be invoked
+        Thread.sleep(PAUSE_DURATION);
+
+        assertAbout(document()).that(documentToAnalyze.get()).hasRotationDeltaInUserComment(0);
+    }
+
+    @Test
+    public void should_returnDocument_withNonZeroRotationDelta_inProceedToAnalysis_ifDocumentWasRotated()
+            throws InterruptedException {
+        final ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 270);
+
+        final AtomicReference<Document> documentToProceedWith = new AtomicReference<>();
+
+        activity.setListenerHook(new ReviewActivityTestStub.ListenerHook() {
+            @Override
+            public void onProceedToAnalysisScreen(@NonNull final Document document) {
+                documentToProceedWith.set(document);
+            }
+        });
+
+        // Modify the document
+        Espresso.onView(ViewMatchers.withId(R.id.gv_button_rotate))
+                .perform(ViewActions.click());
+
+        // Click next
+        Espresso.onView(ViewMatchers.withId(R.id.gv_button_next))
+                .perform(ViewActions.click());
+
+        // Allow the activity to run a little for listeners to be invoked
+        Thread.sleep(PAUSE_DURATION);
+
+        assertAbout(document()).that(documentToProceedWith.get()).hasRotationDeltaInUserComment(90);
+    }
+
+    @Test
+    public void should_returnDocument_withCumulatedRotationDelta_inProceedToAnalysis_ifDocumentWasRotatedMultipleTimes()
+            throws InterruptedException {
+        final ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 180);
+
+        final AtomicReference<Document> documentToProceedWith = new AtomicReference<>();
+
+        activity.setListenerHook(new ReviewActivityTestStub.ListenerHook() {
+            @Override
+            public void onProceedToAnalysisScreen(@NonNull final Document document) {
+                documentToProceedWith.set(document);
+            }
+        });
+
+        // Modify the document
+        Espresso.onView(ViewMatchers.withId(R.id.gv_button_rotate))
+                .perform(ViewActions.click());
+        // Modify the document
+        Espresso.onView(ViewMatchers.withId(R.id.gv_button_rotate))
+                .perform(ViewActions.click());
+
+        // Click next
+        Espresso.onView(ViewMatchers.withId(R.id.gv_button_next))
+                .perform(ViewActions.click());
+
+        // Allow the activity to run a little for listeners to be invoked
+        Thread.sleep(PAUSE_DURATION);
+
+        assertAbout(document()).that(documentToProceedWith.get()).hasRotationDeltaInUserComment(180);
+    }
+
+    @Test
+    public void should_returnDocument_withNormalizedRotationDelta_inProceedToAnalysis_ifDocumentWasRotatedBeyond360Degrees()
+            throws InterruptedException {
+        final ReviewActivityTestStub activity = startReviewActivity(TEST_JPEG, 90);
+
+        final AtomicReference<Document> documentToProceedWith = new AtomicReference<>();
+
+        activity.setListenerHook(new ReviewActivityTestStub.ListenerHook() {
+            @Override
+            public void onProceedToAnalysisScreen(@NonNull final Document document) {
+                documentToProceedWith.set(document);
+            }
+        });
+
+        // Rotate the document 5 times
+        for (int i = 0; i < 5; i++) {
+            Espresso.onView(ViewMatchers.withId(R.id.gv_button_rotate))
+                    .perform(ViewActions.click());
+        }
+
+        // Click next
+        Espresso.onView(ViewMatchers.withId(R.id.gv_button_next))
+                .perform(ViewActions.click());
+
+        // Allow the activity to run a little for listeners to be invoked
+        Thread.sleep(PAUSE_DURATION);
+
+        assertAbout(document()).that(documentToProceedWith.get()).hasRotationDeltaInUserComment(90);
     }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/test/DocumentSubject.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/test/DocumentSubject.java
@@ -64,4 +64,9 @@ public class DocumentSubject extends Subject<DocumentSubject, Document> {
 
         mJpegByteArraySubject.hasSameUUIDinUserCommentAs(other.getJpeg());
     }
+
+    public void hasRotationDeltaInUserComment(final int rotationDelta) {
+        isNotNull();
+        mJpegByteArraySubject.hasRotationDeltaInUserComment(rotationDelta);
+    }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/test/DocumentSubject.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/test/DocumentSubject.java
@@ -53,16 +53,16 @@ public class DocumentSubject extends Subject<DocumentSubject, Document> {
         }
     }
 
-    public void hasSameUUIDinUserCommentAs(Document other) {
+    public void hasSameContentIdInUserCommentAs(Document other) {
         isNotNull();
-        String verb = "has same User Comment UUID";
+        String verb = "has same User Comment ContentId";
 
         if (other == null) {
             fail(verb, (Object) null);
             return;
         }
 
-        mJpegByteArraySubject.hasSameUUIDinUserCommentAs(other.getJpeg());
+        mJpegByteArraySubject.hasSameContentIdInUserCommentAs(other.getJpeg());
     }
 
     public void hasRotationDeltaInUserComment(final int rotationDelta) {

--- a/ginivision/src/androidTest/java/net/gini/android/vision/test/JpegByteArraySubject.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/test/JpegByteArraySubject.java
@@ -30,25 +30,25 @@ class JpegByteArraySubject extends Subject<JpegByteArraySubject, byte[]> {
         super(failureStrategy, subject);
     }
 
-    void hasUUIDinUserComment(@Nullable String uuid) {
+    void hasContentIdInUserComment(@Nullable String contentId) {
         isNotNull();
-        String verb = "has in User Comment UUID";
+        String verb = "has in User Comment ContentId";
 
-        if (uuid == null) {
+        if (contentId == null) {
             fail(verb, (Object) null);
             return;
         }
 
-        final String userComment = readExifUserComment(verb, uuid, getSubject());
-        final String uuidInUserComment = getValueForKeyfromUserComment("UUID", userComment);
+        final String userComment = readExifUserComment(verb, contentId, getSubject());
+        final String contentIdInUserComment = getValueForKeyfromUserComment("ContentId", userComment);
 
-        if (uuidInUserComment == null) {
-            triggerFailureWithRawMessage(verb, uuid, "It had no UUID in User Comment");
+        if (contentIdInUserComment == null) {
+            triggerFailureWithRawMessage(verb, contentId, "It had no ContentId in User Comment");
             return;
         }
 
-        if (!uuid.equals(uuidInUserComment)) {
-            failWithBadResults(verb, uuid, "was", uuidInUserComment);
+        if (!contentId.equals(contentIdInUserComment)) {
+            failWithBadResults(verb, contentId, "was", contentIdInUserComment);
         }
     }
 
@@ -90,9 +90,9 @@ class JpegByteArraySubject extends Subject<JpegByteArraySubject, byte[]> {
         return null;
     }
 
-    void hasSameUUIDinUserCommentAs(@Nullable byte[] jpeg) {
+    void hasSameContentIdInUserCommentAs(@Nullable byte[] jpeg) {
         isNotNull();
-        String verb = "has in User Comment same UUID";
+        String verb = "has in User Comment same ContentId";
 
         if (jpeg == null) {
             fail(verb, (Object) null);
@@ -101,15 +101,15 @@ class JpegByteArraySubject extends Subject<JpegByteArraySubject, byte[]> {
 
         final String userComment = readExifUserComment(getSubject());
         final String expectedUserComment = readExifUserComment(jpeg);
-        final String subjectUuid = getValueForKeyfromUserComment("UUID", userComment);
-        final String otherUuid = getValueForKeyfromUserComment("UUID", expectedUserComment);
+        final String subjectUuid = getValueForKeyfromUserComment("ContentId", userComment);
+        final String otherUuid = getValueForKeyfromUserComment("ContentId", expectedUserComment);
 
         if (subjectUuid == null && otherUuid != null) {
-            triggerFailureWithRawMessage(verb, otherUuid, "It had no UUID in User Comment");
+            triggerFailureWithRawMessage(verb, otherUuid, "It had no ContentId in User Comment");
             return;
         }
         if (otherUuid == null) {
-            triggerFailureWithRawMessage(verb, null, "Target had no UUID in User Comment");
+            triggerFailureWithRawMessage(verb, null, "Target had no ContentId in User Comment");
             return;
         }
 

--- a/ginivision/src/androidTest/java/net/gini/android/vision/test/JpegByteArraySubject.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/test/JpegByteArraySubject.java
@@ -109,12 +109,31 @@ class JpegByteArraySubject extends Subject<JpegByteArraySubject, byte[]> {
             return;
         }
         if (otherUuid == null) {
-            triggerFailureWithRawMessage(verb, null, "Target had no UUID in User Comment.");
+            triggerFailureWithRawMessage(verb, null, "Target had no UUID in User Comment");
             return;
         }
 
         if (!subjectUuid.equals(otherUuid)) {
             failWithBadResults(verb, subjectUuid, "was", otherUuid);
+        }
+    }
+
+    void hasRotationDeltaInUserComment(final int rotationDelta) {
+        isNotNull();
+        String verb = "has in User Comment rotation delta";
+
+        final String userComment = readExifUserComment(getSubject());
+        final String subjectRotDeltaDegString = getValueForKeyfromUserComment("RotDeltaDeg", userComment);
+
+        if (subjectRotDeltaDegString == null) {
+            triggerFailureWithRawMessage(verb, String.valueOf(rotationDelta),
+                    "Target had no rotation delta in User Comment");
+            return;
+        }
+
+        int subjectRotDeltaDeg = Integer.parseInt(subjectRotDeltaDegString);
+        if (subjectRotDeltaDeg != rotationDelta) {
+            failWithBadResults(verb, rotationDelta, "was", subjectRotDeltaDeg);
         }
     }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/test/JpegByteArraySubject.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/test/JpegByteArraySubject.java
@@ -136,4 +136,21 @@ class JpegByteArraySubject extends Subject<JpegByteArraySubject, byte[]> {
             failWithBadResults(verb, rotationDelta, "was", subjectRotDeltaDeg);
         }
     }
+
+    void hasSameUserCommentAs(@Nullable final byte[] other) {
+        isNotNull();
+        String verb = "has User Comment";
+
+        if (other == null) {
+            fail(verb, (Object) null);
+            return;
+        }
+
+        final String subjectUserComment = readExifUserComment(getSubject());
+        final String otherUserComment = readExifUserComment(other);
+
+        if (!otherUserComment.equals(subjectUserComment)) {
+            failWithBadResults(verb, otherUserComment, "was", subjectUserComment);
+        }
+    }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/test/PhotoSubject.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/test/PhotoSubject.java
@@ -30,16 +30,16 @@ public class PhotoSubject extends Subject<PhotoSubject, Photo> {
         mJpegByteArraySubject = new JpegByteArraySubject(failureStrategy, subject.getJpeg());
     }
 
-    public void hasUUIDinUserComment(final String uuid) {
+    public void hasContentIdInUserComment(final String contentId) {
         isNotNull();
-        String verb = "has in User Comment UUID";
+        String verb = "has in User Comment ContentId";
 
-        if (uuid == null) {
+        if (contentId == null) {
             fail(verb, (Object) null);
             return;
         }
 
-        mJpegByteArraySubject.hasUUIDinUserComment(uuid);
+        mJpegByteArraySubject.hasContentIdInUserComment(contentId);
     }
 
     public void hasRotationDeltaInUserComment(final int rotationDelta) {

--- a/ginivision/src/androidTest/java/net/gini/android/vision/test/PhotoSubject.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/test/PhotoSubject.java
@@ -30,7 +30,7 @@ public class PhotoSubject extends Subject<PhotoSubject, Photo> {
         mJpegByteArraySubject = new JpegByteArraySubject(failureStrategy, subject.getJpeg());
     }
 
-    public void hasUUIDinUserComment(String uuid) {
+    public void hasUUIDinUserComment(final String uuid) {
         isNotNull();
         String verb = "has in User Comment UUID";
 
@@ -40,5 +40,10 @@ public class PhotoSubject extends Subject<PhotoSubject, Photo> {
         }
 
         mJpegByteArraySubject.hasUUIDinUserComment(uuid);
+    }
+
+    public void hasRotationDeltaInUserComment(final int rotationDelta) {
+        isNotNull();
+        mJpegByteArraySubject.hasRotationDeltaInUserComment(rotationDelta);
     }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/test/PhotoSubject.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/test/PhotoSubject.java
@@ -46,4 +46,9 @@ public class PhotoSubject extends Subject<PhotoSubject, Photo> {
         isNotNull();
         mJpegByteArraySubject.hasRotationDeltaInUserComment(rotationDelta);
     }
+
+    public void hasSameUserCommentAs(@Nullable final Photo photo) {
+        isNotNull();
+        mJpegByteArraySubject.hasSameUserCommentAs(photo.getJpeg());
+    }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
@@ -42,7 +42,7 @@ class Exif {
     static final String USER_COMMENT_PLATFORM = "Platform";
     static final String USER_COMMENT_OS_VERSION = "OSVer";
     static final String USER_COMMENT_GINI_VISION_VERSION = "GiniVisionVer";
-    static final String USER_COMMENT_UUID = "UUID";
+    static final String USER_COMMENT_CONTENT_ID = "ContentId";
     static final String USER_COMMENT_ROTATION_DELTA = "RotDeltaDeg";
 
     private final TiffOutputSet mTiffOutputSet;
@@ -329,7 +329,7 @@ class Exif {
 
         private boolean mAddMake;
         private boolean mAddModel;
-        private String mUUID;
+        private String mContentId;
         private int mRotationDelta;
 
         private UserCommentBuilder() {
@@ -346,8 +346,8 @@ class Exif {
             return this;
         }
 
-        UserCommentBuilder setUUID(final String UUID) {
-            mUUID = UUID;
+        UserCommentBuilder setContentId(final String contentId) {
+            mContentId = contentId;
             return this;
         }
 
@@ -358,8 +358,8 @@ class Exif {
 
         @NonNull
         public String build() {
-            if (mUUID == null) {
-                throw new IllegalStateException("UUID is required for the User Comment");
+            if (mContentId == null) {
+                throw new IllegalStateException("ContentId is required for the User Comment");
             }
             return createUserComment();
         }
@@ -387,8 +387,8 @@ class Exif {
             map.put(USER_COMMENT_OS_VERSION, String.valueOf(Build.VERSION.RELEASE));
             // GiniVision Version
             map.put(USER_COMMENT_GINI_VISION_VERSION, BuildConfig.VERSION_NAME.replace(" ", ""));
-            // UUID
-            map.put(USER_COMMENT_UUID, mUUID);
+            // Content ID
+            map.put(USER_COMMENT_CONTENT_ID, mContentId);
             // Rotation Delta
             map.put(USER_COMMENT_ROTATION_DELTA, String.valueOf(mRotationDelta));
             return map;

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
@@ -208,12 +208,6 @@ public class Exif {
         }
 
         @NonNull
-        public Builder setRotationDelta(int rotationDelta) {
-            return this;
-        }
-
-
-        @NonNull
         public Exif build() {
             return new Exif(mTiffOutputSet);
         }
@@ -388,6 +382,10 @@ public class Exif {
             // UUID
             userCommentBuilder.append("UUID=");
             userCommentBuilder.append(mUUID);
+            userCommentBuilder.append(",");
+            // Rotation Delta
+            userCommentBuilder.append("RotDeltaDeg=");
+            userCommentBuilder.append(mRotationDelta);
 
             return userCommentBuilder.toString();
         }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
@@ -29,6 +29,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * @exclude
@@ -364,39 +366,50 @@ class Exif {
 
         @NonNull
         private String createUserComment() {
-            final StringBuilder userCommentBuilder = new StringBuilder();
+            final Map<String, String> keyValueMap = createKeyValueMap();
+            return convertMapToCSV(keyValueMap);
+        }
+
+        @NonNull
+        private Map<String, String> createKeyValueMap() {
+            final Map<String, String> map = new LinkedHashMap<>();
             // Make
             if (mAddMake) {
-                userCommentBuilder.append(USER_COMMENT_MAKE).append("=");
-                userCommentBuilder.append(Build.BRAND);
-                userCommentBuilder.append(",");
+                map.put(USER_COMMENT_MAKE, Build.BRAND);
             }
             // Model
             if (mAddModel) {
-                userCommentBuilder.append(USER_COMMENT_MODEL).append("=");
-                userCommentBuilder.append(Build.MODEL);
-                userCommentBuilder.append(",");
+                map.put(USER_COMMENT_MODEL, Build.MODEL);
             }
             // Platform
-            userCommentBuilder.append(USER_COMMENT_PLATFORM).append("=").append("Android");
-            userCommentBuilder.append(",");
+            map.put(USER_COMMENT_PLATFORM, "Android");
             // OS Version
-            userCommentBuilder.append(USER_COMMENT_OS_VERSION).append("=");
-            userCommentBuilder.append(String.valueOf(Build.VERSION.RELEASE));
-            userCommentBuilder.append(",");
+            map.put(USER_COMMENT_OS_VERSION, String.valueOf(Build.VERSION.RELEASE));
             // GiniVision Version
-            userCommentBuilder.append(USER_COMMENT_GINI_VISION_VERSION).append("=");
-            userCommentBuilder.append(BuildConfig.VERSION_NAME.replace(" ", ""));
-            userCommentBuilder.append(",");
+            map.put(USER_COMMENT_GINI_VISION_VERSION, BuildConfig.VERSION_NAME.replace(" ", ""));
             // UUID
-            userCommentBuilder.append(USER_COMMENT_UUID).append("=");
-            userCommentBuilder.append(mUUID);
-            userCommentBuilder.append(",");
+            map.put(USER_COMMENT_UUID, mUUID);
             // Rotation Delta
-            userCommentBuilder.append(USER_COMMENT_ROTATION_DELTA).append("=");
-            userCommentBuilder.append(mRotationDelta);
-
-            return userCommentBuilder.toString();
+            map.put(USER_COMMENT_ROTATION_DELTA, String.valueOf(mRotationDelta));
+            return map;
         }
+
+        @NonNull
+        private String convertMapToCSV(@NonNull final Map<String, String> keyValueMap) {
+            final StringBuilder csvBuilder = new StringBuilder();
+            boolean isFirst = true;
+            for (final Map.Entry<String, String> keyValueEntry : keyValueMap.entrySet()) {
+                if (!isFirst) {
+                    csvBuilder.append(",");
+                }
+                isFirst = false;
+
+                csvBuilder.append(keyValueEntry.getKey())
+                        .append("=")
+                        .append(keyValueEntry.getValue());
+            }
+            return csvBuilder.toString();
+        }
+
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
@@ -33,15 +33,15 @@ import java.nio.charset.Charset;
 /**
  * @exclude
  */
-public class Exif {
+class Exif {
 
-    public static final String USER_COMMENT_MAKE = "Make";
-    public static final String USER_COMMENT_MODEL = "Model";
-    public static final String USER_COMMENT_PLATFORM = "Platform";
-    public static final String USER_COMMENT_OS_VERSION = "OSVer";
-    public static final String USER_COMMENT_GINI_VISION_VERSION = "GiniVisionVer";
-    public static final String USER_COMMENT_UUID = "UUID";
-    public static final String USER_COMMENT_ROTATION_DELTA = "RotDeltaDeg";
+    static final String USER_COMMENT_MAKE = "Make";
+    static final String USER_COMMENT_MODEL = "Model";
+    static final String USER_COMMENT_PLATFORM = "Platform";
+    static final String USER_COMMENT_OS_VERSION = "OSVer";
+    static final String USER_COMMENT_GINI_VISION_VERSION = "GiniVisionVer";
+    static final String USER_COMMENT_UUID = "UUID";
+    static final String USER_COMMENT_ROTATION_DELTA = "RotDeltaDeg";
 
     private final TiffOutputSet mTiffOutputSet;
 
@@ -55,7 +55,7 @@ public class Exif {
         return new Builder(jpeg);
     }
 
-    public static UserCommentBuilder userCommentBuilder() {
+    static UserCommentBuilder userCommentBuilder() {
         return new UserCommentBuilder();
     }
 
@@ -93,7 +93,7 @@ public class Exif {
         return requiredTags;
     }
 
-    public static class Builder {
+    static class Builder {
 
         private TiffOutputSet mTiffOutputSet;
         private TiffOutputDirectory mIfd0Directory;
@@ -271,7 +271,7 @@ public class Exif {
         }
     }
 
-    public static class RequiredTags {
+    static class RequiredTags {
         public TiffField make;
         public TiffField model;
         public TiffField iso;
@@ -323,7 +323,7 @@ public class Exif {
         }
     }
 
-    public static class UserCommentBuilder {
+    static class UserCommentBuilder {
 
         private boolean mAddMake;
         private boolean mAddModel;
@@ -334,22 +334,22 @@ public class Exif {
 
         }
 
-        public UserCommentBuilder setAddMake(final boolean addMake) {
+        UserCommentBuilder setAddMake(final boolean addMake) {
             mAddMake = addMake;
             return this;
         }
 
-        public UserCommentBuilder setAddModel(final boolean addModel) {
+        UserCommentBuilder setAddModel(final boolean addModel) {
             mAddModel = addModel;
             return this;
         }
 
-        public UserCommentBuilder setUUID(final String UUID) {
+        UserCommentBuilder setUUID(final String UUID) {
             mUUID = UUID;
             return this;
         }
 
-        public UserCommentBuilder setRotationDelta(final int rotationDelta) {
+        UserCommentBuilder setRotationDelta(final int rotationDelta) {
             mRotationDelta = rotationDelta;
             return this;
         }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
@@ -35,6 +35,14 @@ import java.nio.charset.Charset;
  */
 public class Exif {
 
+    public static final String USER_COMMENT_MAKE = "Make";
+    public static final String USER_COMMENT_MODEL = "Model";
+    public static final String USER_COMMENT_PLATFORM = "Platform";
+    public static final String USER_COMMENT_OS_VERSION = "OSVer";
+    public static final String USER_COMMENT_GINI_VISION_VERSION = "GiniVisionVer";
+    public static final String USER_COMMENT_UUID = "UUID";
+    public static final String USER_COMMENT_ROTATION_DELTA = "RotDeltaDeg";
+
     private final TiffOutputSet mTiffOutputSet;
 
     private Exif(@NonNull TiffOutputSet tiffOutputSet) {
@@ -316,6 +324,7 @@ public class Exif {
     }
 
     public static class UserCommentBuilder {
+
         private boolean mAddMake;
         private boolean mAddModel;
         private String mUUID;
@@ -358,33 +367,33 @@ public class Exif {
             final StringBuilder userCommentBuilder = new StringBuilder();
             // Make
             if (mAddMake) {
-                userCommentBuilder.append("Make=");
+                userCommentBuilder.append(USER_COMMENT_MAKE).append("=");
                 userCommentBuilder.append(Build.BRAND);
                 userCommentBuilder.append(",");
             }
             // Model
             if (mAddModel) {
-                userCommentBuilder.append("Model=");
+                userCommentBuilder.append(USER_COMMENT_MODEL).append("=");
                 userCommentBuilder.append(Build.MODEL);
                 userCommentBuilder.append(",");
             }
             // Platform
-            userCommentBuilder.append("Platform=Android");
+            userCommentBuilder.append(USER_COMMENT_PLATFORM).append("=").append("Android");
             userCommentBuilder.append(",");
             // OS Version
-            userCommentBuilder.append("OSVer=");
+            userCommentBuilder.append(USER_COMMENT_OS_VERSION).append("=");
             userCommentBuilder.append(String.valueOf(Build.VERSION.RELEASE));
             userCommentBuilder.append(",");
             // GiniVision Version
-            userCommentBuilder.append("GiniVisionVer=");
+            userCommentBuilder.append(USER_COMMENT_GINI_VISION_VERSION).append("=");
             userCommentBuilder.append(BuildConfig.VERSION_NAME.replace(" ", ""));
             userCommentBuilder.append(",");
             // UUID
-            userCommentBuilder.append("UUID=");
+            userCommentBuilder.append(USER_COMMENT_UUID).append("=");
             userCommentBuilder.append(mUUID);
             userCommentBuilder.append(",");
             // Rotation Delta
-            userCommentBuilder.append("RotDeltaDeg=");
+            userCommentBuilder.append(USER_COMMENT_ROTATION_DELTA).append("=");
             userCommentBuilder.append(mRotationDelta);
 
             return userCommentBuilder.toString();

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReader.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReader.java
@@ -20,7 +20,7 @@ class ExifReader {
 
     private final byte[] jpeg;
 
-    public ExifReader(@NonNull final byte[] jpeg) {
+    ExifReader(@NonNull final byte[] jpeg) {
         this.jpeg = jpeg;
     }
 
@@ -50,10 +50,10 @@ class ExifReader {
     }
 
     @Nullable
-    public String getValueForKeyfromUserComment(@NonNull final String key, @NonNull final String userComment) {
-        String[] keyValuePairs = userComment.split(",");
+    String getValueForKeyfromUserComment(@NonNull final String key, @NonNull final String userComment) {
+        final String[] keyValuePairs = userComment.split(",");
         for (final String keyValuePair : keyValuePairs) {
-            String[] keyAndValue = keyValuePair.split("=");
+            final String[] keyAndValue = keyValuePair.split("=");
             if (keyAndValue[0].equals(key)) {
                 return keyAndValue[1];
             }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReader.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReader.java
@@ -50,11 +50,11 @@ class ExifReader {
     }
 
     @Nullable
-    String getValueForKeyfromUserComment(@NonNull final String key, @NonNull final String userComment) {
+    String getValueForKeyFromUserComment(@NonNull final String key, @NonNull final String userComment) {
         final String[] keyValuePairs = userComment.split(",");
         for (final String keyValuePair : keyValuePairs) {
             final String[] keyAndValue = keyValuePair.split("=");
-            if (keyAndValue[0].equals(key)) {
+            if (keyAndValue.length > 0 && keyAndValue[0].equals(key)) {
                 return keyAndValue[1];
             }
         }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReader.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReader.java
@@ -13,7 +13,10 @@ import org.apache.commons.imaging.formats.tiff.constants.ExifTagConstants;
 import java.io.IOException;
 import java.util.Arrays;
 
-public class ExifReader {
+/**
+ * @exclude
+ */
+class ExifReader {
 
     private final byte[] jpeg;
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReader.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReader.java
@@ -1,0 +1,60 @@
+package net.gini.android.vision.internal.camera.photo;
+
+import static org.apache.commons.imaging.Imaging.getMetadata;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import org.apache.commons.imaging.ImageReadException;
+import org.apache.commons.imaging.formats.jpeg.JpegImageMetadata;
+import org.apache.commons.imaging.formats.tiff.TiffField;
+import org.apache.commons.imaging.formats.tiff.constants.ExifTagConstants;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class ExifReader {
+
+    private final byte[] jpeg;
+
+    public ExifReader(@NonNull final byte[] jpeg) {
+        this.jpeg = jpeg;
+    }
+
+    @NonNull
+    public String getUserComment() {
+        try {
+            final JpegImageMetadata jpegMetadata = (JpegImageMetadata) getMetadata(jpeg);
+            if (jpegMetadata == null) {
+                throw new ExifReaderException("No jpeg metadata found");
+            }
+
+            final TiffField userCommentField = jpegMetadata.findEXIFValue(
+                    ExifTagConstants.EXIF_TAG_USER_COMMENT);
+
+            try {
+                final byte[] rawUserComment = userCommentField.getByteArrayValue();
+                if (rawUserComment == null) {
+                    throw new ExifReaderException("No User Comment found");
+                }
+                return new String(Arrays.copyOfRange(rawUserComment, 8, rawUserComment.length));
+            } catch (ClassCastException e) {
+                throw new ExifReaderException("Unexpected type in User Comment: " + e.getMessage(), e);
+            }
+        } catch (IOException | ImageReadException e) {
+            throw new ExifReaderException("Could not read jpeg metadata: " + e.getMessage(), e);
+        }
+    }
+
+    @Nullable
+    public String getValueForKeyfromUserComment(@NonNull final String key, @NonNull final String userComment) {
+        String[] keyValuePairs = userComment.split(",");
+        for (final String keyValuePair : keyValuePairs) {
+            String[] keyAndValue = keyValuePair.split("=");
+            if (keyAndValue[0].equals(key)) {
+                return keyAndValue[1];
+            }
+        }
+        return null;
+    }
+}

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReader.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReader.java
@@ -54,7 +54,7 @@ class ExifReader {
         final String[] keyValuePairs = userComment.split(",");
         for (final String keyValuePair : keyValuePairs) {
             final String[] keyAndValue = keyValuePair.split("=");
-            if (keyAndValue.length > 0 && keyAndValue[0].equals(key)) {
+            if (keyAndValue.length > 1 && keyAndValue[0].equals(key)) {
                 return keyAndValue[1];
             }
         }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReaderException.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReaderException.java
@@ -1,0 +1,14 @@
+package net.gini.android.vision.internal.camera.photo;
+
+import android.support.annotation.NonNull;
+
+public class ExifReaderException extends RuntimeException {
+
+    ExifReaderException(@NonNull final String detailMessage) {
+        super(detailMessage);
+    }
+
+    ExifReaderException(@NonNull final String detailMessage, @NonNull final Throwable throwable) {
+        super(detailMessage, throwable);
+    }
+}

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReaderException.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ExifReaderException.java
@@ -2,7 +2,10 @@ package net.gini.android.vision.internal.camera.photo;
 
 import android.support.annotation.NonNull;
 
-public class ExifReaderException extends RuntimeException {
+/**
+ * @exclude
+ */
+class ExifReaderException extends RuntimeException {
 
     ExifReaderException(@NonNull final String detailMessage) {
         super(detailMessage);

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
@@ -72,9 +72,9 @@ public class Photo implements Parcelable {
         try {
             ExifReader exifReader = new ExifReader(mJpeg);
             String userComment = exifReader.getUserComment();
-            mUUID = exifReader.getValueForKeyfromUserComment(Exif.USER_COMMENT_UUID, userComment);
+            mUUID = exifReader.getValueForKeyFromUserComment(Exif.USER_COMMENT_UUID, userComment);
             mRotationDelta = Integer.parseInt(
-                    exifReader.getValueForKeyfromUserComment(Exif.USER_COMMENT_ROTATION_DELTA,
+                    exifReader.getValueForKeyFromUserComment(Exif.USER_COMMENT_ROTATION_DELTA,
                             userComment));
         } catch (ExifReaderException | NumberFormatException e) {
             // TODO log

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
@@ -72,9 +72,10 @@ public class Photo implements Parcelable {
         try {
             ExifReader exifReader = new ExifReader(mJpeg);
             String userComment = exifReader.getUserComment();
-            mUUID = exifReader.getValueForKeyfromUserComment("UUID", userComment);
+            mUUID = exifReader.getValueForKeyfromUserComment(Exif.USER_COMMENT_UUID, userComment);
             mRotationDelta = Integer.parseInt(
-                    exifReader.getValueForKeyfromUserComment("RotDeltaDeg", userComment));
+                    exifReader.getValueForKeyfromUserComment(Exif.USER_COMMENT_ROTATION_DELTA,
+                            userComment));
         } catch (ExifReaderException | NumberFormatException e) {
             // TODO log
         }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
@@ -48,7 +48,7 @@ public class Photo implements Parcelable {
         return Photo.fromJpeg(document.getJpeg(), document.getRotationForDisplay());
     }
 
-    public static Bitmap createPreview(byte[] jpeg) {
+    static Bitmap createPreview(byte[] jpeg) {
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inSampleSize = 2;
 
@@ -64,7 +64,7 @@ public class Photo implements Parcelable {
         return mBitmapPreview;
     }
 
-    public synchronized void setBitmapPreview(@NonNull Bitmap bitmap) {
+    synchronized void setBitmapPreview(@NonNull Bitmap bitmap) {
         mBitmapPreview = bitmap;
     }
 
@@ -81,14 +81,19 @@ public class Photo implements Parcelable {
         return mRotationForDisplay;
     }
 
-    public synchronized void setRotationForDisplay(int degrees) {
-        // Converts input degrees to degrees between [0,360]
+    synchronized void setRotationForDisplay(int degrees) {
+        // Converts input degrees to degrees between [0,360)
         mRotationForDisplay = ((degrees % 360) + 360) % 360;
     }
 
-    public synchronized void setRotationDelta(int degrees) {
-        // Converts input degrees to degrees between [0,360]
-        mRotationDelta = ((degrees % 360) + 360) % 360;
+    synchronized void updateRotationDeltaBy(int degrees) {
+        // Converts input degrees to degrees between [0,360)
+        mRotationDelta = ((mRotationDelta + degrees % 360) + 360) % 360;
+    }
+
+    @VisibleForTesting
+    int getRotationDelta() {
+        return mRotationDelta;
     }
 
     @VisibleForTesting
@@ -127,11 +132,11 @@ public class Photo implements Parcelable {
                     .setAddMake(addMake)
                     .setAddModel(addModel)
                     .setUUID(mUUID)
+                    .setRotationDelta(mRotationDelta)
                     .build();
 
             exifBuilder.setUserComment(userComment);
             exifBuilder.setOrientationFromDegrees(mRotationForDisplay);
-            exifBuilder.setRotationDelta(mRotationDelta);
 
             mJpeg = exifBuilder.build().writeToJpeg(mJpeg);
         } catch (ImageReadException | ImageWriteException | IOException e) {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
@@ -29,7 +29,7 @@ public class Photo implements Parcelable {
     private byte[] mJpeg;
     private Exif.RequiredTags mRequiredTags;
     private int mRotationForDisplay = 0;
-    private String mUUID = "";
+    private String mContentId = "";
     private int mRotationDelta = 0;
 
     private PhotoEdit mEditor;
@@ -46,7 +46,7 @@ public class Photo implements Parcelable {
         mJpeg = jpeg;
         mRotationForDisplay = orientation;
         mBitmapPreview = createPreview();
-        mUUID = generateUUID();
+        mContentId = generateUUID();
         readRequiredTags();
         updateExif();
     }
@@ -72,7 +72,7 @@ public class Photo implements Parcelable {
         try {
             ExifReader exifReader = new ExifReader(mJpeg);
             String userComment = exifReader.getUserComment();
-            mUUID = exifReader.getValueForKeyFromUserComment(Exif.USER_COMMENT_UUID, userComment);
+            mContentId = exifReader.getValueForKeyFromUserComment(Exif.USER_COMMENT_CONTENT_ID, userComment);
             mRotationDelta = Integer.parseInt(
                     exifReader.getValueForKeyFromUserComment(Exif.USER_COMMENT_ROTATION_DELTA,
                             userComment));
@@ -132,8 +132,8 @@ public class Photo implements Parcelable {
 
     @VisibleForTesting
     @NonNull
-    String getUUID() {
-        return mUUID;
+    String getContentId() {
+        return mContentId;
     }
 
     private synchronized void readRequiredTags() {
@@ -166,7 +166,7 @@ public class Photo implements Parcelable {
             String userComment = Exif.userCommentBuilder()
                     .setAddMake(addMake)
                     .setAddModel(addModel)
-                    .setUUID(mUUID)
+                    .setContentId(mContentId)
                     .setRotationDelta(mRotationDelta)
                     .build();
 
@@ -244,7 +244,7 @@ public class Photo implements Parcelable {
         dest.writeParcelable(token, flags);
 
         dest.writeInt(mRotationForDisplay);
-        dest.writeString(mUUID);
+        dest.writeString(mContentId);
         dest.writeInt(mRotationDelta);
     }
 
@@ -272,7 +272,7 @@ public class Photo implements Parcelable {
         cache.removeJpeg(token);
 
         mRotationForDisplay = in.readInt();
-        mUUID = in.readString();
+        mContentId = in.readString();
         mRotationDelta = in.readInt();
         readRequiredTags();
     }
@@ -295,7 +295,7 @@ public class Photo implements Parcelable {
                 : photo.mRequiredTags != null) {
             return false;
         }
-        if (mUUID != null ? !mUUID.equals(photo.mUUID) : photo.mUUID != null) return false;
+        if (mContentId != null ? !mContentId.equals(photo.mContentId) : photo.mContentId != null) return false;
         return mEditor != null ? mEditor.equals(photo.mEditor) : photo.mEditor == null;
 
     }
@@ -306,7 +306,7 @@ public class Photo implements Parcelable {
         result = 31 * result + Arrays.hashCode(mJpeg);
         result = 31 * result + (mRequiredTags != null ? mRequiredTags.hashCode() : 0);
         result = 31 * result + mRotationForDisplay;
-        result = 31 * result + (mUUID != null ? mUUID.hashCode() : 0);
+        result = 31 * result + (mContentId != null ? mContentId.hashCode() : 0);
         result = 31 * result + mRotationDelta;
         result = 31 * result + (mEditor != null ? mEditor.hashCode() : 0);
         return result;

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoCompressionModifier.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoCompressionModifier.java
@@ -1,0 +1,39 @@
+package net.gini.android.vision.internal.camera.photo;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.support.annotation.NonNull;
+
+import java.io.ByteArrayOutputStream;
+
+/**
+ * @exclude
+ */
+class PhotoCompressionModifier implements PhotoModifier {
+
+    private final Photo mPhoto;
+    private final int mQuality;
+
+    PhotoCompressionModifier(final int quality, @NonNull final Photo photo) {
+        mQuality = quality;
+        mPhoto = photo;
+    }
+
+    @Override
+    public void modify() {
+        if (mPhoto.getJpeg() == null) {
+            return;
+        }
+
+        Bitmap originalImage = BitmapFactory.decodeByteArray(mPhoto.getJpeg(), 0, mPhoto.getJpeg().length);
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        originalImage.compress(Bitmap.CompressFormat.JPEG, mQuality, byteArrayOutputStream);
+
+        byte[] jpeg = byteArrayOutputStream.toByteArray();
+        mPhoto.setJpeg(jpeg);
+        mPhoto.setBitmapPreview(Photo.createPreview(jpeg));
+
+        mPhoto.updateExif();
+    }
+}

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoCompressionModifier.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoCompressionModifier.java
@@ -25,12 +25,12 @@ class PhotoCompressionModifier implements PhotoModifier {
             return;
         }
 
-        Bitmap originalImage = BitmapFactory.decodeByteArray(mPhoto.getJpeg(), 0, mPhoto.getJpeg().length);
+        final Bitmap originalImage = BitmapFactory.decodeByteArray(mPhoto.getJpeg(), 0, mPhoto.getJpeg().length);
 
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         originalImage.compress(Bitmap.CompressFormat.JPEG, mQuality, byteArrayOutputStream);
 
-        byte[] jpeg = byteArrayOutputStream.toByteArray();
+        final byte[] jpeg = byteArrayOutputStream.toByteArray();
         mPhoto.setJpeg(jpeg);
         mPhoto.setBitmapPreview(Photo.createPreview(jpeg));
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoCompressionModifier.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoCompressionModifier.java
@@ -32,7 +32,7 @@ class PhotoCompressionModifier implements PhotoModifier {
 
         final byte[] jpeg = byteArrayOutputStream.toByteArray();
         mPhoto.setJpeg(jpeg);
-        mPhoto.setBitmapPreview(Photo.createPreview(jpeg));
+        mPhoto.updateBitmapPreview();
 
         mPhoto.updateExif();
     }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoEdit.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoEdit.java
@@ -22,14 +22,14 @@ public class PhotoEdit {
 
     @NonNull
     public PhotoEdit rotateTo(int degrees) {
-        PhotoRotationModifier rotationModifier = new PhotoRotationModifier(degrees, mPhoto);
+        final PhotoRotationModifier rotationModifier = new PhotoRotationModifier(degrees, mPhoto);
         mPhotoModifiers.add(rotationModifier);
         return this;
     }
 
     @NonNull
     public PhotoEdit compressBy(int quality) {
-        PhotoCompressionModifier compressionModifier = new PhotoCompressionModifier(quality, mPhoto);
+        final PhotoCompressionModifier compressionModifier = new PhotoCompressionModifier(quality, mPhoto);
         mPhotoModifiers.add(compressionModifier);
         return this;
     }
@@ -40,7 +40,7 @@ public class PhotoEdit {
     }
 
     public void applyAsync(@NonNull final PhotoEditCallback callback) {
-        EditAsync async = new EditAsync(mPhoto, mPhotoModifiers);
+        final EditAsync async = new EditAsync(mPhoto, mPhotoModifiers);
         async.setCallback(new PhotoEditCallback() {
             @Override
             public void onDone(@NonNull Photo photo) {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoEdit.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoEdit.java
@@ -82,6 +82,7 @@ public class PhotoEdit {
         }
 
         photo.setRotationForDisplay(rotationDegrees);
+        photo.updateRotationDeltaBy(rotationDegrees);
         photo.updateExif();
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoModifier.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoModifier.java
@@ -1,0 +1,8 @@
+package net.gini.android.vision.internal.camera.photo;
+
+/**
+ * @exclude
+ */
+interface PhotoModifier {
+    void modify();
+}

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoRotationModifier.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoRotationModifier.java
@@ -1,0 +1,29 @@
+package net.gini.android.vision.internal.camera.photo;
+
+import android.support.annotation.NonNull;
+
+/**
+ * @exclude
+ */
+class PhotoRotationModifier implements PhotoModifier {
+
+    private final Photo mPhoto;
+    private final int mRotationDegrees;
+
+    PhotoRotationModifier(final int rotationDegrees, @NonNull final Photo photo) {
+        mRotationDegrees = rotationDegrees;
+        mPhoto = photo;
+    }
+
+    @Override
+    public void modify() {
+        if (mPhoto.getJpeg() == null) {
+            return;
+        }
+
+        mPhoto.updateRotationDeltaBy(mRotationDegrees - mPhoto.getRotationForDisplay());
+        mPhoto.setRotationForDisplay(mRotationDegrees);
+
+        mPhoto.updateExif();
+    }
+}

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
@@ -249,14 +249,14 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
     private void applyRotationToJpeg(@NonNull PhotoEdit.PhotoEditCallback callback) {
         LOG.info("Rotating the jpeg {} degrees", mCurrentRotation);
         mPhoto.edit()
-                .rotate(mCurrentRotation)
+                .rotateTo(mCurrentRotation)
                 .applyAsync(callback);
     }
 
     private void applyCompressionToJpeg(@NonNull PhotoEdit.PhotoEditCallback callback) {
         LOG.info("Compressing the jpeg to quality {}", JPEG_COMPRESSION_QUALITY_FOR_UPLOAD);
         mPhoto.edit()
-                .compress(JPEG_COMPRESSION_QUALITY_FOR_UPLOAD)
+                .compressBy(JPEG_COMPRESSION_QUALITY_FOR_UPLOAD)
                 .applyAsync(callback);
     }
 


### PR DESCRIPTION
In order to detect images which were uploaded and then uploaded again due to rotation we add the rotation delta to the rotated image. Rotation delta is the degrees rotated compared to the image from the camera.

This PR also contains a fix regarding generating the UUID for the User Comment: The bug was that a new UUID was generated whenever a Photo instance was created from a Document.

### How to test
Run the tests in the `ginivision/src/androidTest` folder. Specifically the following tests are relevant: 
* `net.gini.android.vision.internal.camera.photo.PhotoTest`
* `net.gini.android.vision.review.ReviewScreenTest`

### Merging
Nothing special.

### Ticket 
No ticket.
