### PR TITLE
Feature update support libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ ext {
     compileSdkVersion = 26
     buildToolsVersion = "26.0.1"
     minSdkVersion = 14
-    targetSdkVersion = 25
+    targetSdkVersion = 26
     versionCode = libVersionCode
     versionName = libVersionName
 }

--- a/build.gradle
+++ b/build.gradle
@@ -43,19 +43,24 @@ task printLibraryVersion {
 
 ext {
     compileSdkVersion = 26
-    buildToolsVersion = "26.0.1"
+    buildToolsVersion = '26.0.1'
     minSdkVersion = 14
     targetSdkVersion = 26
     versionCode = libVersionCode
     versionName = libVersionName
 }
 
+def supportLibVersion = '26.0.1'
+def mockitoVersion = '2.6.3'
+def testSupportLibVersion = '1.0.1'
+def espressoVersion = '3.0.1'
+
 ext.deps = [
         // Android
-        appCompatv7: 'com.android.support:appcompat-v7:26.0.1',
-        supportv4: 'com.android.support:support-v4:26.0.1',
-        supportv13: 'com.android.support:support-v13:26.0.1',
-        supportDesign: 'com.android.support:design:26.0.1',
+        appCompatv7: "com.android.support:appcompat-v7:$supportLibVersion",
+        supportv4: "com.android.support:support-v4:$supportLibVersion",
+        supportv13: "com.android.support:support-v13:$supportLibVersion",
+        supportDesign: "com.android.support:design:$supportLibVersion",
         // Exif editing library. IMPORTANT: notify backend when the version is changed
         commonsImaging: 'org.apache.commons:commons-imaging:1.0.0gini',
         // Logging
@@ -65,12 +70,12 @@ ext.deps = [
         // Test dependencies
         junit: 'junit:junit:4.12',
         truth: 'com.google.truth:truth:0.28',
-        mockito: 'org.mockito:mockito-core:2.6.3',
-        mockitoAndroid: 'org.mockito:mockito-android:2.6.3',
-        supportTestRunner: 'com.android.support.test:runner:1.0.1',
-        supportTestRules: 'com.android.support.test:rules:1.0.1',
-        supportTestEspressoCore: 'com.android.support.test.espresso:espresso-core:3.0.1',
-        supportTestEspressoIntents: 'com.android.support.test.espresso:espresso-intents:3.0.1',
+        mockito: "org.mockito:mockito-core:$mockitoVersion",
+        mockitoAndroid: "org.mockito:mockito-android:$mockitoVersion",
+        supportTestRunner: "com.android.support.test:runner:$testSupportLibVersion",
+        supportTestRules: "com.android.support.test:rules:$testSupportLibVersion",
+        supportTestEspressoCore: "com.android.support.test.espresso:espresso-core:$espressoVersion",
+        supportTestEspressoIntents: "com.android.support.test.espresso:espresso-intents:$espressoVersion",
         supportTestUiAutomator: 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2',
         supportMultidex: 'com.android.support:multidex:1.0.1',
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,9 @@ allprojects {
     repositories {
         jcenter()
         maven {
+            url 'https://maven.google.com'
+        }
+        maven {
             // For Commons Imaging
             url 'https://repo.gini.net/nexus/content/repositories/open'
         }
@@ -49,10 +52,10 @@ ext {
 
 ext.deps = [
         // Android
-        appCompatv7: 'com.android.support:appcompat-v7:25.3.0',
-        supportv4: 'com.android.support:support-v4:25.3.0',
-        supportv13: 'com.android.support:support-v13:25.3.0',
-        supportDesign: 'com.android.support:design:25.3.0',
+        appCompatv7: 'com.android.support:appcompat-v7:26.0.1',
+        supportv4: 'com.android.support:support-v4:26.0.1',
+        supportv13: 'com.android.support:support-v13:26.0.1',
+        supportDesign: 'com.android.support:design:26.0.1',
         // Exif editing library. IMPORTANT: notify backend when the version is changed
         commonsImaging: 'org.apache.commons:commons-imaging:1.0.0gini',
         // Logging
@@ -62,14 +65,12 @@ ext.deps = [
         // Test dependencies
         junit: 'junit:junit:4.12',
         truth: 'com.google.truth:truth:0.28',
-        mockito: 'org.mockito:mockito-core:1.10.19',
-        supportTestRunner: 'com.android.support.test:runner:0.5',
-        supportTestRules: 'com.android.support.test:rules:0.5',
-        supportTestEspressoCore: 'com.android.support.test.espresso:espresso-core:2.2.2',
-        supportTestEspressoIntents: 'com.android.support.test.espresso:espresso-intents:2.2.2',
+        mockito: 'org.mockito:mockito-core:2.6.3',
+        mockitoAndroid: 'org.mockito:mockito-android:2.6.3',
+        supportTestRunner: 'com.android.support.test:runner:1.0.1',
+        supportTestRules: 'com.android.support.test:rules:1.0.1',
+        supportTestEspressoCore: 'com.android.support.test.espresso:espresso-core:3.0.1',
+        supportTestEspressoIntents: 'com.android.support.test.espresso:espresso-intents:3.0.1',
         supportTestUiAutomator: 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2',
-        dexmaker: 'com.crittercism.dexmaker:dexmaker:1.4',
-        dexmakerDx: 'com.crittercism.dexmaker:dexmaker-dx:1.4',
-        dexmakerMockito: 'com.crittercism.dexmaker:dexmaker-mockito:1.4',
         supportMultidex: 'com.android.support:multidex:1.0.1',
 ]

--- a/componentapiexample/src/main/res/values/styles.xml
+++ b/componentapiexample/src/main/res/values/styles.xml
@@ -19,21 +19,21 @@
     <!--<style name="GiniVisionTheme.Camera.Error.NoPermission.TextStyle" parent="Root.GiniVisionTheme.Camera.Error.NoPermission.TextStyle">-->
     <!--<item name="android:textStyle">bold</item>-->
     <!--<item name="android:textSize">30sp</item>-->
-    <!--<item name="font">Cave-Story.ttf</item>-->
+    <!--<item name="gvCustomFont">Cave-Story.ttf</item>-->
     <!--</style>-->
 
     <!-- Example of customizing the Camera Screen no camera permission error button's text style -->
     <!--<style name="GiniVisionTheme.Camera.Error.NoPermission.Button.TextStyle" parent="Root.GiniVisionTheme.Camera.Error.NoPermission.Button.TextStyle">-->
     <!--<item name="android:textStyle">italic</item>-->
     <!--<item name="android:textSize">30sp</item>-->
-    <!--<item name="font">Cave-Story.ttf</item>-->
+    <!--<item name="gvCustomFont">Cave-Story.ttf</item>-->
     <!--</style>-->
 
     <!-- Example of customizing the Review Screen bottom panel's text style -->
     <!--<style name="GiniVisionTheme.Review.BottomPanel.TextStyle" parent="Root.GiniVisionTheme.Review.BottomPanel.TextStyle">-->
     <!--<item name="android:textStyle">bold</item>-->
     <!--<item name="android:textSize">16sp</item>-->
-    <!--<item name="font">fonts/Warenhaus-Standard.ttf</item>-->
+    <!--<item name="gvCustomFont">fonts/Warenhaus-Standard.ttf</item>-->
     <!--</style>-->
 
     <!-- Example of customizing the Onboarding Screen's text style -->
@@ -45,14 +45,14 @@
     <!--<style name="GiniVisionTheme.Snackbar.Error.TextStyle" parent="Root.GiniVisionTheme.Snackbar.Error.TextStyle">-->
     <!--<item name="android:textStyle">bold</item>-->
     <!--<item name="android:textSize">16sp</item>-->
-    <!--<item name="font"/>-->
+    <!--<item name="gvCustomFont"/>-->
     <!--</style>-->
 
     <!-- Example of customizing the Analysis Screen error snackbar button's text style -->
     <!--<style name="GiniVisionTheme.Snackbar.Error.Button.TextStyle" parent="Root.GiniVisionTheme.Snackbar.Error.Button.TextStyle">-->
     <!--<item name="android:textStyle">bold|italic</item>-->
     <!--<item name="android:textSize">16sp</item>-->
-    <!--<item name="font"/>-->
+    <!--<item name="gvCustomFont"/>-->
     <!--</style>-->
 
 </resources>

--- a/ginivision/build.gradle
+++ b/ginivision/build.gradle
@@ -55,9 +55,7 @@ dependencies {
     androidTestCompile deps.supportTestEspressoIntents
     androidTestCompile deps.supportTestUiAutomator
     androidTestCompile deps.mockito
-    androidTestCompile deps.dexmaker
-    androidTestCompile deps.dexmakerDx
-    androidTestCompile deps.dexmakerMockito
+    androidTestCompile deps.mockitoAndroid
     androidTestCompile deps.supportMultidex
 }
 

--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
@@ -333,6 +333,7 @@ public class CameraScreenTest {
                 intentWithExtraBackButtonShouldCloseLibrary()), anyInt());
     }
 
+    @RequiresDevice
     @Test
     @SdkSuppress(minSdkVersion = 18)
     public void should_adaptCameraPreviewSize_toLandscapeOrientation_onTablets() throws Exception {

--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
@@ -49,7 +49,6 @@ import net.gini.android.vision.review.ReviewActivity;
 import net.gini.android.vision.review.ReviewActivityTestSpy;
 import net.gini.android.vision.test.EspressoAssertions;
 
-import org.hamcrest.Description;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
@@ -395,8 +394,7 @@ public class CameraScreenTest {
     private ArgumentMatcher<Intent> intentWithExtraBackButtonShouldCloseLibrary() {
         return new ArgumentMatcher<Intent>() {
             @Override
-            public boolean matches(final Object argument) {
-                final Intent intent = (Intent) argument;
+            public boolean matches(final Intent intent) {
                 //noinspection UnnecessaryLocalVariable
                 final boolean shouldCloseLibrary = intent.getBooleanExtra(
                         ReviewActivity.EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY, false);
@@ -404,8 +402,8 @@ public class CameraScreenTest {
             }
 
             @Override
-            public void describeTo(final Description description) {
-                description.appendText("Intent { EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY=true }");
+            public String toString() {
+                return "Intent { EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY=true }";
             }
         };
     }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/test/CurrentActivityTestRule.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/test/CurrentActivityTestRule.java
@@ -3,7 +3,7 @@ package net.gini.android.vision.test;
 import static android.support.test.InstrumentationRegistry.getInstrumentation;
 
 import android.app.Activity;
-import android.support.test.espresso.core.deps.guava.collect.Iterables;
+import android.support.test.espresso.core.internal.deps.guava.collect.Iterables;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
 import android.support.test.runner.lifecycle.Stage;

--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisActivity.java
@@ -1,11 +1,7 @@
 package net.gini.android.vision.analysis;
 
-import net.gini.android.vision.Document;
-import net.gini.android.vision.GiniVisionError;
-import net.gini.android.vision.R;
-import net.gini.android.vision.camera.CameraActivity;
-import net.gini.android.vision.onboarding.OnboardingActivity;
-import net.gini.android.vision.review.ReviewActivity;
+import static net.gini.android.vision.internal.util.ActivityHelper.enableHomeAsUp;
+import static net.gini.android.vision.internal.util.ActivityHelper.handleMenuItemPressedForHomeButton;
 
 import android.content.Context;
 import android.content.Intent;
@@ -16,8 +12,12 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.View;
 
-import static net.gini.android.vision.internal.util.ActivityHelper.enableHomeAsUp;
-import static net.gini.android.vision.internal.util.ActivityHelper.handleMenuItemPressedForHomeButton;
+import net.gini.android.vision.Document;
+import net.gini.android.vision.GiniVisionError;
+import net.gini.android.vision.R;
+import net.gini.android.vision.camera.CameraActivity;
+import net.gini.android.vision.onboarding.OnboardingActivity;
+import net.gini.android.vision.review.ReviewActivity;
 
 /**
  * <h3>Screen API</h3>
@@ -67,7 +67,7 @@ import static net.gini.android.vision.internal.util.ActivityHelper.handleMenuIte
  *             <b>Error message text color:</b> via the color resource named {@code gv_snackbar_error_text}
  *         </li>
  *         <li>
- *             <b>Error message font:</b> via overriding the style named {@code GiniVisionTheme.Snackbar.Error.TextStyle} and setting an item named {@code font} with the path to the font file in your {@code assets} folder
+ *             <b>Error message font:</b> via overriding the style named {@code GiniVisionTheme.Snackbar.Error.TextStyle} and setting an item named {@code gvCustomFont} with the path to the font file in your {@code assets} folder
  *         </li>
  *         <li>
  *             <b>Error message text style:</b> via overriding the style named {@code GiniVisionTheme.Snackbar.Error.TextStyle} and setting an item named {@code android:textStyle} to {@code normal}, {@code bold} or {@code italic}
@@ -79,7 +79,7 @@ import static net.gini.android.vision.internal.util.ActivityHelper.handleMenuIte
  *             <b>Error message button text color:</b> via the color resource named {@code gv_snackbar_error_button_title} and {@code gv_snackbar_error_button_title_pressed}
  *         </li>
  *         <li>
- *             <b>Error message button font:</b> via overriding the style named {@code GiniVisionTheme.Snackbar.Error.Button.TextStyle} and setting an item named {@code font} with the path to the font file in your {@code assets} folder
+ *             <b>Error message button font:</b> via overriding the style named {@code GiniVisionTheme.Snackbar.Error.Button.TextStyle} and setting an item named {@code gvCustomFont} with the path to the font file in your {@code assets} folder
  *         </li>
  *         <li>
  *             <b>Error message button text style:</b> via overriding the style named {@code GiniVisionTheme.Snackbar.Error.Button.TextStyle} and setting an item named {@code android:textStyle} to {@code normal}, {@code bold} or {@code italic}

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
@@ -117,7 +117,7 @@ import java.util.ArrayList;
  *             <b>No camera permission text color:</b> via the color resource named {@code gv_camera_error_no_permission}
  *         </li>
  *         <li>
- *             <b>No camera permission font:</b> via overriding the style named {@code GiniVisionTheme.Camera.Error.NoPermission.TextStyle} and setting an item named {@code font} with the path to the font file in your {@code assets} folder
+ *             <b>No camera permission font:</b> via overriding the style named {@code GiniVisionTheme.Camera.Error.NoPermission.TextStyle} and setting an item named {@code gvCustomFont} with the path to the font file in your {@code assets} folder
  *         </li>
  *         <li>
  *             <b>No camera permission text style:</b> via overriding the style named {@code GiniVisionTheme.Camera.Error.NoPermission.TextStyle} and setting an item named {@code android:textStyle} to {@code normal}, {@code bold} or {@code italic}
@@ -132,7 +132,7 @@ import java.util.ArrayList;
  *             <b>No camera permission button title color:</b> via the color resources named {@code gv_camera_error_no_permission_button_title} and {@code gv_camera_error_no_permission_button_title_pressed}
  *         </li>
  *         <li>
- *             <b>No camera permission button font:</b> via overriding the style named {@code GiniVisionTheme.Camera.Error.NoPermission.Button.TextStyle} and setting an item named {@code font} with the path to the font file in your {@code assets} folder
+ *             <b>No camera permission button font:</b> via overriding the style named {@code GiniVisionTheme.Camera.Error.NoPermission.Button.TextStyle} and setting an item named {@code gvCustomFont} with the path to the font file in your {@code assets} folder
  *         </li>
  *         <li>
  *             <b>No camera permission button text style:</b> via overriding the style named {@code GiniVisionTheme.Camera.Error.NoPermission.Button.TextStyle} and setting an item named {@code android:textStyle} to {@code normal}, {@code bold} or {@code italic}

--- a/ginivision/src/main/java/net/gini/android/vision/internal/ui/CustomFontButton.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/ui/CustomFontButton.java
@@ -7,7 +7,7 @@ import android.util.AttributeSet;
 import android.widget.Button;
 
 /**
- * Custom Button with an additional 'customFont' attribute. System font names or font file paths (full path in the assets folder)
+ * Custom Button with an additional 'gvCustomFont' attribute. System font names or font file paths (full path in the assets folder)
  * can be used.
  *
  * <pre> {@code
@@ -21,13 +21,13 @@ import android.widget.Button;
  *           android:id="@+id/giniTextView"
  *           android:layout_width="wrap_content"
  *           android:layout_height="wrap_content"
- *           gini:customFont="sans-serif-light" />
+ *           gini:gvCustomFont="sans-serif-light" />
  *   </LinearLayout>
  * }</pre>
  *
  * <pre> {@code
  *  <net.gini.android.vision.ui.CustomFontButton
- *      gini:customFont="myFonts/Cave-Story.ttf" />
+ *      gini:gvCustomFont="myFonts/Cave-Story.ttf" />
  * }</pre>
  *
  * @exclude

--- a/ginivision/src/main/java/net/gini/android/vision/internal/ui/CustomFontButton.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/ui/CustomFontButton.java
@@ -7,7 +7,7 @@ import android.util.AttributeSet;
 import android.widget.Button;
 
 /**
- * Custom Button with an additional 'font' attribute. System font names or font file paths (full path in the assets folder)
+ * Custom Button with an additional 'customFont' attribute. System font names or font file paths (full path in the assets folder)
  * can be used.
  *
  * <pre> {@code
@@ -21,13 +21,13 @@ import android.widget.Button;
  *           android:id="@+id/giniTextView"
  *           android:layout_width="wrap_content"
  *           android:layout_height="wrap_content"
- *           gini:font="sans-serif-light" />
+ *           gini:customFont="sans-serif-light" />
  *   </LinearLayout>
  * }</pre>
  *
  * <pre> {@code
  *  <net.gini.android.vision.ui.CustomFontButton
- *      gini:font="myFonts/Cave-Story.ttf" />
+ *      gini:customFont="myFonts/Cave-Story.ttf" />
  * }</pre>
  *
  * @exclude

--- a/ginivision/src/main/java/net/gini/android/vision/internal/ui/CustomFontHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/ui/CustomFontHelper.java
@@ -30,7 +30,7 @@ final class CustomFontHelper {
         TypedArray giniTypedArray = context.getTheme().obtainStyledAttributes(attributeSet, R.styleable.CustomFont, defStyleAttr, 0);
         String fontFamily = null;
         try {
-            fontFamily = giniTypedArray.getString(R.styleable.CustomFont_font);
+            fontFamily = giniTypedArray.getString(R.styleable.CustomFont_customFont);
         } finally {
             giniTypedArray.recycle();
         }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/ui/CustomFontHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/ui/CustomFontHelper.java
@@ -30,7 +30,7 @@ final class CustomFontHelper {
         TypedArray giniTypedArray = context.getTheme().obtainStyledAttributes(attributeSet, R.styleable.CustomFont, defStyleAttr, 0);
         String fontFamily = null;
         try {
-            fontFamily = giniTypedArray.getString(R.styleable.CustomFont_customFont);
+            fontFamily = giniTypedArray.getString(R.styleable.CustomFont_gvCustomFont);
         } finally {
             giniTypedArray.recycle();
         }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/ui/CustomFontTextView.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/ui/CustomFontTextView.java
@@ -7,7 +7,7 @@ import android.util.AttributeSet;
 import android.widget.TextView;
 
 /**
- * Custom TextView with an additional 'font' attribute. System font names or font file paths (full path in the assets folder)
+ * Custom TextView with an additional 'customFont' attribute. System font names or font file paths (full path in the assets folder)
  * can be used.
  *
  * <pre> {@code
@@ -21,13 +21,13 @@ import android.widget.TextView;
  *           android:id="@+id/giniTextView"
  *           android:layout_width="wrap_content"
  *           android:layout_height="wrap_content"
- *           gini:font="sans-serif-light" />
+ *           gini:customFont="sans-serif-light" />
  *   </LinearLayout>
  * }</pre>
  *
  * <pre> {@code
  *  <net.gini.android.vision.ui.CustomFontTextView
- *      gini:font="myFonts/Cave-Story.ttf" />
+ *      gini:customFont="myFonts/Cave-Story.ttf" />
  * }</pre>
  *
  * @exclude

--- a/ginivision/src/main/java/net/gini/android/vision/internal/ui/CustomFontTextView.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/ui/CustomFontTextView.java
@@ -7,7 +7,7 @@ import android.util.AttributeSet;
 import android.widget.TextView;
 
 /**
- * Custom TextView with an additional 'customFont' attribute. System font names or font file paths (full path in the assets folder)
+ * Custom TextView with an additional 'gvCustomFont' attribute. System font names or font file paths (full path in the assets folder)
  * can be used.
  *
  * <pre> {@code
@@ -21,13 +21,13 @@ import android.widget.TextView;
  *           android:id="@+id/giniTextView"
  *           android:layout_width="wrap_content"
  *           android:layout_height="wrap_content"
- *           gini:customFont="sans-serif-light" />
+ *           gini:gvCustomFont="sans-serif-light" />
  *   </LinearLayout>
  * }</pre>
  *
  * <pre> {@code
  *  <net.gini.android.vision.ui.CustomFontTextView
- *      gini:customFont="myFonts/Cave-Story.ttf" />
+ *      gini:gvCustomFont="myFonts/Cave-Story.ttf" />
  * }</pre>
  *
  * @exclude

--- a/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingActivity.java
@@ -47,7 +47,7 @@ import java.util.ArrayList;
  *             <b>Onboarding message color:</b> via the color resource named {@code gv_onboarding_message}
  *         </li>
  *         <li>
- *             <b>Onboarding message font:</b> via overriding the style named {@code GiniVisionTheme.Onboarding.Message.TextStyle} and setting an item named {@code font} with the path to the font file in your {@code assets} folder
+ *             <b>Onboarding message font:</b> via overriding the style named {@code GiniVisionTheme.Onboarding.Message.TextStyle} and setting an item named {@code gvCustomFont} with the path to the font file in your {@code assets} folder
  *         </li>
  *         <li>
  *             <b>Onboarding message text style:</b> via overriding the style named {@code GiniVisionTheme.Onboarding.Message.TextStyle} and setting an item named {@code android:textStyle} to {@code normal}, {@code bold} or {@code italic}

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
@@ -75,7 +75,7 @@ import net.gini.android.vision.onboarding.OnboardingActivity;
  *             <b>Bottom text color:</b> via the color resource named {@code gv_review_bottom_panel_text}
  *         </li>
  *         <li>
- *             <b>Bottom text font:</b> via overriding the style named {@code GiniVisionTheme.Review.BottomPanel.TextStyle} and setting an item named {@code font} with the path to the font file in your {@code assets} folder
+ *             <b>Bottom text font:</b> via overriding the style named {@code GiniVisionTheme.Review.BottomPanel.TextStyle} and setting an item named {@code gvCustomFont} with the path to the font file in your {@code assets} folder
  *         </li>
  *         <li>
  *             <b>Bottom text style:</b> via overriding the style named {@code GiniVisionTheme.Review.BottomPanel.TextStyle} and setting an item named {@code android:textStyle} to {@code normal}, {@code bold} or {@code italic}

--- a/ginivision/src/main/res/values/attrs.xml
+++ b/ginivision/src/main/res/values/attrs.xml
@@ -2,6 +2,6 @@
 <resources>
     <!-- CustomFont* view attributes -->
     <declare-styleable name="CustomFont">
-        <attr name="font" format="string" />
+        <attr name="customFont" format="string" />
     </declare-styleable>
 </resources>

--- a/ginivision/src/main/res/values/attrs.xml
+++ b/ginivision/src/main/res/values/attrs.xml
@@ -2,6 +2,6 @@
 <resources>
     <!-- CustomFont* view attributes -->
     <declare-styleable name="CustomFont">
-        <attr name="customFont" format="string" />
+        <attr name="gvCustomFont" format="string" />
     </declare-styleable>
 </resources>

--- a/ginivision/src/main/res/values/styles.xml
+++ b/ginivision/src/main/res/values/styles.xml
@@ -28,42 +28,42 @@
         <item name="android:textStyle">normal</item>
         <item name="android:textSize">18sp</item>
         <item name="android:textColor">@color/gv_camera_error_no_permission_text</item>
-        <item name="font"/>
+        <item name="customFont"/>
     </style>
 
     <style name="Root.GiniVisionTheme.Camera.Error.NoPermission.Button.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textStyle">normal</item>
         <item name="android:textSize">18sp</item>
         <item name="android:textColor">@drawable/gv_camera_error_no_permission_button_title_color</item>
-        <item name="font"/>
+        <item name="customFont"/>
     </style>
 
     <style name="Root.GiniVisionTheme.Review.BottomPanel.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textStyle">normal</item>
         <item name="android:textSize">14sp</item>
         <item name="android:textColor">@color/gv_review_bottom_panel_text</item>
-        <item name="font"/>
+        <item name="customFont"/>
     </style>
 
     <style name="Root.GiniVisionTheme.Onboarding.Message.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textStyle">normal</item>
         <item name="android:textSize">33sp</item>
         <item name="android:textColor">@color/gv_onboarding_message</item>
-        <item name="font">sans-serif-thin</item>
+        <item name="customFont">sans-serif-thin</item>
     </style>
 
     <style name="Root.GiniVisionTheme.Snackbar.Error.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textStyle">normal</item>
         <item name="android:textSize">14sp</item>
         <item name="android:textColor">@color/gv_snackbar_error_text</item>
-        <item name="font"/>
+        <item name="customFont"/>
     </style>
 
     <style name="Root.GiniVisionTheme.Snackbar.Error.Button.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textStyle">normal</item>
         <item name="android:textSize">14sp</item>
         <item name="android:textColor">@drawable/gv_snackbar_error_button_title_color</item>
-        <item name="font"/>
+        <item name="customFont"/>
     </style>
 
     <!-- Text styles used in the layouts which are overridable for customization -->

--- a/ginivision/src/main/res/values/styles.xml
+++ b/ginivision/src/main/res/values/styles.xml
@@ -28,42 +28,42 @@
         <item name="android:textStyle">normal</item>
         <item name="android:textSize">18sp</item>
         <item name="android:textColor">@color/gv_camera_error_no_permission_text</item>
-        <item name="customFont"/>
+        <item name="gvCustomFont"/>
     </style>
 
     <style name="Root.GiniVisionTheme.Camera.Error.NoPermission.Button.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textStyle">normal</item>
         <item name="android:textSize">18sp</item>
         <item name="android:textColor">@drawable/gv_camera_error_no_permission_button_title_color</item>
-        <item name="customFont"/>
+        <item name="gvCustomFont"/>
     </style>
 
     <style name="Root.GiniVisionTheme.Review.BottomPanel.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textStyle">normal</item>
         <item name="android:textSize">14sp</item>
         <item name="android:textColor">@color/gv_review_bottom_panel_text</item>
-        <item name="customFont"/>
+        <item name="gvCustomFont"/>
     </style>
 
     <style name="Root.GiniVisionTheme.Onboarding.Message.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textStyle">normal</item>
         <item name="android:textSize">33sp</item>
         <item name="android:textColor">@color/gv_onboarding_message</item>
-        <item name="customFont">sans-serif-thin</item>
+        <item name="gvCustomFont">sans-serif-thin</item>
     </style>
 
     <style name="Root.GiniVisionTheme.Snackbar.Error.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textStyle">normal</item>
         <item name="android:textSize">14sp</item>
         <item name="android:textColor">@color/gv_snackbar_error_text</item>
-        <item name="customFont"/>
+        <item name="gvCustomFont"/>
     </style>
 
     <style name="Root.GiniVisionTheme.Snackbar.Error.Button.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textStyle">normal</item>
         <item name="android:textSize">14sp</item>
         <item name="android:textColor">@drawable/gv_snackbar_error_button_title_color</item>
-        <item name="customFont"/>
+        <item name="gvCustomFont"/>
     </style>
 
     <!-- Text styles used in the layouts which are overridable for customization -->

--- a/screenapiexample/build.gradle
+++ b/screenapiexample/build.gradle
@@ -83,9 +83,7 @@ dependencies {
     })
     androidTestCompile deps.supportTestUiAutomator
     androidTestCompile deps.mockito
-    androidTestCompile deps.dexmaker
-    androidTestCompile deps.dexmakerDx
-    androidTestCompile deps.dexmakerMockito
+    androidTestCompile deps.mockitoAndroid
     androidTestCompile deps.supportMultidex
 }
 

--- a/screenapiexample/src/main/res/values/styles.xml
+++ b/screenapiexample/src/main/res/values/styles.xml
@@ -12,21 +12,21 @@
     <!--<style name="GiniVisionTheme.Camera.Error.NoPermission.TextStyle" parent="Root.GiniVisionTheme.Camera.Error.NoPermission.TextStyle">-->
         <!--<item name="android:textStyle">bold</item>-->
         <!--<item name="android:textSize">30sp</item>-->
-        <!--<item name="font">Cave-Story.ttf</item>-->
+        <!--<item name="gvCustomFont">Cave-Story.ttf</item>-->
     <!--</style>-->
 
     <!-- Example of customizing the Camera Screen no camera permission error button's text style -->
     <!--<style name="GiniVisionTheme.Camera.Error.NoPermission.Button.TextStyle" parent="Root.GiniVisionTheme.Camera.Error.NoPermission.Button.TextStyle">-->
         <!--<item name="android:textStyle">italic</item>-->
         <!--<item name="android:textSize">30sp</item>-->
-        <!--<item name="font">Cave-Story.ttf</item>-->
+        <!--<item name="gvCustomFont">Cave-Story.ttf</item>-->
     <!--</style>-->
 
     <!-- Example of customizing the Review Screen bottom panel's text style -->
     <!--<style name="GiniVisionTheme.Review.BottomPanel.TextStyle" parent="Root.GiniVisionTheme.Review.BottomPanel.TextStyle">-->
         <!--<item name="android:textStyle">bold</item>-->
         <!--<item name="android:textSize">16sp</item>-->
-        <!--<item name="font">fonts/Warenhaus-Standard.ttf</item>-->
+        <!--<item name="gvCustomFont">fonts/Warenhaus-Standard.ttf</item>-->
     <!--</style>-->
 
     <!-- Example of customizing the Onboarding Screen's text style -->
@@ -38,14 +38,14 @@
     <!--<style name="GiniVisionTheme.Snackbar.Error.TextStyle" parent="Root.GiniVisionTheme.Snackbar.Error.TextStyle">-->
         <!--<item name="android:textStyle">bold</item>-->
         <!--<item name="android:textSize">16sp</item>-->
-        <!--<item name="font"/>-->
+        <!--<item name="gvCustomFont"/>-->
     <!--</style>-->
 
     <!-- Example of customizing the Analysis Screen error snackbar button's text style -->
     <!--<style name="GiniVisionTheme.Snackbar.Error.Button.TextStyle" parent="Root.GiniVisionTheme.Snackbar.Error.Button.TextStyle">-->
         <!--<item name="android:textStyle">bold|italic</item>-->
         <!--<item name="android:textSize">16sp</item>-->
-        <!--<item name="font"/>-->
+        <!--<item name="gvCustomFont"/>-->
     <!--</style>-->
 
 </resources>


### PR DESCRIPTION
Updated to support library version `26.0.1`. We have to update because our clients won't be able to update to 26 as we have an attribute name conflict with `font`.

Fixed name conflict between our custom attribute `font` (for `CustomFont*` views) and the new `font` attribute in the support lib by renaming our to `gvCustomFont`.

Also updated to the new support test library versions and to the new mockito version.

We have to add to the changelog, that clients have to update to `buildToolsVersion '26.x.x` and use `compileSdkVersion 26`. Otherwise they will get an error (see the [compatibility table](https://github.com/gini/gini-vision-lib-android/issues/69#issuecomment-328148736)).

### How to test
Run JVM and connected tests.

### Merging
Automatic.

### Ticket 
Issue #69 
