### PR TITLE
Fixed retrieving file size for "file://" scheme Uris

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,14 +43,14 @@ task printLibraryVersion {
 
 ext {
     compileSdkVersion = 26
-    buildToolsVersion = '26.0.1'
+    buildToolsVersion = '26.0.3'
     minSdkVersion = 14
     targetSdkVersion = 26
     versionCode = libVersionCode
     versionName = libVersionName
 }
 
-def supportLibVersion = '26.0.1'
+def supportLibVersion = '26.0.2'
 def mockitoVersion = '2.6.3'
 def testSupportLibVersion = '1.0.1'
 def espressoVersion = '3.0.1'

--- a/ginivision/src/androidTest/AndroidManifest.xml
+++ b/ginivision/src/androidTest/AndroidManifest.xml
@@ -23,6 +23,15 @@
             android:name="net.gini.android.vision.internal.ui.ErrorSnackbarTestActivity"
             android:theme="@style/GiniVisionTheme" />
         <activity android:name="net.gini.android.vision.internal.camera.api.NoOpActivity"/>
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="net.gini.android.vision.test.fileprovider"
+            android:grantUriPermissions="true"
+            android:exported="false">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
     </application>
 
 </manifest>

--- a/ginivision/src/androidTest/java/net/gini/android/vision/test/Helpers.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/test/Helpers.java
@@ -1,8 +1,5 @@
 package net.gini.android.vision.test;
 
-import static java.nio.file.FileVisitResult.CONTINUE;
-import static java.nio.file.FileVisitResult.TERMINATE;
-
 import android.app.Instrumentation;
 import android.content.res.AssetManager;
 import android.net.Uri;
@@ -26,11 +23,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 
 public class Helpers {
 
@@ -116,7 +108,8 @@ public class Helpers {
             final File file = new File(storageDirPath,
                     Uri.parse(assetFilePath).getLastPathSegment());
             if (!file.exists()) {
-                Files.createFile(file.toPath());
+                //noinspection ResultOfMethodCallIgnored
+                file.createNewFile();
                 outputStream = new FileOutputStream(file);
                 copyFile(inputStream, outputStream);
             }
@@ -138,36 +131,4 @@ public class Helpers {
             outputStream.write(buffer, 0, read);
         }
     }
-
-    public static void deleteFileOrFolder(@NonNull final File file) throws IOException {
-        Files.walkFileTree(file.toPath(), new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs)
-                    throws IOException {
-                Files.delete(file);
-                return CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult visitFileFailed(final Path file, final IOException e) {
-                return handleException(e);
-            }
-
-            private FileVisitResult handleException(final IOException e) {
-                e.printStackTrace(); // replace with more robust error handling
-                return TERMINATE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(final Path dir, final IOException e)
-                    throws IOException {
-                if (e != null) {
-                    return handleException(e);
-                }
-                Files.delete(dir);
-                return CONTINUE;
-            }
-        });
-    }
-
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/util/UriHelperTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/util/UriHelperTest.java
@@ -2,12 +2,11 @@ package net.gini.android.vision.util;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import static net.gini.android.vision.test.Helpers.deleteFileOrFolder;
-
 import android.content.Context;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
 import android.support.v4.content.FileProvider;
 
 import net.gini.android.vision.test.Helpers;
@@ -15,10 +14,10 @@ import net.gini.android.vision.test.Helpers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 
 /**
  * Created by Alpar Szotyori on 28.11.2017.
@@ -26,6 +25,7 @@ import java.nio.file.Files;
  * Copyright (c) 2017 Gini GmbH.
  */
 
+@RunWith(AndroidJUnit4.class)
 public class UriHelperTest {
 
     private static final String TEST_FILE = "invoice.jpg";
@@ -37,10 +37,10 @@ public class UriHelperTest {
 
     private static void setUpFileProvider() throws IOException {
         final File fileProviderDir = getFileProviderDir();
-        if (fileProviderDir.exists()) {
-            deleteFileOrFolder(fileProviderDir);
+        if (!fileProviderDir.exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            fileProviderDir.mkdirs();
         }
-        Files.createDirectories(fileProviderDir.toPath());
         Helpers.copyAssetToStorage(TEST_FILE, fileProviderDir.getPath());
     }
 
@@ -57,9 +57,9 @@ public class UriHelperTest {
 
     private static void tearDownFileProvider() throws IOException {
         final File fileProviderDir = getFileProviderDir();
-        if (fileProviderDir.exists()) {
-            deleteFileOrFolder(fileProviderDir);
-        }
+        final File testFile = new File(fileProviderDir, TEST_FILE);
+        //noinspection ResultOfMethodCallIgnored
+        testFile.delete();
     }
 
     @Test

--- a/ginivision/src/androidTest/java/net/gini/android/vision/util/UriHelperTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/util/UriHelperTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 public class UriHelperTest {
 
     private static final String TEST_FILE = "invoice.jpg";
+    private static File sFileProviderDir;
 
     @BeforeClass
     public static void setUpClass() throws Exception {
@@ -36,12 +37,12 @@ public class UriHelperTest {
     }
 
     private static void setUpFileProvider() throws IOException {
-        final File fileProviderDir = getFileProviderDir();
-        if (!fileProviderDir.exists()) {
+        sFileProviderDir = getFileProviderDir();
+        if (!sFileProviderDir.exists()) {
             //noinspection ResultOfMethodCallIgnored
-            fileProviderDir.mkdirs();
+            sFileProviderDir.mkdirs();
         }
-        Helpers.copyAssetToStorage(TEST_FILE, fileProviderDir.getPath());
+        Helpers.copyAssetToStorage(TEST_FILE, sFileProviderDir.getPath());
     }
 
     @NonNull
@@ -56,8 +57,7 @@ public class UriHelperTest {
     }
 
     private static void tearDownFileProvider() throws IOException {
-        final File fileProviderDir = getFileProviderDir();
-        final File testFile = new File(fileProviderDir, TEST_FILE);
+        final File testFile = new File(sFileProviderDir, TEST_FILE);
         //noinspection ResultOfMethodCallIgnored
         testFile.delete();
     }
@@ -75,12 +75,11 @@ public class UriHelperTest {
     }
 
     private int getTestFileSize() {
-        File fileProviderDir = getFileProviderDir();
-        return (int) new File(fileProviderDir, TEST_FILE).length();
+        return (int) new File(sFileProviderDir, TEST_FILE).length();
     }
 
     private Uri getTestFileContentUri() {
-        final File file = new File(getFileProviderDir(), TEST_FILE);
+        final File file = new File(sFileProviderDir, TEST_FILE);
         return FileProvider.getUriForFile(InstrumentationRegistry.getTargetContext(),
                 "net.gini.android.vision.test.fileprovider", file);
     }
@@ -98,7 +97,7 @@ public class UriHelperTest {
     }
 
     private Uri getTestFileFileUri() {
-        File file = new File(getFileProviderDir(), TEST_FILE);
+        File file = new File(sFileProviderDir, TEST_FILE);
         return Uri.parse(file.getPath());
     }
 

--- a/ginivision/src/androidTest/java/net/gini/android/vision/util/UriHelperTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/util/UriHelperTest.java
@@ -1,0 +1,127 @@
+package net.gini.android.vision.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import static net.gini.android.vision.test.Helpers.deleteFileOrFolder;
+
+import android.content.Context;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.test.InstrumentationRegistry;
+import android.support.v4.content.FileProvider;
+
+import net.gini.android.vision.test.Helpers;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+/**
+ * Created by Alpar Szotyori on 28.11.2017.
+ *
+ * Copyright (c) 2017 Gini GmbH.
+ */
+
+public class UriHelperTest {
+
+    private static final String TEST_FILE = "invoice.jpg";
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        setUpFileProvider();
+    }
+
+    private static void setUpFileProvider() throws IOException {
+        final File fileProviderDir = getFileProviderDir();
+        if (fileProviderDir.exists()) {
+            deleteFileOrFolder(fileProviderDir);
+        }
+        Files.createDirectories(fileProviderDir.toPath());
+        Helpers.copyAssetToStorage(TEST_FILE, fileProviderDir.getPath());
+    }
+
+    @NonNull
+    private static File getFileProviderDir() {
+        final Context context = InstrumentationRegistry.getTargetContext();
+        return new File(context.getFilesDir(), "file-provider");
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        tearDownFileProvider();
+    }
+
+    private static void tearDownFileProvider() throws IOException {
+        final File fileProviderDir = getFileProviderDir();
+        if (fileProviderDir.exists()) {
+            deleteFileOrFolder(fileProviderDir);
+        }
+    }
+
+    @Test
+    public void should_getFileSize_forContentUri() {
+        // Given
+        final Uri contentUri = getTestFileContentUri();
+        final int expectedSize = getTestFileSize();
+        // When
+        final int size = UriHelper.getFileSizeFromUri(contentUri,
+                InstrumentationRegistry.getTargetContext());
+        // Then
+        assertThat(size).isEqualTo(expectedSize);
+    }
+
+    private int getTestFileSize() {
+        File fileProviderDir = getFileProviderDir();
+        return (int) new File(fileProviderDir, TEST_FILE).length();
+    }
+
+    private Uri getTestFileContentUri() {
+        final File file = new File(getFileProviderDir(), TEST_FILE);
+        return FileProvider.getUriForFile(InstrumentationRegistry.getTargetContext(),
+                "net.gini.android.vision.test.fileprovider", file);
+    }
+
+    @Test
+    public void should_getFileSize_forFileUri() {
+        // Given
+        final Uri fileUri = getTestFileFileUri();
+        final int expectedSize = getTestFileSize();
+        // When
+        final int size = UriHelper.getFileSizeFromUri(fileUri,
+                InstrumentationRegistry.getTargetContext());
+        // Then
+        assertThat(size).isEqualTo(expectedSize);
+    }
+
+    private Uri getTestFileFileUri() {
+        File file = new File(getFileProviderDir(), TEST_FILE);
+        return Uri.parse(file.getPath());
+    }
+
+    @Test
+    public void should_getFilename_forContentUri() {
+        // Given
+        final Uri contentUri = getTestFileContentUri();
+        // When
+        final String filename = UriHelper.getFilenameFromUri(contentUri,
+                InstrumentationRegistry.getTargetContext());
+        // Then
+        assertThat(filename).isEqualTo(TEST_FILE);
+    }
+
+    @Test
+    public void should_getFilename_forFileUri() {
+        // Given
+        final Uri fileUri = getTestFileFileUri();
+        // When
+        final String filename = UriHelper.getFilenameFromUri(fileUri,
+                InstrumentationRegistry.getTargetContext());
+        // Then
+        assertThat(filename).isEqualTo(TEST_FILE);
+    }
+
+}

--- a/ginivision/src/androidTest/res/xml/filepaths.xml
+++ b/ginivision/src/androidTest/res/xml/filepaths.xml
@@ -1,0 +1,3 @@
+<paths>
+    <files-path path="file-provider/" name="fileprovider" />
+</paths>

--- a/ginivision/src/main/java/net/gini/android/vision/util/UriHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/util/UriHelper.java
@@ -7,7 +7,10 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.provider.OpenableColumns;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -84,10 +87,13 @@ public final class UriHelper {
      */
     @NonNull
     public static String getFilenameFromUri(@NonNull final Uri uri, @NonNull final Context context) {
-        Cursor cursor = null;
-        cursor = context.getContentResolver().query(uri, null, null, null, null);
+        final Cursor cursor = context.getContentResolver().query(uri, null, null, null, null);
         if (cursor == null) {
-            throw new IllegalStateException("Could not retrieve a Cursor for the Uri");
+            final String filename = getFilenameForPath(uri.getPath());
+            if (TextUtils.isEmpty(filename)) {
+                throw new IllegalStateException("Could not retrieve fhe filename");
+            }
+            return filename;
         }
         final int nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
         if (nameIndex == -1) {
@@ -99,20 +105,32 @@ public final class UriHelper {
         return filename;
     }
 
+    @Nullable
+    private static String getFilenameForPath(final String path) {
+        final File file = new File(path);
+        if (file.exists()) {
+            return file.getName();
+        }
+        return null;
+    }
+
     /**
      * Retrieves the file size of a Uri, if available.
      *
      * @param uri     a {@link Uri} pointing to a file
      * @param context Android context
      * @return the filename
-     * @throws IllegalStateException if the Uri is not pointing to a file or the filename was not
+     * @throws IllegalStateException if the Uri is not pointing to a file or the filesize was not
      *                               available
      */
     public static int getFileSizeFromUri(@NonNull final Uri uri, @NonNull final Context context) {
-        Cursor cursor = null;
-        cursor = context.getContentResolver().query(uri, null, null, null, null);
+        final Cursor cursor = context.getContentResolver().query(uri, null, null, null, null);
         if (cursor == null) {
-            throw new IllegalStateException("Could not retrieve a Cursor for the Uri");
+            final int size = getFileSizeForPath(uri.getPath());
+            if (size == 0) {
+                throw new IllegalStateException("Could not retrieve the file size");
+            }
+            return size;
         }
         final int nameIndex = cursor.getColumnIndex(OpenableColumns.SIZE);
         if (nameIndex == -1) {
@@ -122,6 +140,14 @@ public final class UriHelper {
         final int fileSize = cursor.getInt(nameIndex);
         cursor.close();
         return fileSize;
+    }
+
+    private static int getFileSizeForPath(final String path) {
+        final File file = new File(path);
+        if (file.exists()) {
+            return (int) file.length();
+        }
+        return 0;
     }
 
 }

--- a/ginivision/src/main/java/net/gini/android/vision/util/UriHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/util/UriHelper.java
@@ -127,7 +127,7 @@ public final class UriHelper {
         final Cursor cursor = context.getContentResolver().query(uri, null, null, null, null);
         if (cursor == null) {
             final int size = getFileSizeForPath(uri.getPath());
-            if (size == 0) {
+            if (size < 0) {
                 throw new IllegalStateException("Could not retrieve the file size");
             }
             return size;
@@ -147,7 +147,7 @@ public final class UriHelper {
         if (file.exists()) {
             return (int) file.length();
         }
-        return 0;
+        return -1;
     }
 
 }


### PR DESCRIPTION
Some apps share files by using a file Uri. For these querying the ContentResolver doesn't work and we have to use File to get the size and the filename.

### How to test
Run `UriHelperTest` and install one of the example apps on a device or emulator and send a file to the app with "open with".

### Merging
Nothing special.

### Ticket 
#122 
