### PR TITLE
Added device orientation and device type to the exif user comment

### DIFF
--- a/ginivision/src/androidTest/java/net/gini/android/vision/analysis/AnalysisScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/analysis/AnalysisScreenTest.java
@@ -77,7 +77,7 @@ public class AnalysisScreenTest {
 
         assertThat(activity.analyzeDocument).isNotNull();
 
-        assertAbout(document()).that(activity.analyzeDocument).isEqualToDocument(Document.fromPhoto(Photo.fromJpeg(TEST_JPEG, 0)));
+        assertAbout(document()).that(activity.analyzeDocument).isEqualToDocument(Document.fromPhoto(Photo.fromJpeg(TEST_JPEG, 0, "portrait", "phone")));
     }
 
     @Test
@@ -314,7 +314,8 @@ public class AnalysisScreenTest {
 
         assertThat(activity.analyzeDocument).isNotNull();
 
-        assertAbout(document()).that(activity.analyzeDocument).isEqualToDocument(Document.fromPhoto(Photo.fromJpeg(TEST_JPEG, 0)));
+        assertAbout(document()).that(activity.analyzeDocument)
+                .isEqualToDocument(Document.fromPhoto(Photo.fromJpeg(TEST_JPEG, 0, "portrait", "phone")));
     }
 
     @Test
@@ -338,7 +339,7 @@ public class AnalysisScreenTest {
 
     private AnalysisActivityTestSpy startAnalysisActivity(byte[] jpeg, int orientation) {
         Intent intent = getAnalysisActivityIntent();
-        intent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, Document.fromPhoto(Photo.fromJpeg(jpeg, orientation)));
+        intent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, Document.fromPhoto(Photo.fromJpeg(jpeg, orientation, "portrait", "phone")));
         return mActivityTestRule.launchActivity(intent);
     }
 
@@ -348,7 +349,7 @@ public class AnalysisScreenTest {
 
     private Intent getAnalysisActivityIntentWithDocument(byte[] jpeg, int orientation) {
         Intent intent = new Intent(InstrumentationRegistry.getTargetContext(), AnalysisActivityTestSpy.class);
-        intent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, createDocument(jpeg, orientation));
+        intent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, createDocument(jpeg, orientation, "portrait", "phone"));
         return intent;
     }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
