### PR TITLE
Implemented criteria checking for the imported files.

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -1,6 +1,8 @@
 package net.gini.android.vision.camera;
 
 import static net.gini.android.vision.camera.Util.cameraExceptionToGiniVisionError;
+import static net.gini.android.vision.internal.fileimport.FileChooserActivity.EXTRA_OUT_ERROR;
+import static net.gini.android.vision.internal.fileimport.FileChooserActivity.RESULT_ERROR;
 import static net.gini.android.vision.internal.util.ActivityHelper.forcePortraitOrientationOnPhones;
 import static net.gini.android.vision.internal.util.AndroidHelper.isMarshmallowOrLater;
 import static net.gini.android.vision.internal.util.ContextHelper.getClientApplicationId;
@@ -328,8 +330,14 @@ class CameraFragmentImpl implements CameraFragmentInterface {
 
     boolean onActivityResult(final int requestCode, final int resultCode, final Intent data) {
         if (requestCode == REQ_CODE_CHOOSE_FILE) {
-            LOG.info("Document file received");
-            Toast.makeText(mFragment.getActivity(), "File received", Toast.LENGTH_LONG).show();
+            if(resultCode != RESULT_ERROR) {
+                LOG.info("Document file received");
+                Toast.makeText(mFragment.getActivity(), "File received", Toast.LENGTH_LONG).show();
+            } else {
+                LOG.info("Document file opening gone wrong");
+                GiniVisionError error = data.getParcelableExtra(EXTRA_OUT_ERROR);
+                Toast.makeText(mFragment.getActivity(), error.getMessage(), Toast.LENGTH_LONG).show();
+            }
             return true;
         }
         return false;

--- a/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
@@ -9,10 +9,8 @@ import static net.gini.android.vision.GiniVisionError.ErrorCode.DOCUMENT_IMPORT;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
-import android.graphics.pdf.PdfRenderer;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.ParcelFileDescriptor;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.transition.AutoTransition;
@@ -32,8 +30,8 @@ import net.gini.android.vision.internal.fileimport.providerchooser.ProvidersAppI
 import net.gini.android.vision.internal.fileimport.providerchooser.ProvidersItem;
 import net.gini.android.vision.internal.fileimport.providerchooser.ProvidersSectionItem;
 import net.gini.android.vision.internal.fileimport.providerchooser.ProvidersSpanSizeLookup;
+import net.gini.android.vision.internal.util.FileImportValidator;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -136,13 +134,12 @@ public class FileChooserActivity extends AppCompatActivity {
     protected void onActivityResult(final int requestCode, final int resultCode,
             final Intent data) {
         if (requestCode == REQ_CODE_CHOOSE_FILE && resultCode == RESULT_OK) {
-            if(fileMatchesCriteria(data)) {
+            final FileImportValidator fileImportValidator = new FileImportValidator(this);
+            if(fileImportValidator.matchesCriteria(data.getData())) {
                 setResult(resultCode, data);
             } else {
-                final GiniVisionError error = new GiniVisionError(DOCUMENT_IMPORT,
-                        "File doesn't match the upload criteria.");
                 final Intent result = new Intent();
-                result.putExtra(EXTRA_OUT_ERROR, error);
+                result.putExtra(EXTRA_OUT_ERROR, fileImportValidator.getError());
                 setResult(RESULT_ERROR, result);
             }
         } else {
@@ -153,57 +150,6 @@ public class FileChooserActivity extends AppCompatActivity {
             setResult(RESULT_ERROR, result);
         }
         finish();
-    }
-
-    private boolean fileMatchesCriteria(final Intent data) {
-        final String type = getContentResolver().getType(data.getData());
-        if(isSupportedFileType(type)) {
-            try {
-                ParcelFileDescriptor parcelFileDescriptor = getContentResolver().openFileDescriptor(
-                        data.getData(), "r");
-                if (parcelFileDescriptor != null && matchesSizeCriteria(parcelFileDescriptor.getStatSize())) {
-                    if (isPdf(type)) {
-                        return matchesPdfCriteria(parcelFileDescriptor);
-                    } else {
-                        return true;
-                    }
-                }
-            } catch (IOException e) {
-                return false;
-            }
-        }
-        return false;
-    }
-
-    private boolean matchesPdfCriteria(final ParcelFileDescriptor parcelFileDescriptor)
-            throws IOException {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            PdfRenderer pdfRenderer = new PdfRenderer(parcelFileDescriptor);
-            final int pageCount = pdfRenderer.getPageCount();
-            if (pageCount <= 10) {
-                return true;
-            }
-        } else {
-            //not sure if we should just ignore this case
-            return true;
-        }
-        return false;
-    }
-
-    private boolean isPdf(final String fileType) {
-        return "application/pdf".equals(fileType);
-    }
-
-    private boolean matchesSizeCriteria(final long statSize) {
-        return statSize < 10485760;
-    }
-
-    private boolean isSupportedFileType(final String type) {
-        return "image/jpeg".equals(type)
-                || "image/png".equals(type)
-                || "image/tiff".equals(type)
-                || "image/gif".equals(type)
-                || isPdf(type);
     }
 
     private void populateFileProviders() {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/util/FileImportValidator.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/util/FileImportValidator.java
@@ -1,0 +1,103 @@
+package net.gini.android.vision.internal.util;
+
+
+import android.content.Context;
+import android.graphics.pdf.PdfRenderer;
+import android.net.Uri;
+import android.os.Build;
+import android.os.ParcelFileDescriptor;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import net.gini.android.vision.GiniVisionError;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+public class FileImportValidator {
+
+    private final Context mContext;
+    private GiniVisionError mError;
+
+    public FileImportValidator(final Context context) {
+        mContext = context;
+    }
+
+    @Nullable
+    public GiniVisionError getError() {
+        return mError;
+    }
+
+    public boolean matchesCriteria(@NonNull final Uri fileUri) {
+        final String type = mContext.getContentResolver().getType(fileUri);
+
+        if (!isSupportedFileType(type)) {
+            mError = new GiniVisionError(GiniVisionError.ErrorCode.DOCUMENT_IMPORT,
+                    "File type is not supported for document import.");
+            return false;
+        }
+
+        if (!matchesSizeCriteria(fileUri)) {
+            mError = new GiniVisionError(GiniVisionError.ErrorCode.DOCUMENT_IMPORT,
+                    "File is too big for document import.");
+            return false;
+        }
+
+        if (isPdf(type)) {
+            if (!matchesPdfCriteria(fileUri)) {
+                mError = new GiniVisionError(GiniVisionError.ErrorCode.DOCUMENT_IMPORT,
+                        "PDF does not match the criteria for document import.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private boolean isPdf(final String fileType) {
+        return "application/pdf".equals(fileType);
+    }
+
+    private boolean isSupportedFileType(final String type) {
+        return "image/jpeg".equals(type)
+                || "image/png".equals(type)
+                || "image/tiff".equals(type)
+                || "image/gif".equals(type)
+                || isPdf(type);
+    }
+
+    private boolean matchesPdfCriteria(final Uri fileUri) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            try {
+                final ParcelFileDescriptor parcelFileDescriptor =
+                        mContext.getContentResolver().openFileDescriptor(fileUri, "r");
+                if (parcelFileDescriptor != null) {
+                    PdfRenderer pdfRenderer = new PdfRenderer(parcelFileDescriptor);
+                    final int pageCount = pdfRenderer.getPageCount();
+                    if (pageCount <= 10) {
+                        return true;
+                    }
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            //not sure if we should just ignore this case
+            return true;
+        }
+        return false;
+    }
+
+    private boolean matchesSizeCriteria(final Uri fileUri) {
+        ParcelFileDescriptor parcelFileDescriptor = null;
+        try {
+            parcelFileDescriptor = mContext.getContentResolver().openFileDescriptor(fileUri, "r");
+            if (parcelFileDescriptor != null) {
+                return parcelFileDescriptor.getStatSize() < 10485760;
+            }
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Check if the chosen file is supported and matches the criteria.
The problem right now is that without a third party library we can't check if a PDF has <= 10 pages for SDK versions < 21. However to add another library would be wrong and implementing by our own would be an overkill in my opinion, therefore this check always succeeds now.

### How to test
open some files and see the toast

### Merging
none

### Ticket 
#63 
