### PR TITLE
Bugfix photo rotation

### DIFF
--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoEditTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoEditTest.java
@@ -1,0 +1,68 @@
+package net.gini.android.vision.internal.camera.photo;
+
+import static com.google.common.truth.Truth.assertAbout;
+
+import static net.gini.android.vision.test.Helpers.getTestJpeg;
+import static net.gini.android.vision.test.PhotoSubject.photo;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.support.annotation.NonNull;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(AndroidJUnit4.class)
+public class PhotoEditTest {
+
+    @Test
+    public void should_allowAddingModifications_afterAsyncApply() throws Exception {
+        // Given
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Photo photo = getPhoto();
+        final PhotoEdit photoEdit = new PhotoEdit(photo);
+
+        // When
+        // Start async rotations to 90 degrees
+        for (int i = 0; i < 20; i++) {
+            photoEdit.rotateTo(90);
+        }
+        photoEdit.applyAsync(new PhotoEdit.PhotoEditCallback() {
+            @Override
+            public void onDone(@NonNull final Photo photo) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailed() {
+            }
+        });
+        // Add rotations until the async apply completes
+        final Handler handler = new Handler(Looper.getMainLooper());
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                photoEdit.rotateTo(180);
+                if (latch.getCount() == 1) {
+                    handler.post(this);
+                }
+            }
+        });
+
+        // Then
+        latch.await(500, TimeUnit.MILLISECONDS);
+        // Rotation should be at 90 degrees
+        assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(90);
+    }
+
+    private Photo getPhoto() throws IOException {
+        final byte[] jpeg = getTestJpeg();
+        return Photo.fromJpeg(jpeg, 0);
+    }
+
+}

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoEditTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoEditTest.java
@@ -1,6 +1,7 @@
 package net.gini.android.vision.internal.camera.photo;
 
 import static com.google.common.truth.Truth.assertAbout;
+import static com.google.common.truth.Truth.assertThat;
 
 import static net.gini.android.vision.test.Helpers.getTestJpeg;
 import static net.gini.android.vision.test.PhotoSubject.photo;
