### PR TITLE
Bugfix for PDF rendering on the Huawei MediaPad T2 10" Pro

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
@@ -37,7 +37,6 @@ import net.gini.android.vision.document.PdfDocument;
 import net.gini.android.vision.internal.AsyncCallback;
 import net.gini.android.vision.internal.document.DocumentRenderer;
 import net.gini.android.vision.internal.document.DocumentRendererFactory;
-import net.gini.android.vision.internal.pdf.Pdf;
 import net.gini.android.vision.internal.ui.ErrorSnackbar;
 import net.gini.android.vision.internal.ui.FragmentImplCallback;
 import net.gini.android.vision.internal.util.Size;
@@ -383,8 +382,8 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
 
     private void onViewLayoutFinished() {
         LOG.debug("View layout finished");
-        showDocument();
         showPdfInfoForPdfDocument();
+        showDocument();
         analyzeDocument();
     }
 
@@ -438,13 +437,27 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
                 mPdfTitleTextView.setText(filename);
             }
 
-            final int pageCount = Pdf.fromDocument(pdfDocument).getPageCount(activity);
-            if (pageCount > 0) {
-                mPdfPageCountTextView.setVisibility(View.VISIBLE);
-                final String pageCountString = activity.getResources().getQuantityString(
-                        R.plurals.gv_analysis_pdf_pages, pageCount, pageCount);
-                mPdfPageCountTextView.setText(pageCountString);
-            }
+            mPdfPageCountTextView.setVisibility(View.VISIBLE);
+            mPdfPageCountTextView.setText("");
+
+            mDocumentRenderer.getPageCount(new AsyncCallback<Integer>() {
+                @Override
+                public void onSuccess(final Integer result) {
+                    if (result > 0) {
+                        mPdfPageCountTextView.setVisibility(View.VISIBLE);
+                        final String pageCountString = activity.getResources().getQuantityString(
+                                R.plurals.gv_analysis_pdf_pages, result, result);
+                        mPdfPageCountTextView.setText(pageCountString);
+                    } else {
+                        mPdfPageCountTextView.setVisibility(View.GONE);
+                    }
+                }
+
+                @Override
+                public void onError(final Exception exception) {
+                    mPdfPageCountTextView.setVisibility(View.GONE);
+                }
+            });
         }
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/document/DocumentRenderer.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/document/DocumentRenderer.java
@@ -4,6 +4,7 @@ import android.graphics.Bitmap;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import net.gini.android.vision.internal.AsyncCallback;
 import net.gini.android.vision.internal.util.Size;
 
 /**
@@ -12,6 +13,8 @@ import net.gini.android.vision.internal.util.Size;
 public interface DocumentRenderer {
 
     void toBitmap(@NonNull final Size targetSize, @NonNull final Callback callback);
+
+    void getPageCount(@NonNull final AsyncCallback<Integer> asyncCallback);
 
     interface Callback {
         void onBitmapReady(@Nullable final Bitmap bitmap, final int rotationForDisplay);

--- a/ginivision/src/main/java/net/gini/android/vision/internal/document/ImageDocumentRenderer.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/document/ImageDocumentRenderer.java
@@ -44,4 +44,9 @@ class ImageDocumentRenderer implements DocumentRenderer {
             callback.onBitmapReady(mPhoto.getBitmapPreview(), mPhoto.getRotationForDisplay());
         }
     }
+
+    @Override
+    public void getPageCount(@NonNull final AsyncCallback<Integer> asyncCallback) {
+        asyncCallback.onSuccess(1);
+    }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/pdf/Renderer.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/pdf/Renderer.java
@@ -2,19 +2,17 @@ package net.gini.android.vision.internal.pdf;
 
 import android.graphics.Bitmap;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
+import net.gini.android.vision.internal.AsyncCallback;
 import net.gini.android.vision.internal.util.Size;
 
 /**
  * @exclude
  */
 public interface Renderer {
-    void toBitmap(@NonNull final Size targetSize, @NonNull final Callback callback);
+    void toBitmap(@NonNull final Size targetSize, @NonNull final AsyncCallback<Bitmap> asyncCallback);
+
+    void getPageCount(@NonNull final AsyncCallback<Integer> asyncCallback);
 
     int getPageCount();
-
-    interface Callback {
-        void onBitmapReady(@Nullable final Bitmap bitmap);
-    }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/pdf/RendererLollipop.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/pdf/RendererLollipop.java
@@ -6,6 +6,7 @@ import static net.gini.android.vision.internal.pdf.Pdf.DEFAULT_PREVIEW_WIDTH;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.pdf.PdfRenderer;
 import android.net.Uri;
@@ -133,18 +134,11 @@ class RendererLollipop implements Renderer {
 
     @NonNull
     private static Bitmap createWhiteBitmap(@NonNull Size renderingSize) {
-        int[] colors = createWhiteColors(renderingSize);
-        return Bitmap.createBitmap(colors, renderingSize.width, renderingSize.height,
+        final Bitmap bitmap = Bitmap.createBitmap(renderingSize.width, renderingSize.height,
                 Bitmap.Config.ARGB_8888);
-    }
-
-    @NonNull
-    private static int[] createWhiteColors(@NonNull Size renderingSize) {
-        int[] colors = new int[renderingSize.width * renderingSize.height];
-        for (int i = 0; i < colors.length; i++) {
-            colors[i] = Color.WHITE;
-        }
-        return colors;
+        final Canvas canvas = new Canvas(bitmap);
+        canvas.drawColor(Color.WHITE);
+        return bitmap;
     }
 
     @NonNull

--- a/ginivision/src/main/java/net/gini/android/vision/internal/pdf/RendererLollipop.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/pdf/RendererLollipop.java
@@ -17,6 +17,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
 
+import net.gini.android.vision.internal.AsyncCallback;
 import net.gini.android.vision.internal.util.Size;
 
 import org.slf4j.Logger;
@@ -26,6 +27,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 
 /**
+ * This class is not thread safe due to the underlying {@link PdfRenderer}.
+ *
  * @exclude
  */
 @RequiresApi(21)
@@ -42,7 +45,7 @@ class RendererLollipop implements Renderer {
     }
 
     @Nullable
-    private Bitmap toBitmap(@NonNull final Size targetSize) {
+    private synchronized Bitmap toBitmap(@NonNull final Size targetSize) {
         Bitmap bitmap = null;
         final PdfRenderer pdfRenderer = getPdfRenderer();
         if (pdfRenderer == null) {
@@ -81,24 +84,42 @@ class RendererLollipop implements Renderer {
 
     @Override
     public void toBitmap(@NonNull final Size targetSize,
-            @NonNull final Callback callback) {
-        final AsyncTask<RendererLollipop, Void, Bitmap> asyncTask =
-                new AsyncTask<RendererLollipop, Void, Bitmap>() {
+            @NonNull final AsyncCallback<Bitmap> asyncCallback) {
+        final RenderAsyncTask asyncTask = new RenderAsyncTask(this,
+                targetSize,
+                new AsyncCallback<Bitmap>() {
                     @Override
-                    protected Bitmap doInBackground(final RendererLollipop... renderers) {
-                        return renderers[0].toBitmap(targetSize);
+                    public void onSuccess(final Bitmap result) {
+                        asyncCallback.onSuccess(result);
                     }
 
                     @Override
-                    protected void onPostExecute(final Bitmap bitmap) {
-                        callback.onBitmapReady(bitmap);
+                    public void onError(final Exception exception) {
+                        asyncCallback.onError(exception);
                     }
-                };
-        asyncTask.execute(this);
+                });
+        asyncTask.execute();
     }
 
     @Override
-    public int getPageCount() {
+    public void getPageCount(@NonNull final AsyncCallback<Integer> asyncCallback) {
+        final PageCountAsyncTask asyncTask = new PageCountAsyncTask(this,
+                new AsyncCallback<Integer>() {
+                    @Override
+                    public void onSuccess(final Integer result) {
+                        asyncCallback.onSuccess(result);
+                    }
+
+                    @Override
+                    public void onError(final Exception exception) {
+                        asyncCallback.onError(exception);
+                    }
+                });
+        asyncTask.execute();
+    }
+
+    @Override
+    public synchronized int getPageCount() {
         final PdfRenderer pdfRenderer = getPdfRenderer();
         if (pdfRenderer == null) {
             return 0;
@@ -147,5 +168,54 @@ class RendererLollipop implements Renderer {
             return new Size(DEFAULT_PREVIEW_WIDTH, DEFAULT_PREVIEW_HEIGHT);
         }
         return size;
+    }
+
+    private static class RenderAsyncTask extends AsyncTask<Void, Void, Bitmap> {
+
+        private final RendererLollipop mRendererLollipop;
+        private final Size mTargetSize;
+        private final AsyncCallback<Bitmap> mCallback;
+
+        private RenderAsyncTask(final RendererLollipop rendererLollipop,
+                final Size targetSize,
+                final AsyncCallback<Bitmap> callback) {
+            mRendererLollipop = rendererLollipop;
+            mTargetSize = targetSize;
+            mCallback = callback;
+        }
+
+        @Override
+        protected Bitmap doInBackground(final Void... voids) {
+            return mRendererLollipop.toBitmap(mTargetSize);
+        }
+
+        @Override
+        protected void onPostExecute(final Bitmap bitmap) {
+            super.onPostExecute(bitmap);
+            mCallback.onSuccess(bitmap);
+        }
+    }
+
+    private static class PageCountAsyncTask extends AsyncTask<Void, Void, Integer> {
+
+        private final RendererLollipop mRendererLollipop;
+        private final AsyncCallback<Integer> mCallback;
+
+        private PageCountAsyncTask(final RendererLollipop rendererLollipop,
+                final AsyncCallback<Integer> callback) {
+            mRendererLollipop = rendererLollipop;
+            mCallback = callback;
+        }
+
+        @Override
+        protected Integer doInBackground(final Void... voids) {
+            return mRendererLollipop.getPageCount();
+        }
+
+        @Override
+        protected void onPostExecute(final Integer pageCount) {
+            super.onPostExecute(pageCount);
+            mCallback.onSuccess(pageCount);
+        }
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/pdf/RendererPreLollipop.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/pdf/RendererPreLollipop.java
@@ -1,7 +1,9 @@
 package net.gini.android.vision.internal.pdf;
 
+import android.graphics.Bitmap;
 import android.support.annotation.NonNull;
 
+import net.gini.android.vision.internal.AsyncCallback;
 import net.gini.android.vision.internal.util.Size;
 
 /**
@@ -11,12 +13,18 @@ class RendererPreLollipop implements Renderer {
 
     @Override
     public void toBitmap(@NonNull final Size targetSize,
-            @NonNull final Callback callback) {
-        callback.onBitmapReady(null);
+            @NonNull final AsyncCallback<Bitmap> asyncCallback) {
+        asyncCallback.onSuccess(null);
+    }
+
+    @Override
+    public void getPageCount(@NonNull final AsyncCallback<Integer> asyncCallback) {
+        asyncCallback.onSuccess(0);
     }
 
     @Override
     public int getPageCount() {
         return 0;
     }
+
 }


### PR DESCRIPTION
The bug was cause by using different PdfRenderer instances on different threads. PdfRenderer is not thread safe and even though instances were not shared between threads the underlying libpdfium.so caused SIGSEGV faults. This issue was encountered only on this Huawei tablet.

To fix it we use one RendererLollipop instance in the AnalysisFragment which creates PdfRenderer instances on secondary threads (AsyncTask) and uses synchronization to allow only one at a time. The single RendererLollipop instance is the lock for synchronization.

### How to test
Run on the Huawei tablet and analyze different pdfs.

### Merging
Automatic.