@@ -325,7 +325,7 @@ public class CameraScreenTest {
         // Prevent really starting the ReviewActivity
         doNothing().when(cameraActivitySpy).startActivityForResult(any(Intent.class), anyInt());
         // Fake taking of a picture, which will cause the ReviewActivity to be launched
-        cameraActivitySpy.onDocumentAvailable(Document.fromPhoto(Photo.fromJpeg(new byte[]{}, 0)));
+        cameraActivitySpy.onDocumentAvailable(Document.fromPhoto(Photo.fromJpeg(new byte[]{}, 0, "portrait", "phone")));
 
         // Check that the extra was passed on to the ReviewActivity
         verify(cameraActivitySpy).startActivityForResult(argThat(

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoEditTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoEditTest.java
@@ -63,7 +63,7 @@ public class PhotoEditTest {
 
     private Photo getPhoto() throws IOException {
         final byte[] jpeg = getTestJpeg();
-        return Photo.fromJpeg(jpeg, 0);
+        return Photo.fromJpeg(jpeg, 0, "portrait", "phone");
     }
 
     @Test

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoTest.java
@@ -37,7 +37,7 @@ public class PhotoTest {
     @Test
     public void should_supportParceling() {
         // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         // When
         Photo photoFromParcel = doParcelingRoundTrip(photo, Photo.CREATOR);
         // Then
@@ -47,7 +47,7 @@ public class PhotoTest {
     @Test
     public void should_keepUserComment_whenCreating_fromDocument() {
         // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         // When
         Photo fromDocument = Photo.fromDocument(Document.fromPhoto(photo));
         // Then
@@ -57,7 +57,7 @@ public class PhotoTest {
     @Test
     public void should_setContentIdFromUserComment_whenCreating_fromDocument() {
         // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         // When
         Photo fromDocument = Photo.fromDocument(Document.fromPhoto(photo));
         // Then
@@ -67,7 +67,7 @@ public class PhotoTest {
     @Test
     public void should_setRotationDeltafromUserComment_whenCreating_fromDocument() {
         // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         // When
         photo.edit().rotateTo(90).apply();
         Photo fromDocument = Photo.fromDocument(Document.fromPhoto(photo));
@@ -78,7 +78,7 @@ public class PhotoTest {
     @Test
     public void should_generateUUID_forContentId_whenCreated() {
         // When
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         // Then
         assertThat(UUID.fromString(photo.getContentId())).isNotNull();
     }
@@ -86,8 +86,8 @@ public class PhotoTest {
     @Test
     public void should_generate_uniqueContentIds_forEachInstance() {
         // Given
-        Photo photo1 = Photo.fromJpeg(TEST_JPEG, 0);
-        Photo photo2 = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo1 = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
+        Photo photo2 = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         // Then
         assertThat(photo1.getContentId()).isNotEqualTo(photo2.getContentId());
     }
@@ -95,7 +95,7 @@ public class PhotoTest {
     @Test
     public void should_addContentId_toExifUserComment() {
         // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         // Then
         assertAbout(photo()).that(photo).hasContentIdInUserComment(photo.getContentId());
     }
@@ -103,7 +103,7 @@ public class PhotoTest {
     @Test
     public void should_keepContentId_afterRotation() {
         // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         String contentId = photo.getContentId();
         // When
         photo.edit().rotateTo(90).apply();
@@ -114,7 +114,7 @@ public class PhotoTest {
     @Test
     public void should_keepContentId_afterCompression() {
         // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         String contentId = photo.getContentId();
         // When
         photo.edit().compressBy(10).apply();
@@ -125,7 +125,7 @@ public class PhotoTest {
     @Test
     public void should_initRotationDelta_whenCreated() {
         // When
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         // Then
         assertThat(photo.getRotationDelta()).isEqualTo(0);
     }
@@ -133,7 +133,7 @@ public class PhotoTest {
     @Test
     public void should_initRotationDelta_whenCreated_withNonZeroOrientation() {
         // When
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 90);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 90, "portrait", "photo");
         // Then
         assertThat(photo.getRotationDelta()).isEqualTo(0);
     }
@@ -141,7 +141,7 @@ public class PhotoTest {
     @Test
     public void should_addRotationDelta_toExifUserComment() {
         // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         // Then
         assertAbout(photo()).that(photo).hasRotationDeltaInUserComment(0);
     }
@@ -149,7 +149,7 @@ public class PhotoTest {
     @Test
     public void should_updateRotationDelta_afterCWRotation() {
         // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         // When
         photo.edit().rotateTo(90).apply();
         // Then
@@ -159,7 +159,7 @@ public class PhotoTest {
     @Test
     public void should_updateRotationDelta_afterCCWRotation() {
         // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         // When
         photo.edit().rotateTo(-90).apply();
         // Then
@@ -169,7 +169,7 @@ public class PhotoTest {
     @Test
     public void should_normalizeRotationDelta_forCWRotation() {
         // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         // When
         photo.edit().rotateTo(450).apply();
         // Then
@@ -179,7 +179,7 @@ public class PhotoTest {
     @Test
     public void should_normalizeRotationDelta_forCCWRotation() {
         // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 0);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 0, "portrait", "photo");
         // When
         photo.edit().rotateTo(-270).apply();
         // Then
@@ -189,7 +189,7 @@ public class PhotoTest {
     @Test
     public void should_keepRotationDelta_afterCompression() {
         // Given
-        Photo photo = Photo.fromJpeg(TEST_JPEG, 90);
+        Photo photo = Photo.fromJpeg(TEST_JPEG, 90, "portrait", "photo");
         // When
         photo.edit().compressBy(50).apply();
         // Then

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/UserCommentBuilderTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/UserCommentBuilderTest.java
@@ -1,5 +1,7 @@
 package net.gini.android.vision.internal.camera.photo;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import android.support.annotation.NonNull;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -8,8 +10,6 @@ import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Created by aszotyori on 13/03/2017.
@@ -26,14 +26,17 @@ public class UserCommentBuilderTest {
         builder.setRotationDelta(90)
                 .setContentId("asdasd-assd-ssdsa-sdsdss")
                 .setAddMake(true)
-                .setAddModel(true);
+                .setAddModel(true)
+                .setDeviceOrientation("landscape")
+                .setDeviceType("tablet");
         String userComment = builder.build();
         // Then
         List<String> keys = getListOfKeys(userComment);
         assertThat(keys).containsExactly(Exif.USER_COMMENT_MAKE, Exif.USER_COMMENT_MODEL,
                 Exif.USER_COMMENT_PLATFORM, Exif.USER_COMMENT_OS_VERSION,
                 Exif.USER_COMMENT_GINI_VISION_VERSION, Exif.USER_COMMENT_CONTENT_ID,
-                Exif.USER_COMMENT_ROTATION_DELTA).inOrder();
+                Exif.USER_COMMENT_ROTATION_DELTA, Exif.USER_COMMENT_DEVICE_ORIENTATION,
+                Exif.USER_COMMENT_DEVICE_TYPE).inOrder();
     }
 
     @NonNull

--- a/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/review/ReviewScreenTest.java
@@ -106,7 +106,7 @@ public class ReviewScreenTest {
 
     private Intent getReviewActivityIntent(byte[] jpeg, int orientation) {
         Intent intent = new Intent(InstrumentationRegistry.getTargetContext(), ReviewActivityTestSpy.class);
-        intent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, createDocument(jpeg, orientation));
+        intent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, createDocument(jpeg, orientation, "portrait", "phone"));
         intent.putExtra(ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY, new Intent(InstrumentationRegistry.getTargetContext(), AnalysisActivityTestSpy.class));
         return intent;
     }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/test/Helpers.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/test/Helpers.java
@@ -68,8 +68,9 @@ public class Helpers {
         return bytes;
     }
 
-    public static Document createDocument(byte[] jpeg, int orientation) {
-        return Document.fromPhoto(Photo.fromJpeg(jpeg, orientation));
+    public static Document createDocument(byte[] jpeg, int orientation, String deviceOrientation,
+            String deviceType) {
+        return Document.fromPhoto(Photo.fromJpeg(jpeg, orientation, deviceOrientation, deviceType));
     }
 
     public static boolean isTablet() {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
@@ -23,6 +23,7 @@ import android.view.View;
 
 import net.gini.android.vision.internal.camera.photo.Photo;
 import net.gini.android.vision.internal.camera.photo.Size;
+import net.gini.android.vision.internal.util.ContextHelper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -352,7 +353,10 @@ public class CameraController implements CameraInterface {
                     @Override
                     public void onPictureTaken(final byte[] bytes, Camera camera) {
                         mTakingPictureFuture.set(null);
-                        final Photo photo = Photo.fromJpeg(bytes, getDisplayOrientationForCamera(mActivity));
+                        final Photo photo = Photo.fromJpeg(bytes,
+                                getDisplayOrientationForCamera(mActivity),
+                                getDeviceOrientation(mActivity),
+                                getDeviceType(mActivity));
                         LOG.info("Picture taken");
                         pictureTaken.complete(photo);
                     }
@@ -495,6 +499,14 @@ public class CameraController implements CameraInterface {
         }
 
         return result;
+    }
+
+    private String getDeviceOrientation(Activity activity) {
+        return ContextHelper.isPortraitOrientation(activity) ? "portrait" : "landscape";
+    }
+
+    private String getDeviceType(Activity activity) {
+        return ContextHelper.isTablet(activity) ? "tablet" : "phone";
     }
 
     @Nullable

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
@@ -44,6 +44,8 @@ class Exif {
     static final String USER_COMMENT_GINI_VISION_VERSION = "GiniVisionVer";
     static final String USER_COMMENT_CONTENT_ID = "ContentId";
     static final String USER_COMMENT_ROTATION_DELTA = "RotDeltaDeg";
+    static final String USER_COMMENT_DEVICE_ORIENTATION = "DeviceOrientation";
+    static final String USER_COMMENT_DEVICE_TYPE = "DeviceType";
 
     private final TiffOutputSet mTiffOutputSet;
 
@@ -331,6 +333,8 @@ class Exif {
         private boolean mAddModel;
         private String mContentId;
         private int mRotationDelta;
+        private String mDeviceOrientation;
+        private String mDeviceType;
 
         private UserCommentBuilder() {
 
@@ -353,6 +357,16 @@ class Exif {
 
         UserCommentBuilder setRotationDelta(final int rotationDelta) {
             mRotationDelta = rotationDelta;
+            return this;
+        }
+
+        UserCommentBuilder setDeviceOrientation(final String orientation) {
+            mDeviceOrientation = orientation;
+            return this;
+        }
+
+        UserCommentBuilder setDeviceType(final String type) {
+            mDeviceType = type;
             return this;
         }
 
@@ -391,6 +405,10 @@ class Exif {
             map.put(USER_COMMENT_CONTENT_ID, mContentId);
             // Rotation Delta
             map.put(USER_COMMENT_ROTATION_DELTA, String.valueOf(mRotationDelta));
+            // Device Orientation
+            map.put(USER_COMMENT_DEVICE_ORIENTATION, mDeviceOrientation);
+            // Device Type
+            map.put(USER_COMMENT_DEVICE_TYPE, mDeviceType);
             return map;
         }
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
@@ -31,20 +31,26 @@ public class Photo implements Parcelable {
     private int mRotationForDisplay = 0;
     private String mContentId = "";
     private int mRotationDelta = 0;
+    private String mDeviceOrientation;
+    private String mDeviceType;
 
-    public static Photo fromJpeg(@NonNull final byte[] jpeg, final int orientation) {
-        return new Photo(jpeg, orientation);
+    public static Photo fromJpeg(@NonNull final byte[] jpeg, final int orientation,
+            final String deviceOrientation, final String deviceType) {
+        return new Photo(jpeg, orientation, deviceOrientation, deviceType);
     }
 
     public static Photo fromDocument(@NonNull final Document document) {
         return new Photo(document);
     }
 
-    private Photo(@NonNull byte[] jpeg, int orientation) {
+    private Photo(@NonNull byte[] jpeg, int orientation,
+            final String deviceOrientation, final String deviceType) {
         mJpeg = jpeg;
         mRotationForDisplay = orientation;
         mBitmapPreview = createPreview();
         mContentId = generateUUID();
+        mDeviceOrientation = deviceOrientation;
+        mDeviceType = deviceType;
         readRequiredTags();
         updateExif();
     }
@@ -74,6 +80,12 @@ public class Photo implements Parcelable {
             mRotationDelta = Integer.parseInt(
                     exifReader.getValueForKeyFromUserComment(Exif.USER_COMMENT_ROTATION_DELTA,
                             userComment));
+            mDeviceOrientation =
+                    exifReader.getValueForKeyFromUserComment(Exif.USER_COMMENT_DEVICE_ORIENTATION,
+                            userComment);
+            mDeviceType =
+                    exifReader.getValueForKeyFromUserComment(Exif.USER_COMMENT_DEVICE_TYPE,
+                            userComment);
         } catch (ExifReaderException | NumberFormatException e) {
             // TODO log
         }
@@ -166,6 +178,8 @@ public class Photo implements Parcelable {
                     .setAddModel(addModel)
                     .setContentId(mContentId)
                     .setRotationDelta(mRotationDelta)
+                    .setDeviceType(mDeviceType)
+                    .setDeviceOrientation(mDeviceOrientation)
                     .build();
 
             exifBuilder.setUserComment(userComment);
@@ -241,6 +255,8 @@ public class Photo implements Parcelable {
         dest.writeInt(mRotationForDisplay);
         dest.writeString(mContentId);
         dest.writeInt(mRotationDelta);
+        dest.writeString(mDeviceOrientation);
+        dest.writeString(mDeviceType);
     }
 
     public static final Parcelable.Creator<Photo> CREATOR = new Parcelable.Creator<Photo>() {
@@ -269,6 +285,9 @@ public class Photo implements Parcelable {
         mRotationForDisplay = in.readInt();
         mContentId = in.readString();
         mRotationDelta = in.readInt();
+        mDeviceOrientation = in.readString();
+        mDeviceType = in.readString();
+
         readRequiredTags();
     }
 
@@ -290,7 +309,16 @@ public class Photo implements Parcelable {
                 : photo.mRequiredTags != null) {
             return false;
         }
-        return mContentId != null ? mContentId.equals(photo.mContentId) : photo.mContentId == null;
+        if (mContentId != null ? !mContentId.equals(photo.mContentId) : photo.mContentId != null) {
+            return false;
+        }
+        if (mDeviceOrientation != null ? !mDeviceOrientation.equals(photo.mDeviceOrientation)
+                : photo.mDeviceOrientation != null) {
+            return false;
+        }
+        return mDeviceType != null ? mDeviceType.equals(photo.mDeviceType)
+                : photo.mDeviceType == null;
+
     }
 
     @Override
@@ -301,6 +329,8 @@ public class Photo implements Parcelable {
         result = 31 * result + mRotationForDisplay;
         result = 31 * result + (mContentId != null ? mContentId.hashCode() : 0);
         result = 31 * result + mRotationDelta;
+        result = 31 * result + (mDeviceOrientation != null ? mDeviceOrientation.hashCode() : 0);
+        result = 31 * result + (mDeviceType != null ? mDeviceType.hashCode() : 0);
         return result;
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/util/ContextHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/util/ContextHelper.java
@@ -24,6 +24,13 @@ public final class ContextHelper {
         return context.getResources().getBoolean(R.bool.gv_is_tablet);
     }
 
+    /**
+     * @exclude
+     */
+    public static boolean isPortraitOrientation(@NonNull final Context context) {
+        return context.getResources().getBoolean(R.bool.gv_is_portrait);
+    }
+
     private ContextHelper() {
     }
 }

--- a/ginivision/src/main/res/values-land/device_orientation.xml
+++ b/ginivision/src/main/res/values-land/device_orientation.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="gv_is_portrait">false</bool>
+</resources>

--- a/ginivision/src/main/res/values/device_orientation.xml
+++ b/ginivision/src/main/res/values/device_orientation.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="gv_is_portrait">true</bool>
+</resources>


### PR DESCRIPTION
Device orientation landscape or portrait and device type tablet or phone are added to the user comment exif field.

### How to test
Run the screen or component api example apps and check the generated user comment string.

### Merging
Automatic.

### Ticket 
Issue #55 