@@ -63,6 +64,22 @@ public class PhotoEditTest {
     private Photo getPhoto() throws IOException {
         final byte[] jpeg = getTestJpeg();
         return Photo.fromJpeg(jpeg, 0);
+    }
+
+    @Test
+    public void should_allowOnlyOne_compressionModifier() throws Exception {
+        // Given
+        final Photo photo = getPhoto();
+        final PhotoEdit photoEdit = new PhotoEdit(photo);
+        // When
+        photoEdit.compressBy(30)
+                .compressBy(50)
+                .compressBy(100);
+        // Then
+        assertThat(photoEdit.mPhotoModifiers).hasSize(1);
+        assertThat(((PhotoCompressionModifier) photoEdit.mPhotoModifiers.get(0))
+                .getQuality()).isEqualTo(100);
+
     }
 
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
@@ -126,13 +126,13 @@ public class Photo implements Parcelable {
     }
 
     @VisibleForTesting
-    int getRotationDelta() {
+    synchronized int getRotationDelta() {
         return mRotationDelta;
     }
 
     @VisibleForTesting
     @NonNull
-    String getContentId() {
+    synchronized String getContentId() {
         return mContentId;
     }
 
@@ -147,7 +147,7 @@ public class Photo implements Parcelable {
         }
     }
 
-    public boolean updateExif() {
+    synchronized boolean updateExif() {
         if (mJpeg == null) {
             return false;
         }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
@@ -32,8 +32,6 @@ public class Photo implements Parcelable {
     private String mContentId = "";
     private int mRotationDelta = 0;
 
-    private PhotoEdit mEditor;
-
     public static Photo fromJpeg(@NonNull final byte[] jpeg, final int orientation) {
         return new Photo(jpeg, orientation);
     }
@@ -182,10 +180,7 @@ public class Photo implements Parcelable {
     }
 
     public synchronized PhotoEdit edit() {
-        if (mEditor == null) {
-            mEditor = new PhotoEdit(this);
-        }
-        return mEditor;
+        return new PhotoEdit(this);
     }
 
     public synchronized void saveJpegToFile(File file) {
@@ -295,9 +290,7 @@ public class Photo implements Parcelable {
                 : photo.mRequiredTags != null) {
             return false;
         }
-        if (mContentId != null ? !mContentId.equals(photo.mContentId) : photo.mContentId != null) return false;
-        return mEditor != null ? mEditor.equals(photo.mEditor) : photo.mEditor == null;
-
+        return mContentId != null ? mContentId.equals(photo.mContentId) : photo.mContentId == null;
     }
 
     @Override
@@ -308,7 +301,6 @@ public class Photo implements Parcelable {
         result = 31 * result + mRotationForDisplay;
         result = 31 * result + (mContentId != null ? mContentId.hashCode() : 0);
         result = 31 * result + mRotationDelta;
-        result = 31 * result + (mEditor != null ? mEditor.hashCode() : 0);
         return result;
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoCompressionModifier.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoCompressionModifier.java
@@ -3,6 +3,7 @@ package net.gini.android.vision.internal.camera.photo;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 
 import java.io.ByteArrayOutputStream;
 
@@ -17,6 +18,11 @@ class PhotoCompressionModifier implements PhotoModifier {
     PhotoCompressionModifier(final int quality, @NonNull final Photo photo) {
         mQuality = quality;
         mPhoto = photo;
+    }
+
+    @VisibleForTesting
+    int getQuality() {
+        return mQuality;
     }
 
     @Override

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoCompressionModifier.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoCompressionModifier.java
@@ -24,16 +24,18 @@ class PhotoCompressionModifier implements PhotoModifier {
         if (mPhoto.getJpeg() == null) {
             return;
         }
+        synchronized (mPhoto) {
+            final Bitmap originalImage = BitmapFactory.decodeByteArray(mPhoto.getJpeg(), 0,
+                    mPhoto.getJpeg().length);
 
-        final Bitmap originalImage = BitmapFactory.decodeByteArray(mPhoto.getJpeg(), 0, mPhoto.getJpeg().length);
+            final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            originalImage.compress(Bitmap.CompressFormat.JPEG, mQuality, byteArrayOutputStream);
 
-        final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        originalImage.compress(Bitmap.CompressFormat.JPEG, mQuality, byteArrayOutputStream);
+            final byte[] jpeg = byteArrayOutputStream.toByteArray();
+            mPhoto.setJpeg(jpeg);
+            mPhoto.updateBitmapPreview();
 
-        final byte[] jpeg = byteArrayOutputStream.toByteArray();
-        mPhoto.setJpeg(jpeg);
-        mPhoto.updateBitmapPreview();
-
-        mPhoto.updateExif();
+            mPhoto.updateExif();
+        }
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoEdit.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoEdit.java
@@ -3,6 +3,7 @@ package net.gini.android.vision.internal.camera.photo;
 import android.os.AsyncTask;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,7 +14,8 @@ import java.util.List;
 public class PhotoEdit {
 
     private final Photo mPhoto;
-    private List<PhotoModifier> mPhotoModifiers;
+    @VisibleForTesting
+    List<PhotoModifier> mPhotoModifiers;
 
     PhotoEdit(@NonNull Photo photo) {
         mPhoto = photo;
@@ -35,9 +37,20 @@ public class PhotoEdit {
 
     @NonNull
     public PhotoEdit compressBy(int quality) {
+        removeCompressionModifier();
         final PhotoCompressionModifier compressionModifier = new PhotoCompressionModifier(quality, mPhoto);
         getPhotoModifiers().add(compressionModifier);
         return this;
+    }
+
+    private void removeCompressionModifier() {
+        final List<PhotoModifier> photoModifiers = getPhotoModifiers();
+        for (final PhotoModifier photoModifier : photoModifiers) {
+            if (photoModifier.getClass() == PhotoCompressionModifier.class) {
+                photoModifiers.remove(photoModifier);
+                return;
+            }
+        }
     }
 
     public void apply() {
@@ -51,7 +64,6 @@ public class PhotoEdit {
         async.setCallback(callback);
         async.execute((Void[]) null);
     }
-
 
     private static void applyChanges(@Nullable final List<PhotoModifier> modifiers) {
         if (modifiers == null) {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoEdit.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoEdit.java
@@ -13,55 +13,50 @@ import java.util.List;
 public class PhotoEdit {
 
     private final Photo mPhoto;
-    private final List<PhotoModifier> mPhotoModifiers;
+    private List<PhotoModifier> mPhotoModifiers;
 
     PhotoEdit(@NonNull Photo photo) {
         mPhoto = photo;
-        mPhotoModifiers = new ArrayList<>();
+    }
+
+    private List<PhotoModifier> getPhotoModifiers() {
+        if (mPhotoModifiers == null) {
+            mPhotoModifiers = new ArrayList<>();
+        }
+        return mPhotoModifiers;
     }
 
     @NonNull
     public PhotoEdit rotateTo(int degrees) {
         final PhotoRotationModifier rotationModifier = new PhotoRotationModifier(degrees, mPhoto);
-        mPhotoModifiers.add(rotationModifier);
+        getPhotoModifiers().add(rotationModifier);
         return this;
     }
 
     @NonNull
     public PhotoEdit compressBy(int quality) {
         final PhotoCompressionModifier compressionModifier = new PhotoCompressionModifier(quality, mPhoto);
-        mPhotoModifiers.add(compressionModifier);
+        getPhotoModifiers().add(compressionModifier);
         return this;
     }
 
     public void apply() {
         applyChanges(mPhotoModifiers);
-        clearModifiers();
+        mPhotoModifiers = null;
     }
 
     public void applyAsync(@NonNull final PhotoEditCallback callback) {
         final EditAsync async = new EditAsync(mPhoto, mPhotoModifiers);
-        async.setCallback(new PhotoEditCallback() {
-            @Override
-            public void onDone(@NonNull Photo photo) {
-                callback.onDone(photo);
-                clearModifiers();
-            }
-
-            @Override
-            public void onFailed() {
-                callback.onFailed();
-                clearModifiers();
-            }
-        });
+        mPhotoModifiers = null;
+        async.setCallback(callback);
         async.execute((Void[]) null);
     }
 
-    private void clearModifiers() {
-        mPhotoModifiers.clear();
-    }
 
-    private static void applyChanges(@NonNull final List<PhotoModifier> modifiers) {
+    private static void applyChanges(@Nullable final List<PhotoModifier> modifiers) {
+        if (modifiers == null) {
+            return;
+        }
         for (final PhotoModifier modifier : modifiers) {
             modifier.modify();
         }
@@ -83,7 +78,7 @@ public class PhotoEdit {
         private final List<PhotoModifier> mPhotoModifiers;
         private PhotoEditCallback mCallback = NO_OP_CALLBACK;
 
-        EditAsync(@NonNull final Photo photo, @NonNull final List<PhotoModifier> photoModifiers) {
+        EditAsync(@NonNull final Photo photo, @Nullable final List<PhotoModifier> photoModifiers) {
             mPhoto = photo;
             mPhotoModifiers = photoModifiers;
         }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoRotationModifier.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoRotationModifier.java
@@ -20,10 +20,11 @@ class PhotoRotationModifier implements PhotoModifier {
         if (mPhoto.getJpeg() == null) {
             return;
         }
+        synchronized (mPhoto) {
+            mPhoto.updateRotationDeltaBy(mRotationDegrees - mPhoto.getRotationForDisplay());
+            mPhoto.setRotationForDisplay(mRotationDegrees);
 
-        mPhoto.updateRotationDeltaBy(mRotationDegrees - mPhoto.getRotationForDisplay());
-        mPhoto.setRotationForDisplay(mRotationDegrees);
-
-        mPhoto.updateExif();
+            mPhoto.updateExif();
+        }
     }
 }


### PR DESCRIPTION
Photo rotation could throw a ConcurrentModificationException:
```
java.lang.RuntimeException: An error occured while executing doInBackground()
                                                       at android.os.AsyncTask$3.done(AsyncTask.java:304)
                                                       at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:355)
                                                       at java.util.concurrent.FutureTask.setException(FutureTask.java:222)
                                                       at java.util.concurrent.FutureTask.run(FutureTask.java:242)
                                                       at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:231)
                                                       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
                                                       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
                                                       at java.lang.Thread.run(Thread.java:818)
                                                    Caused by: java.util.ConcurrentModificationException
                                                       at java.util.ArrayList$ArrayListIterator.next(ArrayList.java:573)
                                                       at net.gini.android.vision.internal.camera.photo.PhotoEdit.applyChanges(PhotoEdit.java:65)
                                                       at net.gini.android.vision.internal.camera.photo.PhotoEdit.access$100(PhotoEdit.java:13)
                                                       at net.gini.android.vision.internal.camera.photo.PhotoEdit$EditAsync.doInBackground(PhotoEdit.java:101)
                                                       at net.gini.android.vision.internal.camera.photo.PhotoEdit$EditAsync.doInBackground(PhotoEdit.java:70)
                                                       at android.os.AsyncTask$2.call(AsyncTask.java:292)
                                                       at java.util.concurrent.FutureTask.run(FutureTask.java:237)
```
The cause was that the mPhotoModifiers list was shared with AsyncTasks. Fixed it by setting the reference to the list to null after passing it to the AsyncTask. A new list will be created if it's null each time a modification is added.

### How to test
Run `net.gini.android.vision.internal.camera.photo.PhotoEditTest#should_allowAddingModifications_afterAsyncApply()`.

