### PR TITLE
Mention ui assets repo

### DIFF
--- a/ginivision/src/doc/source/updating-to-2-4-0.rst
+++ b/ginivision/src/doc/source/updating-to-2-4-0.rst
@@ -204,6 +204,10 @@ Analysis Screen:
 
 For detailed customization options consult the Javadoc of the ``CameraActivity`` and ``AnalysisActivity``.
 
+.. note::
+
+    The `Gini Vision Library UI Assets <https://github.com/gini/gini-vision-lib-assets/>`_ repository can be used as an aid for customizing the UI.
+
 .. _File Import:
 
 File Import ("Open With")
@@ -395,6 +399,10 @@ Customizing the UI
 
 For detailed customization options consult the Javadoc of the ``HelpActivity``, ``PhotoTipsActivity``, ``FileImportActivity`` and ``SupportedFormatsActivity``.
 
+.. note::
+
+    The `Gini Vision Library UI Assets <https://github.com/gini/gini-vision-lib-assets/>`_ repository can be used as an aid for customizing the UI.
+
 No Results Screen
 ^^^^
 
@@ -452,6 +460,10 @@ Customizing the UI
 
 For detailed customization options consult the Javadoc of the ``NoResultsActivity``.
 
+.. note::
+
+    The `Gini Vision Library UI Assets <https://github.com/gini/gini-vision-lib-assets/>`_ repository can be used as an aid for customizing the UI.
+
 Tablet Support
 ^^^^
 
@@ -502,6 +514,10 @@ Tablet specific images are required only for the Camera Screen for tablets. The 
 * ``gv_onboarding_align.png`` - Fourth onboarding page image
 
 These images are higher resolution versions of the same images that are used for phones.
+
+.. note::
+
+    The `Gini Vision Library UI Assets <https://github.com/gini/gini-vision-lib-assets/>`_ repository can be used as an aid for customizing the UI.
 
 .. _Quick Checklist:
 

--- a/ginivision/src/main/java/net/gini/android/vision/help/FileImportActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/help/FileImportActivity.java
@@ -72,7 +72,7 @@ import net.gini.android.vision.review.ReviewActivity;
  *         </li>
  *         <li>
  *             <b>Section 1 illustration image:</b> via images for mdpi, hdpi, xhdpi, xxhdpi, xxxhdpi
- *             named {@code gv_file_import_section_1_illustration.png}
+ *             named {@code gv_file_import_section_1_illustration.png}. For creating your custom illustration you may use <a href="https://github.com/gini/gini-vision-lib-assets/blob/master/Gini-Vision-Lib-Design-Elements/Illustrations/PDF/android_pdf_open_with_illustration_1.pdf" target="_blank">this template</a> from the <a href="https://github.com/gini/gini-vision-lib-assets" target="_blank">Gini Vision Library UI Assets</a> repository.
  *         </li>
  *         <li>
  *             <b>Section 2 title:</b> via overriding the string resource named {@code gv_file_import_section_2_title}
@@ -82,7 +82,7 @@ import net.gini.android.vision.review.ReviewActivity;
  *         </li>
  *         <li>
  *             <b>Section 2 illustration image:</b> via images for mdpi, hdpi, xhdpi, xxhdpi, xxxhdpi
- *             named {@code gv_file_import_section_2_illustration.png}
+ *             named {@code gv_file_import_section_2_illustration.png}. For creating your custom illustration you may use <a href="https://github.com/gini/gini-vision-lib-assets/blob/master/Gini-Vision-Lib-Design-Elements/Illustrations/PDF/android_pdf_open_with_illustration_2.pdf" target="_blank">this template</a> from the <a href="https://github.com/gini/gini-vision-lib-assets" target="_blank">Gini Vision Library UI Assets</a> repository.
  *         </li>
  *         <li>
  *             <b>Section 3 title:</b> via overriding the string resource named {@code gv_file_import_section_3_title}

--- a/ginivision/src/main/java/net/gini/android/vision/noresults/NoResultsActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/noresults/NoResultsActivity.java
@@ -30,6 +30,10 @@ import net.gini.android.vision.review.ReviewActivity;
  *     The following items are customizable:
  *     <ul>
  *         <li>
+ *             <b>Header icon:</b> via images for mdpi, hdpi, xhdpi, xxhdpi, xxxhdpi named
+ *             {@code gv_alert_icon.png}
+ *         </li>
+ *         <li>
  *             <b>Header text color:</b> via the color resource named {@code
  *             gv_noresults_header}
  *         </li>


### PR DESCRIPTION
Mentioned and added links to the [ui assets repo](https://github.com/gini/gini-vision-lib-assets) in the migration guide and javadoc.

Also added customization info for the alert icon on the No Results Screen.