### PR TITLE
Enable uploading of QR Codes to the Gini API

### DIFF
--- a/componentapiexample/build.gradle
+++ b/componentapiexample/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     compile 'com.github.tony19:logback-android-core:1.1.1-5'
     compile 'com.github.tony19:logback-android-classic:1.1.1-5'
 
-    compile('net.gini:gini-android-sdk:1.3.92@aar') {
+    compile('net.gini:gini-android-sdk:1.4.1@aar') {
         transitive = true
     }
 

--- a/componentapiexample/src/main/java/net/gini/android/vision/component/analysis/BaseAnalysisScreenHandler.java
+++ b/componentapiexample/src/main/java/net/gini/android/vision/component/analysis/BaseAnalysisScreenHandler.java
@@ -4,6 +4,7 @@ import static android.app.Activity.RESULT_OK;
 
 import static net.gini.android.vision.component.analysis.compat.AnalysisExampleAppCompatActivity.EXTRA_IN_DOCUMENT;
 import static net.gini.android.vision.component.analysis.compat.AnalysisExampleAppCompatActivity.EXTRA_IN_ERROR_MESSAGE;
+import static net.gini.android.vision.example.ExampleUtil.getExtractionsBundle;
 import static net.gini.android.vision.example.ExampleUtil.hasNoPay5Extractions;
 
 import android.app.Activity;
@@ -67,7 +68,7 @@ public abstract class BaseAnalysisScreenHandler implements AnalysisFragmentListe
         getSingleDocumentAnalyzer().analyzeDocument(document,
                 new DocumentAnalyzer.Listener() {
                     @Override
-                    public void onException(Exception exception) {
+                    public void onException(final Exception exception) {
                         mAnalysisFragmentInterface.stopScanAnimation();
                         String message = mActivity.getString(R.string.unknown_error);
                         if (exception.getMessage() != null) {
@@ -81,7 +82,7 @@ public abstract class BaseAnalysisScreenHandler implements AnalysisFragmentListe
                                 mActivity.getString(R.string.retry_analysis),
                                 new View.OnClickListener() {
                                     @Override
-                                    public void onClick(View v) {
+                                    public void onClick(final View v) {
                                         mAnalysisFragmentInterface.startScanAnimation();
                                         getSingleDocumentAnalyzer().cancelAnalysis();
                                         getSingleDocumentAnalyzer().analyzeDocument(document,
@@ -92,7 +93,8 @@ public abstract class BaseAnalysisScreenHandler implements AnalysisFragmentListe
                     }
 
                     @Override
-                    public void onExtractionsReceived(Map<String, SpecificExtraction> extractions) {
+                    public void onExtractionsReceived(
+                            final Map<String, SpecificExtraction> extractions) {
                         LOG.debug("Document analyzed in the Analysis Screen");
                         // Calling onDocumentAnalyzed() is important to notify the Analysis
                         // Fragment that the
@@ -113,8 +115,8 @@ public abstract class BaseAnalysisScreenHandler implements AnalysisFragmentListe
         return mSingleDocumentAnalyzer;
     }
 
-    private void showExtractions(net.gini.android.models.Document giniApiDocument,
-            Map<String, SpecificExtraction> extractions, Document document) {
+    private void showExtractions(final net.gini.android.models.Document giniApiDocument,
+            final Map<String, SpecificExtraction> extractions, final Document document) {
         LOG.debug("Show extractions");
         // If we have no Pay 5 extractions we query the Gini Vision Library
         // whether we should show the the Gini Vision No Results Screen
@@ -125,7 +127,7 @@ public abstract class BaseAnalysisScreenHandler implements AnalysisFragmentListe
             // for using the Gini Vision Library
             showNoResultsScreen(document);
         } else {
-            Intent intent = new Intent(mActivity, ExtractionsActivity.class);
+            final Intent intent = new Intent(mActivity, ExtractionsActivity.class);
             intent.putExtra(ExtractionsActivity.EXTRA_IN_DOCUMENT, giniApiDocument);
             intent.putExtra(ExtractionsActivity.EXTRA_IN_EXTRACTIONS,
                     getExtractionsBundle(extractions));
@@ -133,14 +135,6 @@ public abstract class BaseAnalysisScreenHandler implements AnalysisFragmentListe
             mActivity.setResult(Activity.RESULT_OK);
             mActivity.finish();
         }
-    }
-
-    private Bundle getExtractionsBundle(Map<String, SpecificExtraction> extractions) {
-        final Bundle extractionsBundle = new Bundle();
-        for (Map.Entry<String, SpecificExtraction> entry : extractions.entrySet()) {
-            extractionsBundle.putParcelable(entry.getKey(), entry.getValue());
-        }
-        return extractionsBundle;
     }
 
     private void showNoResultsScreen(final Document document) {

--- a/componentapiexample/src/main/java/net/gini/android/vision/component/camera/BaseCameraScreenHandler.java
+++ b/componentapiexample/src/main/java/net/gini/android/vision/component/camera/BaseCameraScreenHandler.java
@@ -131,6 +131,7 @@ public abstract class BaseCameraScreenHandler implements CameraFragmentListener,
                         final Intent intent = new Intent(mActivity, ExtractionsActivity.class);
                         intent.putExtra(ExtractionsActivity.EXTRA_IN_EXTRACTIONS,
                                 getExtractionsBundle(extractions));
+                        intent.putExtra(ExtractionsActivity.EXTRA_IN_DOCUMENT, getSingleDocumentAnalyzer().getGiniApiDocument());
                         mActivity.startActivity(intent);
                         mActivity.setResult(Activity.RESULT_OK);
                         mActivity.finish();

--- a/componentapiexample/src/main/java/net/gini/android/vision/component/camera/BaseCameraScreenHandler.java
+++ b/componentapiexample/src/main/java/net/gini/android/vision/component/camera/BaseCameraScreenHandler.java
@@ -121,7 +121,7 @@ public abstract class BaseCameraScreenHandler implements CameraFragmentListener,
                     @Override
                     public void onException(final Exception exception) {
                         mCameraFragmentInterface.hideActivityIndicatorAndEnableInteraction();
-                        mCameraFragmentInterface.showError("Could not use the QR Code. Try again or take a picture of your document.", 4000);
+                        mCameraFragmentInterface.showError(mActivity.getString(R.string.qrcode_error), 4000);
                     }
 
                     @Override

--- a/componentapiexample/src/main/java/net/gini/android/vision/component/camera/compat/CameraExampleAppCompatActivity.java
+++ b/componentapiexample/src/main/java/net/gini/android/vision/component/camera/compat/CameraExampleAppCompatActivity.java
@@ -9,12 +9,12 @@ import android.view.MenuItem;
 
 import net.gini.android.vision.Document;
 import net.gini.android.vision.GiniVisionError;
-import net.gini.android.vision.PaymentData;
 import net.gini.android.vision.camera.CameraFragmentCompat;
 import net.gini.android.vision.camera.CameraFragmentListener;
 import net.gini.android.vision.component.R;
 import net.gini.android.vision.component.analysis.compat.AnalysisExampleAppCompatActivity;
 import net.gini.android.vision.component.review.compat.ReviewExampleAppCompatActivity;
+import net.gini.android.vision.document.QRCodeDocument;
 import net.gini.android.vision.help.HelpActivity;
 import net.gini.android.vision.onboarding.OnboardingFragmentCompat;
 import net.gini.android.vision.onboarding.OnboardingFragmentListener;
@@ -89,8 +89,8 @@ public class CameraExampleAppCompatActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onPaymentDataAvailable(@NonNull final PaymentData paymentData) {
-        mCameraScreenHandler.onPaymentDataAvailable(paymentData);
+    public void onQRCodeAvailable(@NonNull final QRCodeDocument qrCodeDocument) {
+        mCameraScreenHandler.onQRCodeAvailable(qrCodeDocument);
     }
 
     @Override

--- a/componentapiexample/src/main/java/net/gini/android/vision/component/camera/standard/CameraExampleActivity.java
+++ b/componentapiexample/src/main/java/net/gini/android/vision/component/camera/standard/CameraExampleActivity.java
@@ -9,12 +9,12 @@ import android.view.MenuItem;
 
 import net.gini.android.vision.Document;
 import net.gini.android.vision.GiniVisionError;
-import net.gini.android.vision.PaymentData;
 import net.gini.android.vision.camera.CameraFragmentListener;
 import net.gini.android.vision.camera.CameraFragmentStandard;
 import net.gini.android.vision.component.R;
 import net.gini.android.vision.component.analysis.standard.AnalysisExampleActivity;
 import net.gini.android.vision.component.review.standard.ReviewExampleActivity;
+import net.gini.android.vision.document.QRCodeDocument;
 import net.gini.android.vision.help.HelpActivity;
 import net.gini.android.vision.onboarding.OnboardingFragmentListener;
 import net.gini.android.vision.onboarding.OnboardingFragmentStandard;
@@ -88,8 +88,8 @@ public class CameraExampleActivity extends Activity implements CameraFragmentLis
     }
 
     @Override
-    public void onPaymentDataAvailable(@NonNull final PaymentData paymentData) {
-        mCameraScreenHandler.onPaymentDataAvailable(paymentData);
+    public void onQRCodeAvailable(@NonNull final QRCodeDocument qrCodeDocument) {
+        mCameraScreenHandler.onQRCodeAvailable(qrCodeDocument);
     }
 
     @Override

--- a/componentapiexample/src/main/java/net/gini/android/vision/component/review/BaseReviewScreenHandler.java
+++ b/componentapiexample/src/main/java/net/gini/android/vision/component/review/BaseReviewScreenHandler.java
@@ -3,6 +3,7 @@ package net.gini.android.vision.component.review;
 import static android.app.Activity.RESULT_OK;
 
 import static net.gini.android.vision.component.review.compat.ReviewExampleAppCompatActivity.EXTRA_IN_DOCUMENT;
+import static net.gini.android.vision.example.ExampleUtil.getExtractionsBundle;
 import static net.gini.android.vision.example.ExampleUtil.hasNoPay5Extractions;
 
 import android.app.Activity;
@@ -72,7 +73,7 @@ public abstract class BaseReviewScreenHandler implements ReviewFragmentListener 
         getSingleDocumentAnalyzer().analyzeDocument(document,
                 new DocumentAnalyzer.Listener() {
                     @Override
-                    public void onException(Exception exception) {
+                    public void onException(final Exception exception) {
                         String message = mActivity.getString(R.string.unknown_error);
                         if (exception.getMessage() != null) {
                             message = exception.getMessage();
@@ -86,7 +87,8 @@ public abstract class BaseReviewScreenHandler implements ReviewFragmentListener 
                     }
 
                     @Override
-                    public void onExtractionsReceived(Map<String, SpecificExtraction> extractions) {
+                    public void onExtractionsReceived(
+                            final Map<String, SpecificExtraction> extractions) {
                         LOG.debug("Document analyzed in the Review Screen");
                         // Cache the extractions until the user clicks the next button and
                         // onDocumentReviewedAndAnalyzed()
@@ -130,8 +132,8 @@ public abstract class BaseReviewScreenHandler implements ReviewFragmentListener 
         }
     }
 
-    private void showExtractions(net.gini.android.models.Document giniApiDocument,
-            Map<String, SpecificExtraction> extractions, Document document) {
+    private void showExtractions(final net.gini.android.models.Document giniApiDocument,
+            final Map<String, SpecificExtraction> extractions, final Document document) {
         LOG.debug("Show extractions");
         // If we have no Pay 5 extractions we query the Gini Vision Library
         // whether we should show the the Gini Vision No Results Screen
@@ -142,7 +144,7 @@ public abstract class BaseReviewScreenHandler implements ReviewFragmentListener 
             // for using the Gini Vision Library
             showNoResultsScreen(document);
         } else {
-            Intent intent = new Intent(mActivity, ExtractionsActivity.class);
+            final Intent intent = new Intent(mActivity, ExtractionsActivity.class);
             intent.putExtra(ExtractionsActivity.EXTRA_IN_DOCUMENT, giniApiDocument);
             intent.putExtra(ExtractionsActivity.EXTRA_IN_EXTRACTIONS,
                     getExtractionsBundle(extractions));
@@ -150,14 +152,6 @@ public abstract class BaseReviewScreenHandler implements ReviewFragmentListener 
             mActivity.setResult(RESULT_OK);
             mActivity.finish();
         }
-    }
-
-    private Bundle getExtractionsBundle(Map<String, SpecificExtraction> extractions) {
-        final Bundle extractionsBundle = new Bundle();
-        for (Map.Entry<String, SpecificExtraction> entry : extractions.entrySet()) {
-            extractionsBundle.putParcelable(entry.getKey(), entry.getValue());
-        }
-        return extractionsBundle;
     }
 
     private void showNoResultsScreen(final Document document) {

--- a/componentapiexample/src/main/res/values/strings.xml
+++ b/componentapiexample/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="no_results_screen_subtitle">Wir haben ein paar Tipps für Sie</string>
     <string name="review_screen_title">Seite überprüfen</string>
     <string name="review_screen_subtitle">Vollständig, scharf und in Leserichtung?</string>
+    <string name="qrcode_error">Could not use the QR Code. Try again or take a picture of your document.</string>
 
     <!-- String customization examples -->
 

--- a/exampleShared/java/net/gini/android/vision/example/ExampleUtil.java
+++ b/exampleShared/java/net/gini/android/vision/example/ExampleUtil.java
@@ -3,13 +3,11 @@ package net.gini.android.vision.example;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
-import net.gini.android.models.Box;
-import net.gini.android.models.Extraction;
 import net.gini.android.models.SpecificExtraction;
-import net.gini.android.vision.PaymentData;
 
-import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 
 public final class ExampleUtil {
@@ -28,7 +26,7 @@ public final class ExampleUtil {
         return true;
     }
 
-    public static boolean isPay5Extraction(final String extractionName) {
+    private static boolean isPay5Extraction(final String extractionName) {
         return extractionName.equals("amountToPay") ||
                 extractionName.equals("bic") ||
                 extractionName.equals("iban") ||
@@ -36,31 +34,15 @@ public final class ExampleUtil {
                 extractionName.equals("paymentRecipient");
     }
 
-    public static Bundle getExtractionsBundle(@NonNull final PaymentData paymentData) {
+    public static Bundle getExtractionsBundle(@Nullable final Map<String, SpecificExtraction> extractions) {
+        if (extractions ==null) {
+            return null;
+        }
         final Bundle extractionsBundle = new Bundle();
-        extractionsBundle.putParcelable("paymentReference",
-                createSpecificExtraction("paymentReference",
-                        paymentData.getPaymentReference()));
-        extractionsBundle.putParcelable("paymentRecipient",
-                createSpecificExtraction("paymentRecipient",
-                        paymentData.getPaymentRecipient()));
-        extractionsBundle.putParcelable("amountToPay",
-                createSpecificExtraction("amountToPay",
-                        paymentData.getAmount()));
-        extractionsBundle.putParcelable("iban",
-                createSpecificExtraction("iban",
-                        paymentData.getIBAN()));
-        extractionsBundle.putParcelable("bic",
-                createSpecificExtraction("bic",
-                        paymentData.getBIC()));
+        for (final Map.Entry<String, SpecificExtraction> entry : extractions.entrySet()) {
+            extractionsBundle.putParcelable(entry.getKey(), entry.getValue());
+        }
         return extractionsBundle;
-    }
-
-    @NonNull
-    private static SpecificExtraction createSpecificExtraction(
-            final @NonNull String name, final @NonNull String value) {
-        return new SpecificExtraction(name, value, "", new Box(0, 0, 0, 0, 0),
-                Collections.<Extraction>emptyList());
     }
 
     private ExampleUtil() {

--- a/exampleShared/java/net/gini/android/vision/example/ExampleUtil.java
+++ b/exampleShared/java/net/gini/android/vision/example/ExampleUtil.java
@@ -26,7 +26,7 @@ public final class ExampleUtil {
         return true;
     }
 
-    private static boolean isPay5Extraction(final String extractionName) {
+    public static boolean isPay5Extraction(final String extractionName) {
         return extractionName.equals("amountToPay") ||
                 extractionName.equals("bic") ||
                 extractionName.equals("iban") ||

--- a/ginivision/src/androidTest/java/net/gini/android/vision/PaymentQRCodeDataTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/PaymentQRCodeDataTest.java
@@ -4,6 +4,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import android.support.test.runner.AndroidJUnit4;
 
+import net.gini.android.vision.internal.qrcode.PaymentQRCodeData;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -14,12 +16,12 @@ import org.junit.runner.RunWith;
  */
 
 @RunWith(AndroidJUnit4.class)
-public class PaymentDataTest {
+public class PaymentQRCodeDataTest {
 
     @Test
     public void should_writePaymentData_toJson() {
         // Given
-        final PaymentData paymentData = new PaymentData(
+        final PaymentQRCodeData paymentData = new PaymentQRCodeData(
                 "bank://singlepaymentsepa?name=GINI%20GMBH&reason=BezahlCode%20Test&iban=DE27100777770209299700&bic=DEUTDEMMXXX&amount=140%2C4",
                 "GINI GMBH",
                 "BezahlCode Test",
@@ -36,7 +38,7 @@ public class PaymentDataTest {
     @Test
     public void should_notWrite_emptyLabel_toPaymentDataJson() {
         // Given
-        final PaymentData paymentData = new PaymentData(
+        final PaymentQRCodeData paymentData = new PaymentQRCodeData(
                 "bank://singlepaymentsepa?name=GINI%20GMBH&reason=BezahlCode%20Test&iban=DE27100777770209299700&bic=DEUTDEMMXXX&amount=140%2C4",
                 "GINI GMBH",
                 "BezahlCode Test",

--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraActivityFake.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraActivityFake.java
@@ -3,7 +3,7 @@ package net.gini.android.vision.camera;
 import android.support.annotation.NonNull;
 
 import net.gini.android.vision.GiniVisionFeatureConfiguration;
-import net.gini.android.vision.PaymentData;
+import net.gini.android.vision.document.QRCodeDocument;
 import net.gini.android.vision.internal.camera.api.CameraControllerFake;
 
 /**
@@ -15,7 +15,7 @@ import net.gini.android.vision.internal.camera.api.CameraControllerFake;
 public class CameraActivityFake extends CameraActivity {
 
     private CameraFragmentCompatFake mCameraFragmentCompatFake;
-    private PaymentData mPaymentData;
+    private QRCodeDocument mQRCodeDocument;
 
     @Override
     protected CameraFragmentCompat createCameraFragmentCompat() {
@@ -30,8 +30,8 @@ public class CameraActivityFake extends CameraActivity {
     }
 
     @Override
-    public void onPaymentDataAvailable(@NonNull final PaymentData paymentData) {
-        mPaymentData = paymentData;
+    public void onQRCodeAvailable(@NonNull final QRCodeDocument qrCodeDocument) {
+        mQRCodeDocument = qrCodeDocument;
     }
 
     public CameraControllerFake getCameraControllerFake() {
@@ -42,7 +42,7 @@ public class CameraActivityFake extends CameraActivity {
         return mCameraFragmentCompatFake.getCameraFragmentImplFake();
     }
 
-    public PaymentData getPaymentData() {
-        return mPaymentData;
+    public QRCodeDocument getQRCodeDocument() {
+        return mQRCodeDocument;
     }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraFragmentImplFake.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraFragmentImplFake.java
@@ -30,7 +30,7 @@ public class CameraFragmentImplFake extends CameraFragmentImpl {
     }
 
     @Override
-    long getHidePaymentDataDetectedPopupDelayMs() {
+    long getHideQRCodeDetectedPopupDelayMs() {
         return CameraFragmentImpl.DEFAULT_ANIMATION_DURATION + mHidePaymentDataDetectedPopupDelayMs;
     }
 
@@ -40,7 +40,7 @@ public class CameraFragmentImplFake extends CameraFragmentImpl {
     }
 
     @Override
-    long getDifferentPaymentDataDetectedPopupDelayMs() {
+    long getDifferentQRCodeDetectedPopupDelayMs() {
         return 100;
     }
 

--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
@@ -46,13 +46,13 @@ import android.view.View;
 
 import net.gini.android.vision.DocumentImportEnabledFileTypes;
 import net.gini.android.vision.GiniVisionFeatureConfiguration;
-import net.gini.android.vision.PaymentData;
 import net.gini.android.vision.R;
 import net.gini.android.vision.analysis.AnalysisActivityTestSpy;
 import net.gini.android.vision.document.DocumentFactory;
 import net.gini.android.vision.document.QRCodeDocumentHelper;
 import net.gini.android.vision.internal.camera.api.CameraControllerFake;
 import net.gini.android.vision.internal.camera.photo.PhotoFactory;
+import net.gini.android.vision.internal.qrcode.PaymentQRCodeData;
 import net.gini.android.vision.onboarding.OnboardingActivity;
 import net.gini.android.vision.onboarding.OnboardingPage;
 import net.gini.android.vision.review.ReviewActivity;
@@ -459,7 +459,7 @@ public class CameraScreenTest {
     public void should_detectBezahlCode_andShowPopup_andReturnPaymentData_whenPopupClicked()
             throws IOException, InterruptedException {
         detectAndCheckQRCode("qrcode_bezahlcode.jpeg", "qrcode_bezahlcode_nv21.bmp",
-                new PaymentData(
+                new PaymentQRCodeData(
                         "bank://singlepaymentsepa?name=GINI%20GMBH&reason=BezahlCode%20Test&iban=DE27100777770209299700&bic=DEUTDEMMXXX&amount=140%2C4",
                         "GINI GMBH",
                         "BezahlCode Test",
@@ -469,7 +469,7 @@ public class CameraScreenTest {
     }
 
     private void detectAndCheckQRCode(@NonNull final String jpegFilename,
-            @NonNull final String nv21Filename, @NonNull final PaymentData paymentData)
+            @NonNull final String nv21Filename, @NonNull final PaymentQRCodeData paymentData)
             throws IOException, InterruptedException {
         // Given
         assumeTrue(!isTablet());
@@ -486,11 +486,11 @@ public class CameraScreenTest {
 
         // When
         Thread.sleep(PAUSE_DURATION);
-        Espresso.onView(ViewMatchers.withId(R.id.gv_payment_data_detected_popup_container))
+        Espresso.onView(ViewMatchers.withId(R.id.gv_qrcode_detected_popup_container))
                 .perform(ViewActions.click());
 
         // Then
-        final PaymentData actualPaymentData = QRCodeDocumentHelper.getPaymentData(
+        final PaymentQRCodeData actualPaymentData = QRCodeDocumentHelper.getPaymentData(
                 mCameraActivityFakeActivityTestRule.getActivity().getQRCodeDocument());
         assertThat(actualPaymentData).isEqualTo(paymentData);
     }
@@ -510,7 +510,7 @@ public class CameraScreenTest {
     public void should_detectEPC069_andShowPopup_andReturnPaymentData_whenPopupClicked()
             throws IOException, InterruptedException {
         detectAndCheckQRCode("qrcode_epc069_12.jpeg", "qrcode_epc069_12_nv21.bmp",
-                new PaymentData(
+                new PaymentQRCodeData(
                         "BCD\n001\n2\nSCT\nSOLADES1PFD\nGirosolution GmbH\nDE19690516200000581900\nEUR140.4\n\n\nBezahlCode Test",
                         "Girosolution GmbH",
                         "BezahlCode Test",
@@ -539,9 +539,9 @@ public class CameraScreenTest {
 
         // When
         final long hideDelay =
-                mCameraActivityFakeActivityTestRule.getActivity().getCameraFragmentImplFake().getHidePaymentDataDetectedPopupDelayMs();
+                mCameraActivityFakeActivityTestRule.getActivity().getCameraFragmentImplFake().getHideQRCodeDetectedPopupDelayMs();
         Thread.sleep(hideDelay + CameraFragmentImpl.DEFAULT_ANIMATION_DURATION + 200);
-        Espresso.onView(ViewMatchers.withId(R.id.gv_payment_data_detected_popup_container))
+        Espresso.onView(ViewMatchers.withId(R.id.gv_qrcode_detected_popup_container))
                 .check(ViewAssertions.matches(ViewMatchers.withAlpha(0)));
     }
 
@@ -569,7 +569,7 @@ public class CameraScreenTest {
                 cameraActivityFake.getCameraFragmentImplFake();
         Thread.sleep(CameraFragmentImpl.DEFAULT_ANIMATION_DURATION + 100);
         Mockito.verify(cameraFragmentImplFake, times(2))
-                .showPaymentDataDetectedPopup(anyLong());
+                .showQRCodeDetectedPopup(anyLong());
     }
 
     @Test
@@ -598,7 +598,7 @@ public class CameraScreenTest {
 
         // Then
         Thread.sleep(CameraFragmentImpl.DEFAULT_ANIMATION_DURATION + 100);
-        Espresso.onView(ViewMatchers.withId(R.id.gv_payment_data_detected_popup_container))
+        Espresso.onView(ViewMatchers.withId(R.id.gv_qrcode_detected_popup_container))
                 .check(ViewAssertions.matches(ViewMatchers.withAlpha(0)));
     }
 
@@ -629,7 +629,7 @@ public class CameraScreenTest {
 
         // Then
         Thread.sleep(CameraFragmentImpl.DEFAULT_ANIMATION_DURATION + 100);
-        Espresso.onView(ViewMatchers.withId(R.id.gv_payment_data_detected_popup_container))
+        Espresso.onView(ViewMatchers.withId(R.id.gv_qrcode_detected_popup_container))
                 .check(ViewAssertions.matches(ViewMatchers.withAlpha(0)));
     }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
@@ -50,6 +50,7 @@ import net.gini.android.vision.PaymentData;
 import net.gini.android.vision.R;
 import net.gini.android.vision.analysis.AnalysisActivityTestSpy;
 import net.gini.android.vision.document.DocumentFactory;
+import net.gini.android.vision.document.QRCodeDocumentHelper;
 import net.gini.android.vision.internal.camera.api.CameraControllerFake;
 import net.gini.android.vision.internal.camera.photo.PhotoFactory;
 import net.gini.android.vision.onboarding.OnboardingActivity;
@@ -489,8 +490,9 @@ public class CameraScreenTest {
                 .perform(ViewActions.click());
 
         // Then
-        assertThat(mCameraActivityFakeActivityTestRule.getActivity().getPaymentData())
-                .isEqualTo(paymentData);
+        final PaymentData actualPaymentData = QRCodeDocumentHelper.getPaymentData(
+                mCameraActivityFakeActivityTestRule.getActivity().getQRCodeDocument());
+        assertThat(actualPaymentData).isEqualTo(paymentData);
     }
 
     private void detectQRCode(

--- a/ginivision/src/androidTest/java/net/gini/android/vision/document/QRCodeDocumentHelper.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/document/QRCodeDocumentHelper.java
@@ -2,7 +2,7 @@ package net.gini.android.vision.document;
 
 import android.support.annotation.NonNull;
 
-import net.gini.android.vision.PaymentData;
+import net.gini.android.vision.internal.qrcode.PaymentQRCodeData;
 
 /**
  * Created by Alpar Szotyori on 12.01.2018.
@@ -11,7 +11,7 @@ import net.gini.android.vision.PaymentData;
  */
 public class QRCodeDocumentHelper {
 
-    public static PaymentData getPaymentData(@NonNull final QRCodeDocument qrCodeDocument) {
+    public static PaymentQRCodeData getPaymentData(@NonNull final QRCodeDocument qrCodeDocument) {
         return qrCodeDocument.getPaymentData();
     }
 

--- a/ginivision/src/androidTest/java/net/gini/android/vision/document/QRCodeDocumentHelper.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/document/QRCodeDocumentHelper.java
@@ -1,0 +1,20 @@
+package net.gini.android.vision.document;
+
+import android.support.annotation.NonNull;
+
+import net.gini.android.vision.PaymentData;
+
+/**
+ * Created by Alpar Szotyori on 12.01.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+public class QRCodeDocumentHelper {
+
+    public static PaymentData getPaymentData(@NonNull final QRCodeDocument qrCodeDocument) {
+        return qrCodeDocument.getPaymentData();
+    }
+
+    private QRCodeDocumentHelper() {
+    }
+}

--- a/ginivision/src/main/java/net/gini/android/vision/Document.java
+++ b/ginivision/src/main/java/net/gini/android/vision/Document.java
@@ -114,6 +114,10 @@ public interface Document extends Parcelable {
         /**
          * The document is a PDF.
          */
-        PDF
+        PDF,
+        /**
+         * The document is a payment QR Code.
+         */
+        QRCode
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/Document.java
+++ b/ginivision/src/main/java/net/gini/android/vision/Document.java
@@ -61,7 +61,7 @@ public interface Document extends Parcelable {
      * The contents of a document, if the document was loaded into memory.
      * </p>
      * <p>
-     *     For photos captured with the camera this is never null.
+     *     For photos captured with the camera or for QR Codes this is never null.
      * </p>
      * <p>
      *     If {@link Document#isImported()} is {@code true} then this might be null. If it's null you can use {@link Document#getIntent()} and access the contents using the Intent.

--- a/ginivision/src/main/java/net/gini/android/vision/PaymentData.java
+++ b/ginivision/src/main/java/net/gini/android/vision/PaymentData.java
@@ -1,5 +1,7 @@
 package net.gini.android.vision;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
@@ -26,7 +28,7 @@ import java.io.StringWriter;
  * (<a href="https://www.stuzza.at/de/zahlungsverkehr/qr-code.html">Stuzza (AT)</a> and <a href="https://www.girocode.de/rechnungsempfaenger/">GiroCode (DE)</a>)
  * QRCodes are detected and read.
  */
-public class PaymentData {
+public class PaymentData implements Parcelable {
 
     private static final Logger LOG = LoggerFactory.getLogger(PaymentData.class);
 
@@ -167,4 +169,40 @@ public class PaymentData {
         result = 31 * result + (mPaymentReference != null ? mPaymentReference.hashCode() : 0);
         return result;
     }
+
+    private PaymentData(final Parcel in) {
+        mUnparsedContent = in.readString();
+        mAmount = in.readString();
+        mBIC = in.readString();
+        mIBAN = in.readString();
+        mPaymentRecipient = in.readString();
+        mPaymentReference = in.readString();
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull final Parcel dest, final int flags) {
+        dest.writeString(mUnparsedContent);
+        dest.writeString(mAmount);
+        dest.writeString(mBIC);
+        dest.writeString(mIBAN);
+        dest.writeString(mPaymentRecipient);
+        dest.writeString(mPaymentReference);
+    }
+
+    public static final Creator<PaymentData> CREATOR = new Creator<PaymentData>() {
+        @Override
+        public PaymentData createFromParcel(final Parcel in) {
+            return new PaymentData(in);
+        }
+
+        @Override
+        public PaymentData[] newArray(final int size) {
+            return new PaymentData[size];
+        }
+    };
 }

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
@@ -152,26 +152,26 @@ import java.util.ArrayList;
  *         gvCustomFont} with the path to the font file in your {@code assets} folder
  *     </li>
  *     <li>
- *         <b>Payment data (QRCode) detected popup background:</b> via the color resource named {@code gv_payment_data_detected_popup_background}
+ *         <b>QRCode detected popup background:</b> via the color resource named {@code gv_qrcode_detected_popup_background}
  *     </li>
  *     <li>
- *         <b>Payment data (QRCode) detected popup texts:</b> via the string resources named {@code gv_payment_data_detected_popup_message_1} and
- *         {@code gv_payment_data_detected_popup_message_2}
+ *         <b>QRCode detected popup texts:</b> via the string resources named {@code gv_qrcode_detected_popup_message_1} and
+ *         {@code gv_qrcode_detected_popup_message_2}
  *     </li>
  *     <li>
- *         <b>Payment data (QRCode) detected popup text sizes:</b>  via overriding the styles named {@code
- *         GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message1.TextStyle} and {@code
- *         GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message2.TextStyle} and setting an item named {@code
+ *         <b>QRCode detected popup text sizes:</b>  via overriding the styles named {@code
+ *         GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle} and {@code
+ *         GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle} and setting an item named {@code
  *         android:textSize} with the desired {@code sp} size
  *     </li>
  *     <li>
- *         <b>Payment data (QRCode) detected popup text colors:</b> via the color resource name {@code gv_payment_data_detected_popup_message_1} and
- *         {@code gv_payment_data_detected_popup_message_2}
+ *         <b>QRCode detected popup text colors:</b> via the color resource name {@code gv_qrcode_detected_popup_message_1} and
+ *         {@code gv_qrcode_detected_popup_message_2}
  *     </li>
  *     <li>
- *         <b>Payment data (QRCode) detected popup fonts:</b>  via overriding the styles named {@code
- *         GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message1.TextStyle} and {@code
- *         GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message2.TextStyle} and setting an item named {@code
+ *         <b>QRCode detected popup fonts:</b>  via overriding the styles named {@code
+ *         GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle} and {@code
+ *         GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle} and setting an item named {@code
  *         gvCustomFont} with the path to the font file in your {@code assets} folder
  *     </li>
  *     <li>

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
@@ -17,9 +17,9 @@ import net.gini.android.vision.DocumentImportEnabledFileTypes;
 import net.gini.android.vision.GiniVisionCoordinator;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.GiniVisionFeatureConfiguration;
-import net.gini.android.vision.PaymentData;
 import net.gini.android.vision.R;
 import net.gini.android.vision.analysis.AnalysisActivity;
+import net.gini.android.vision.document.QRCodeDocument;
 import net.gini.android.vision.help.HelpActivity;
 import net.gini.android.vision.internal.util.ActivityHelper;
 import net.gini.android.vision.onboarding.OnboardingActivity;
@@ -297,7 +297,8 @@ import java.util.ArrayList;
  * </ul>
  * </p>
  **/
-public class CameraActivity extends AppCompatActivity implements CameraFragmentListener {
+public class CameraActivity extends AppCompatActivity implements CameraFragmentListener,
+        CameraFragmentInterface {
 
     /**
      * <p>
@@ -639,7 +640,7 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
     }
 
     @Override
-    public void onPaymentDataAvailable(@NonNull final PaymentData paymentData) {
+    public void onQRCodeAvailable(@NonNull final QRCodeDocument qrCodeDocument) {
 
     }
 
@@ -698,12 +699,49 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
         }
     }
 
-    private void showInterface() {
+    @Override
+    public void showDocumentCornerGuides() {
+        mFragment.showDocumentCornerGuides();
+    }
+
+    @Override
+    public void hideDocumentCornerGuides() {
+        mFragment.hideDocumentCornerGuides();
+    }
+
+    @Override
+    public void showCameraTriggerButton() {
+        mFragment.showCameraTriggerButton();
+    }
+
+    @Override
+    public void hideCameraTriggerButton() {
+        mFragment.hideCameraTriggerButton();
+    }
+
+    @Override
+    public void showInterface() {
         mFragment.showInterface();
     }
 
-    private void hideInterface() {
+    @Override
+    public void hideInterface() {
         mFragment.hideInterface();
+    }
+
+    @Override
+    public void showActivityIndicatorAndDisableInteraction() {
+        mFragment.showActivityIndicatorAndDisableInteraction();
+    }
+
+    @Override
+    public void hideActivityIndicatorAndEnableInteraction() {
+        mFragment.hideActivityIndicatorAndEnableInteraction();
+    }
+
+    @Override
+    public void showError(@NonNull final String message, final int duration) {
+        mFragment.showError(message, duration);
     }
 
     private void clearMemory() {

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentCompat.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentCompat.java
@@ -198,6 +198,21 @@ public class CameraFragmentCompat extends Fragment implements CameraFragmentInte
     }
 
     @Override
+    public void showActivityIndicatorAndDisableInteraction() {
+        mFragmentImpl.showActivityIndicatorAndDisableInteraction();
+    }
+
+    @Override
+    public void hideActivityIndicatorAndEnableInteraction() {
+        mFragmentImpl.hideActivityIndicatorAndEnableInteraction();
+    }
+
+    @Override
+    public void showError(@NonNull final String message, final int duration) {
+        mFragmentImpl.showError(message, duration);
+    }
+
+    @Override
     public void requestPermission(@NonNull final String permission,
             @NonNull final PermissionRequestListener listener) {
         mRuntimePermissions.requestPermission(this, permission, listener);

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -44,7 +44,6 @@ import net.gini.android.vision.Document;
 import net.gini.android.vision.DocumentImportEnabledFileTypes;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.GiniVisionFeatureConfiguration;
-import net.gini.android.vision.PaymentData;
 import net.gini.android.vision.R;
 import net.gini.android.vision.document.DocumentFactory;
 import net.gini.android.vision.document.GiniVisionDocument;
@@ -57,6 +56,7 @@ import net.gini.android.vision.internal.camera.photo.Photo;
 import net.gini.android.vision.internal.camera.view.CameraPreviewSurface;
 import net.gini.android.vision.internal.fileimport.FileChooserActivity;
 import net.gini.android.vision.internal.permission.PermissionRequestListener;
+import net.gini.android.vision.internal.qrcode.PaymentQRCodeData;
 import net.gini.android.vision.internal.qrcode.PaymentQRCodeReader;
 import net.gini.android.vision.internal.qrcode.QRCodeDetectorTask;
 import net.gini.android.vision.internal.qrcode.QRCodeDetectorTaskGoogleVision;
@@ -80,8 +80,8 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     private static final String GV_SHARED_PREFS = "GV_SHARED_PREFS";
     @VisibleForTesting
     static final int DEFAULT_ANIMATION_DURATION = 200;
-    private static final long HIDE_PAYMENT_DATA_DETECTED_POPUP_DELAY_MS = 10000;
-    private static final long DIFFERENT_PAYMENT_DATA_DETECTED_POPUP_DELAY_MS = 200;
+    private static final long HIDE_QRCODE_DETECTED_POPUP_DELAY_MS = 10000;
+    private static final long DIFFERENT_QRCODE_DETECTED_POPUP_DELAY_MS = 200;
     private static final Logger LOG = LoggerFactory.getLogger(CameraFragmentImpl.class);
 
     private static final CameraFragmentListener NO_OP_LISTENER = new CameraFragmentListener() {
@@ -110,7 +110,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
 
     private final CameraFragmentImplCallback mFragment;
     private final GiniVisionFeatureConfiguration mGiniVisionFeatureConfiguration;
-    private HidePaymentDataDetectedRunnable mHidePaymentDataDetectedPopupRunnable;
+    private HideQRCodeDetectedRunnable mHideQRCodeDetectedPopupRunnable;
 
     private View mImageCorners;
     private boolean mInterfaceHidden = false;
@@ -125,8 +125,8 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     private ImageButton mButtonCameraTrigger;
     private LinearLayout mLayoutNoPermission;
     private ImageButton mButtonImportDocument;
-    private View mPaymentDataDetectedPopupContainer;
-    private PaymentData mPaymentData;
+    private View mQRCodeDetectedPopupContainer;
+    private PaymentQRCodeData mPaymentQRCodeData;
     private View mUploadHintCloseButton;
     private View mUploadHintContainer;
     private View mUploadHintContainerArrow;
@@ -136,7 +136,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     private ViewPropertyAnimatorCompat mUploadHintContainerArrowAnimation;
     private ViewPropertyAnimatorCompat mCameraPreviewShadeAnimation;
     private ViewPropertyAnimatorCompat mUploadHintContainerAnimation;
-    private ViewPropertyAnimatorCompat mPaymentDataDetectedPopupAnimation;
+    private ViewPropertyAnimatorCompat mQRCodeDetectedPopupAnimation;
 
     private ViewStubSafeInflater mViewStubInflater;
 
@@ -156,12 +156,12 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     }
 
     @Override
-    public void onPaymentDataAvailable(@NonNull final PaymentData paymentData) {
+    public void onPaymentQRCodeDataAvailable(@NonNull final PaymentQRCodeData paymentQRCodeData) {
         if (mUploadHintContainer.getVisibility() == View.VISIBLE
                 || mInterfaceHidden
                 || mActivityIndicator.getVisibility() == View.VISIBLE) {
-            hidePaymentDataDetectedPopup(null);
-            mPaymentData = null;
+            hideQRCodeDetectedPopup(null);
+            mPaymentQRCodeData = null;
             return;
         }
 
@@ -170,95 +170,97 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
             return;
         }
 
-        if (mPaymentData == null
-                || mPaymentDataDetectedPopupContainer.getVisibility() == View.GONE) {
-            showPaymentDataDetectedPopup(0);
-            view.removeCallbacks(mHidePaymentDataDetectedPopupRunnable);
-            view.postDelayed(mHidePaymentDataDetectedPopupRunnable,
-                    getHidePaymentDataDetectedPopupDelayMs());
+        if (mPaymentQRCodeData == null
+                || mQRCodeDetectedPopupContainer.getVisibility() == View.GONE) {
+            showQRCodeDetectedPopup(0);
+            view.removeCallbacks(mHideQRCodeDetectedPopupRunnable);
+            view.postDelayed(mHideQRCodeDetectedPopupRunnable,
+                    getHideQRCodeDetectedPopupDelayMs());
         } else {
-            if (mPaymentData.equals(paymentData)) {
-                view.removeCallbacks(mHidePaymentDataDetectedPopupRunnable);
-                view.postDelayed(mHidePaymentDataDetectedPopupRunnable,
-                        getHidePaymentDataDetectedPopupDelayMs());
+            if (mPaymentQRCodeData.equals(paymentQRCodeData)) {
+                view.removeCallbacks(mHideQRCodeDetectedPopupRunnable);
+                view.postDelayed(mHideQRCodeDetectedPopupRunnable,
+                        getHideQRCodeDetectedPopupDelayMs());
             } else {
-                view.removeCallbacks(mHidePaymentDataDetectedPopupRunnable);
-                hidePaymentDataDetectedPopup(new ViewPropertyAnimatorListenerAdapter() {
+                view.removeCallbacks(mHideQRCodeDetectedPopupRunnable);
+                hideQRCodeDetectedPopup(new ViewPropertyAnimatorListenerAdapter() {
                     @Override
                     public void onAnimationEnd(final View view) {
-                        showPaymentDataDetectedPopup(
-                                getDifferentPaymentDataDetectedPopupDelayMs());
+                        showQRCodeDetectedPopup(
+                                getDifferentQRCodeDetectedPopupDelayMs());
                     }
                 });
             }
         }
-        mPaymentData = paymentData;
+        mPaymentQRCodeData = paymentQRCodeData;
     }
 
-    long getHidePaymentDataDetectedPopupDelayMs() {
-        return HIDE_PAYMENT_DATA_DETECTED_POPUP_DELAY_MS;
+    @VisibleForTesting
+    long getHideQRCodeDetectedPopupDelayMs() {
+        return HIDE_QRCODE_DETECTED_POPUP_DELAY_MS;
     }
 
-    long getDifferentPaymentDataDetectedPopupDelayMs() {
-        return DIFFERENT_PAYMENT_DATA_DETECTED_POPUP_DELAY_MS;
+    @VisibleForTesting
+    long getDifferentQRCodeDetectedPopupDelayMs() {
+        return DIFFERENT_QRCODE_DETECTED_POPUP_DELAY_MS;
     }
 
-    private class HidePaymentDataDetectedRunnable implements Runnable {
+    private class HideQRCodeDetectedRunnable implements Runnable {
 
         @Override
         public void run() {
-            hidePaymentDataDetectedPopup(null);
-            mPaymentData = null;
+            hideQRCodeDetectedPopup(null);
+            mPaymentQRCodeData = null;
         }
     }
 
     @VisibleForTesting
-    void showPaymentDataDetectedPopup(final long startDelay) {
-        if (mPaymentDataDetectedPopupContainer.getAlpha() != 0) {
+    void showQRCodeDetectedPopup(final long startDelay) {
+        if (mQRCodeDetectedPopupContainer.getAlpha() != 0) {
             return;
         }
-        clearPaymentDataDetectedPopUpAnimation();
-        mPaymentDataDetectedPopupContainer.setVisibility(View.VISIBLE);
-        mPaymentDataDetectedPopupAnimation = ViewCompat.animate(mPaymentDataDetectedPopupContainer)
+        clearQRCodeDetectedPopUpAnimation();
+        mQRCodeDetectedPopupContainer.setVisibility(View.VISIBLE);
+        mQRCodeDetectedPopupAnimation = ViewCompat.animate(mQRCodeDetectedPopupContainer)
                 .alpha(1.0f)
                 .setStartDelay(startDelay)
                 .setDuration(DEFAULT_ANIMATION_DURATION);
-        mPaymentDataDetectedPopupAnimation.start();
+        mQRCodeDetectedPopupAnimation.start();
     }
 
-    private void hidePaymentDataDetectedPopup(
+    private void hideQRCodeDetectedPopup(
             @Nullable final ViewPropertyAnimatorListener animatorListener) {
-        if (mPaymentDataDetectedPopupContainer.getAlpha() != 1) {
+        if (mQRCodeDetectedPopupContainer.getAlpha() != 1) {
             if (animatorListener != null) {
-                animatorListener.onAnimationEnd(mPaymentDataDetectedPopupContainer);
+                animatorListener.onAnimationEnd(mQRCodeDetectedPopupContainer);
             }
             return;
         }
-        clearPaymentDataDetectedPopUpAnimation();
-        mPaymentDataDetectedPopupAnimation = ViewCompat.animate(mPaymentDataDetectedPopupContainer)
+        clearQRCodeDetectedPopUpAnimation();
+        mQRCodeDetectedPopupAnimation = ViewCompat.animate(mQRCodeDetectedPopupContainer)
                 .alpha(0.0f)
                 .setDuration(DEFAULT_ANIMATION_DURATION)
                 .setListener(new ViewPropertyAnimatorListenerAdapter() {
                     @Override
                     public void onAnimationEnd(final View view) {
-                        mPaymentDataDetectedPopupContainer.setVisibility(View.GONE);
+                        mQRCodeDetectedPopupContainer.setVisibility(View.GONE);
                         if (animatorListener != null) {
                             animatorListener.onAnimationEnd(view);
                         }
                     }
                 });
-        mPaymentDataDetectedPopupAnimation.start();
+        mQRCodeDetectedPopupAnimation.start();
     }
 
-    private void clearPaymentDataDetectedPopUpAnimation() {
-        if (mPaymentDataDetectedPopupAnimation != null) {
-            mPaymentDataDetectedPopupAnimation.cancel();
-            mPaymentDataDetectedPopupContainer.clearAnimation();
-            mPaymentDataDetectedPopupAnimation.setListener(null);
+    private void clearQRCodeDetectedPopUpAnimation() {
+        if (mQRCodeDetectedPopupAnimation != null) {
+            mQRCodeDetectedPopupAnimation.cancel();
+            mQRCodeDetectedPopupContainer.clearAnimation();
+            mQRCodeDetectedPopupAnimation.setListener(null);
         }
         final View view = mFragment.getView();
         if (view != null) {
-            view.removeCallbacks(mHidePaymentDataDetectedPopupRunnable);
+            view.removeCallbacks(mHideQRCodeDetectedPopupRunnable);
         }
     }
 
@@ -295,7 +297,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         initViews();
         initCameraController(activity);
         if (mGiniVisionFeatureConfiguration.isQRCodeScanningEnabled()) {
-            mHidePaymentDataDetectedPopupRunnable = new HidePaymentDataDetectedRunnable();
+            mHideQRCodeDetectedPopupRunnable = new HideQRCodeDetectedRunnable();
             initQRCodeReader(activity);
         }
 
@@ -528,7 +530,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     void onStop() {
         closeCamera();
         clearUploadHintPopUpAnimations();
-        clearPaymentDataDetectedPopUpAnimation();
+        clearQRCodeDetectedPopUpAnimation();
     }
 
     private void closeCamera() {
@@ -560,8 +562,8 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         mActivityIndicatorBackground =
                 view.findViewById(R.id.gv_activity_indicator_background);
         mActivityIndicator = view.findViewById(R.id.gv_activity_indicator);
-        mPaymentDataDetectedPopupContainer = view.findViewById(
-                R.id.gv_payment_data_detected_popup_container);
+        mQRCodeDetectedPopupContainer = view.findViewById(
+                R.id.gv_qrcode_detected_popup_container);
     }
 
     private void initViews() {
@@ -644,15 +646,15 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                 closeUploadHintPopUp();
             }
         });
-        mPaymentDataDetectedPopupContainer.setOnClickListener(new View.OnClickListener() {
+        mQRCodeDetectedPopupContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(final View v) {
-                hidePaymentDataDetectedPopup(null);
-                if (mPaymentData != null) {
-                        final QRCodeDocument qrCodeDocument = QRCodeDocument.fromPaymentData(
-                                mPaymentData);
+                hideQRCodeDetectedPopup(null);
+                if (mPaymentQRCodeData != null) {
+                        final QRCodeDocument qrCodeDocument = QRCodeDocument.fromPaymentQRCodeData(
+                                mPaymentQRCodeData);
                         mListener.onQRCodeAvailable(qrCodeDocument);
-                        mPaymentData = null;
+                        mPaymentQRCodeData = null;
                 }
             }
         });

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentInterface.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentInterface.java
@@ -83,17 +83,24 @@ public interface CameraFragmentInterface {
     void hideInterface();
 
     /**
-     * TODO: documentation
+     * <p>
+     *     Call this method to show an activity indicator and disable user interaction.
+     *     The camera preview remains visible.
+     * </p>
      */
     void showActivityIndicatorAndDisableInteraction();
 
     /**
-     * TODO: documentation
+     * <p>
+     *     Call this method to hide the activity indicator and enable user interaction.
+     * </p>
      */
     void hideActivityIndicatorAndEnableInteraction();
 
     /**
-     * TODO: documentation
+     * <p>
+     * Call this method when to show an error message to the user in the Camera Screen.
+     * </p>
      *
      * @param message  a short error message
      * @param duration how long should the error message be shown in ms

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentInterface.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentInterface.java
@@ -99,7 +99,7 @@ public interface CameraFragmentInterface {
 
     /**
      * <p>
-     * Call this method when to show an error message to the user in the Camera Screen.
+     *     Call this method when to show an error message to the user in the Camera Screen.
      * </p>
      *
      * @param message  a short error message

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentInterface.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentInterface.java
@@ -1,5 +1,7 @@
 package net.gini.android.vision.camera;
 
+import android.support.annotation.NonNull;
+
 /**
  * <p>
  *     Methods which both Camera Fragments must implement.
@@ -79,4 +81,22 @@ public interface CameraFragmentInterface {
      *
      */
     void hideInterface();
+
+    /**
+     * TODO: documentation
+     */
+    void showActivityIndicatorAndDisableInteraction();
+
+    /**
+     * TODO: documentation
+     */
+    void hideActivityIndicatorAndEnableInteraction();
+
+    /**
+     * TODO: documentation
+     *
+     * @param message  a short error message
+     * @param duration how long should the error message be shown in ms
+     */
+    void showError(@NonNull String message, int duration);
 }

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentInterface.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentInterface.java
@@ -99,7 +99,7 @@ public interface CameraFragmentInterface {
 
     /**
      * <p>
-     *     Call this method when to show an error message to the user in the Camera Screen.
+     *     Call this method to show an error message to the user in the Camera Screen.
      * </p>
      *
      * @param message  a short error message

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentListener.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentListener.java
@@ -4,8 +4,8 @@ import android.support.annotation.NonNull;
 
 import net.gini.android.vision.Document;
 import net.gini.android.vision.GiniVisionError;
-import net.gini.android.vision.PaymentData;
 import net.gini.android.vision.document.QRCodeDocument;
+import net.gini.android.vision.internal.qrcode.PaymentQRCodeData;
 
 /**
  * <p>
@@ -29,7 +29,7 @@ public interface CameraFragmentListener {
      *     close the Gini Vision Library and continue to your app's transfer form.
      * </p>
      * <p>
-     *      See {@link PaymentData} for supported formats.
+     *      See {@link PaymentQRCodeData} for supported formats.
      * </p>
      *
      * @param qrCodeDocument {@link Document} instance containing payment data from a QR Code

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentListener.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentListener.java
@@ -5,7 +5,6 @@ import android.support.annotation.NonNull;
 import net.gini.android.vision.Document;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.document.QRCodeDocument;
-import net.gini.android.vision.internal.qrcode.PaymentQRCodeData;
 
 /**
  * <p>
@@ -29,10 +28,10 @@ public interface CameraFragmentListener {
      *     close the Gini Vision Library and continue to your app's transfer form.
      * </p>
      * <p>
-     *      See {@link PaymentQRCodeData} for supported formats.
+     *      See {@link QRCodeDocument} for supported formats.
      * </p>
      *
-     * @param qrCodeDocument {@link Document} instance containing payment data from a QR Code
+     * @param qrCodeDocument contains payment data from a QR Code
      */
     void onQRCodeAvailable(@NonNull QRCodeDocument qrCodeDocument);
 

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentListener.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentListener.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import net.gini.android.vision.Document;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.PaymentData;
+import net.gini.android.vision.document.QRCodeDocument;
 
 /**
  * <p>
@@ -23,18 +24,17 @@ public interface CameraFragmentListener {
 
     /**
      * <p>
-     *     Called when the user clicked the payment data detected popup. You should check the data,
-     *     close the Gini Vision Library and continue to your app's transfer form, if all the needed
-     *     information was present. Otherwise you may show a message informing the user about missing
-     *     data and wait until {@link CameraFragmentListener#onDocumentAvailable(Document)} is called.
+     *     Called when the user clicked the QR Code detected popup.
+     *     You should upload the {@link QRCodeDocument}'s data to the Gini API to get the extractions,
+     *     close the Gini Vision Library and continue to your app's transfer form.
      * </p>
      * <p>
      *      See {@link PaymentData} for supported formats.
      * </p>
      *
-     * @param paymentData extracted payment data
+     * @param qrCodeDocument {@link Document} instance containing payment data from a QR Code
      */
-    void onPaymentDataAvailable(@NonNull PaymentData paymentData);
+    void onQRCodeAvailable(@NonNull QRCodeDocument qrCodeDocument);
 
     /**
      * <p>

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentStandard.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentStandard.java
@@ -207,6 +207,21 @@ public class CameraFragmentStandard extends Fragment implements CameraFragmentIn
     }
 
     @Override
+    public void showActivityIndicatorAndDisableInteraction() {
+        mFragmentImpl.showActivityIndicatorAndDisableInteraction();
+    }
+
+    @Override
+    public void hideActivityIndicatorAndEnableInteraction() {
+        mFragmentImpl.hideActivityIndicatorAndEnableInteraction();
+    }
+
+    @Override
+    public void showError(@NonNull final String message, final int duration) {
+        mFragmentImpl.showError(message, duration);
+    }
+
+    @Override
     public void requestPermission(@NonNull final String permission,
             @NonNull final PermissionRequestListener listener) {
         mRuntimePermissions.requestPermission(this, permission, listener);

--- a/ginivision/src/main/java/net/gini/android/vision/document/QRCodeDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/QRCodeDocument.java
@@ -1,0 +1,77 @@
+package net.gini.android.vision.document;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
+
+import net.gini.android.vision.PaymentData;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ * Created by Alpar Szotyori on 12.01.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+
+public class QRCodeDocument extends GiniVisionDocument {
+
+    private static final Logger LOG = LoggerFactory.getLogger(QRCodeDocument.class);
+
+    public static QRCodeDocument fromPaymentData(@NonNull final PaymentData paymentData) {
+        byte[] jsonBytes = new byte[]{};
+        try {
+            jsonBytes = paymentData.toJson().getBytes("UTF-8");
+        } catch (final UnsupportedEncodingException e) {
+            LOG.error("UTF-8 encoding not available", e);
+        }
+        return new QRCodeDocument(jsonBytes, paymentData);
+    }
+
+    private final PaymentData mPaymentData;
+
+    private QRCodeDocument(@NonNull final byte[] data, @NonNull final PaymentData paymentData) {
+        super(Type.QRCode, data, null, false, false);
+        mPaymentData = paymentData;
+    }
+
+    private QRCodeDocument(final Parcel in) {
+        super(in);
+        mPaymentData = in.readParcelable(PaymentData.class.getClassLoader());
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull final Parcel dest, final int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeParcelable(mPaymentData, flags);
+    }
+
+    public static final Creator<QRCodeDocument> CREATOR = new Parcelable.Creator<QRCodeDocument>() {
+        @Override
+        public QRCodeDocument createFromParcel(final Parcel in) {
+            return new QRCodeDocument(in);
+        }
+
+        @Override
+        public QRCodeDocument[] newArray(final int size) {
+            return new QRCodeDocument[size];
+        }
+    };
+
+    /**
+     * @exclude
+     */
+    @VisibleForTesting
+    PaymentData getPaymentData() {
+        return mPaymentData;
+    }
+}

--- a/ginivision/src/main/java/net/gini/android/vision/document/QRCodeDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/QRCodeDocument.java
@@ -18,6 +18,17 @@ import java.io.UnsupportedEncodingException;
  * Copyright (c) 2018 Gini GmbH.
  */
 
+/**
+ * Contains payment information required for transactions that were parsed from a document with a QR Code.
+ * <p>
+ * Payment data from
+ * <a href="http://www.bezahlcode.de/wp-content/uploads/BezahlCode_TechDok.pdf">BezahlCode</a>
+ * and <a href="https://www.europeanpaymentscouncil.eu/document-library/guidance-documents/quick-response-code-guidelines-enable-data-capture-initiation">EPC069-12</a>
+ * (<a href="https://www.stuzza.at/de/zahlungsverkehr/qr-code.html">Stuzza (AT)</a> and <a href="https://www.girocode.de/rechnungsempfaenger/">GiroCode (DE)</a>)
+ * QRCodes are detected and read.
+ * <p>
+ * Get the contents with ({@link QRCodeDocument#getData()}) and upload it to the Gini API to get the extractions.
+ */
 public class QRCodeDocument extends GiniVisionDocument {
 
     private static final Logger LOG = LoggerFactory.getLogger(QRCodeDocument.class);

--- a/ginivision/src/main/java/net/gini/android/vision/document/QRCodeDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/QRCodeDocument.java
@@ -5,7 +5,7 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
-import net.gini.android.vision.PaymentData;
+import net.gini.android.vision.internal.qrcode.PaymentQRCodeData;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,26 +22,26 @@ public class QRCodeDocument extends GiniVisionDocument {
 
     private static final Logger LOG = LoggerFactory.getLogger(QRCodeDocument.class);
 
-    public static QRCodeDocument fromPaymentData(@NonNull final PaymentData paymentData) {
+    public static QRCodeDocument fromPaymentQRCodeData(@NonNull final PaymentQRCodeData paymentQRCodeData) {
         byte[] jsonBytes = new byte[]{};
         try {
-            jsonBytes = paymentData.toJson().getBytes("UTF-8");
+            jsonBytes = paymentQRCodeData.toJson().getBytes("UTF-8");
         } catch (final UnsupportedEncodingException e) {
             LOG.error("UTF-8 encoding not available", e);
         }
-        return new QRCodeDocument(jsonBytes, paymentData);
+        return new QRCodeDocument(jsonBytes, paymentQRCodeData);
     }
 
-    private final PaymentData mPaymentData;
+    private final PaymentQRCodeData mPaymentData;
 
-    private QRCodeDocument(@NonNull final byte[] data, @NonNull final PaymentData paymentData) {
+    private QRCodeDocument(@NonNull final byte[] data, @NonNull final PaymentQRCodeData paymentQRCodeData) {
         super(Type.QRCode, data, null, false, false);
-        mPaymentData = paymentData;
+        mPaymentData = paymentQRCodeData;
     }
 
     private QRCodeDocument(final Parcel in) {
         super(in);
-        mPaymentData = in.readParcelable(PaymentData.class.getClassLoader());
+        mPaymentData = in.readParcelable(PaymentQRCodeData.class.getClassLoader());
     }
 
     @Override
@@ -71,7 +71,7 @@ public class QRCodeDocument extends GiniVisionDocument {
      * @exclude
      */
     @VisibleForTesting
-    PaymentData getPaymentData() {
+    PaymentQRCodeData getPaymentData() {
         return mPaymentData;
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/document/QRCodeDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/QRCodeDocument.java
@@ -5,6 +5,7 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
+import net.gini.android.vision.Document;
 import net.gini.android.vision.internal.qrcode.PaymentQRCodeData;
 
 import org.slf4j.Logger;
@@ -27,12 +28,20 @@ import java.io.UnsupportedEncodingException;
  * (<a href="https://www.stuzza.at/de/zahlungsverkehr/qr-code.html">Stuzza (AT)</a> and <a href="https://www.girocode.de/rechnungsempfaenger/">GiroCode (DE)</a>)
  * QRCodes are detected and read.
  * <p>
- * Get the contents with ({@link QRCodeDocument#getData()}) and upload it to the Gini API to get the extractions.
+ * Get the contents with ({@link Document#getData()}) and upload it to the Gini API to get the extractions.
  */
 public class QRCodeDocument extends GiniVisionDocument {
 
     private static final Logger LOG = LoggerFactory.getLogger(QRCodeDocument.class);
 
+    /**
+     * Creates an instance with the provided QR Code data.
+     *
+     * @param paymentQRCodeData contents of a payment QR Code
+     * @return new instance
+     *
+     * @exclude
+     */
     public static QRCodeDocument fromPaymentQRCodeData(@NonNull final PaymentQRCodeData paymentQRCodeData) {
         byte[] jsonBytes = new byte[]{};
         try {
@@ -55,17 +64,26 @@ public class QRCodeDocument extends GiniVisionDocument {
         mPaymentData = in.readParcelable(PaymentQRCodeData.class.getClassLoader());
     }
 
+    /**
+     * @exclude
+     */
     @Override
     public int describeContents() {
         return 0;
     }
 
+    /**
+     * @exclude
+     */
     @Override
     public void writeToParcel(@NonNull final Parcel dest, final int flags) {
         super.writeToParcel(dest, flags);
         dest.writeParcelable(mPaymentData, flags);
     }
 
+    /**
+     * @exclude
+     */
     public static final Creator<QRCodeDocument> CREATOR = new Parcelable.Creator<QRCodeDocument>() {
         @Override
         public QRCodeDocument createFromParcel(final Parcel in) {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/BezahlCodeParser.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/BezahlCodeParser.java
@@ -7,8 +7,6 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
-import net.gini.android.vision.PaymentData;
-
 /**
  * Created by Alpar Szotyori on 11.12.2017.
  *
@@ -21,7 +19,7 @@ import net.gini.android.vision.PaymentData;
  * See also the
  * <a href="http://www.bezahlcode.de/wp-content/uploads/BezahlCode_TechDok.pdf">BezahlCode Specification</a>
  */
-class BezahlCodeParser implements QRCodeParser<PaymentData> {
+class BezahlCodeParser implements QRCodeParser<PaymentQRCodeData> {
 
     private final IBANValidator mIBANValidator;
 
@@ -30,7 +28,7 @@ class BezahlCodeParser implements QRCodeParser<PaymentData> {
     }
 
     @Override
-    public PaymentData parse(@NonNull final String qrCodeContent)
+    public PaymentQRCodeData parse(@NonNull final String qrCodeContent)
             throws IllegalArgumentException {
         final Uri uri = Uri.parse(qrCodeContent);
         if (!"bank".equals(uri.getScheme())) {
@@ -49,7 +47,7 @@ class BezahlCodeParser implements QRCodeParser<PaymentData> {
         String currency = normalizeCurrency(uri.getQueryParameter("currency"));
         currency = TextUtils.isEmpty(currency) ? "EUR" : currency;
         final String amount = normalizeAmount(uri.getQueryParameter("amount"), currency);
-        return new PaymentData(qrCodeContent, paymentRecipient, paymentReference, iban, bic,
+        return new PaymentQRCodeData(qrCodeContent, paymentRecipient, paymentReference, iban, bic,
                 amount);
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/EPC069_12Parser.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/EPC069_12Parser.java
@@ -6,8 +6,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
-import net.gini.android.vision.PaymentData;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,7 +25,7 @@ import org.slf4j.LoggerFactory;
  * See also the
  * <a href="https://www.stuzza.at/de/zahlungsverkehr/qr-code.html">"Zahlen mit Code" Specification</a>
  */
-class EPC069_12Parser implements QRCodeParser<PaymentData> {
+class EPC069_12Parser implements QRCodeParser<PaymentQRCodeData> {
 
     private static final Logger LOG = LoggerFactory.getLogger(EPC069_12Parser.class);
     private final IBANValidator mIBANValidator;
@@ -37,7 +35,7 @@ class EPC069_12Parser implements QRCodeParser<PaymentData> {
     }
 
     @Override
-    public PaymentData parse(@NonNull final String qrCodeContent)
+    public PaymentQRCodeData parse(@NonNull final String qrCodeContent)
             throws IllegalArgumentException {
         final String[] lines = qrCodeContent.split("\r\n|\n", 12);
         if (lines.length == 0 || !"BCD".equals(lines[0])) {
@@ -56,7 +54,7 @@ class EPC069_12Parser implements QRCodeParser<PaymentData> {
         }
         final String bic = getLineString(4, lines);
         final String amount = normalizeAmount(processAmount(getLineString(7, lines)), "EUR");
-        return new PaymentData(qrCodeContent, paymentRecipient, paymentReference, iban, bic,
+        return new PaymentQRCodeData(qrCodeContent, paymentRecipient, paymentReference, iban, bic,
                 amount);
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/PaymentQRCodeData.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/PaymentQRCodeData.java
@@ -1,4 +1,4 @@
-package net.gini.android.vision;
+package net.gini.android.vision.internal.qrcode;
 
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -20,17 +20,15 @@ import java.io.StringWriter;
  */
 
 /**
- * Contains payment information required for transactions that were extracted from the document.
+ * Contains payment information required for transactions that were parsed from a payment QR Code.
  * <p>
- * Payment data from
- * <a href="http://www.bezahlcode.de/wp-content/uploads/BezahlCode_TechDok.pdf">BezahlCode</a>
- * and <a href="https://www.europeanpaymentscouncil.eu/document-library/guidance-documents/quick-response-code-guidelines-enable-data-capture-initiation">EPC069-12</a>
- * (<a href="https://www.stuzza.at/de/zahlungsverkehr/qr-code.html">Stuzza (AT)</a> and <a href="https://www.girocode.de/rechnungsempfaenger/">GiroCode (DE)</a>)
- * QRCodes are detected and read.
+ * See {@link PaymentQRCodeParser} for supported formats.
+ *
+ * @exclude
  */
-public class PaymentData implements Parcelable {
+public class PaymentQRCodeData implements Parcelable {
 
-    private static final Logger LOG = LoggerFactory.getLogger(PaymentData.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PaymentQRCodeData.class);
 
     private final String mUnparsedContent;
     private final String mAmount;
@@ -39,7 +37,7 @@ public class PaymentData implements Parcelable {
     private final String mPaymentRecipient;
     private final String mPaymentReference;
 
-    public PaymentData(@NonNull final String unparsedContent,
+    public PaymentQRCodeData(@NonNull final String unparsedContent,
             @Nullable final String paymentRecipient,
             @Nullable final String paymentReference,
             @Nullable final String iban,
@@ -84,7 +82,7 @@ public class PaymentData implements Parcelable {
 
     @Override
     public String toString() {
-        return "PaymentData{" +
+        return "PaymentQRCodeData{" +
                 "mUnparsedContent='" + mUnparsedContent + '\'' +
                 ", mAmount='" + mAmount + '\'' +
                 ", mBIC='" + mBIC + '\'' +
@@ -137,7 +135,7 @@ public class PaymentData implements Parcelable {
             return false;
         }
 
-        final PaymentData that = (PaymentData) o;
+        final PaymentQRCodeData that = (PaymentQRCodeData) o;
 
         if (!mUnparsedContent.equals(that.mUnparsedContent)) {
             return false;
@@ -170,7 +168,7 @@ public class PaymentData implements Parcelable {
         return result;
     }
 
-    private PaymentData(final Parcel in) {
+    private PaymentQRCodeData(final Parcel in) {
         mUnparsedContent = in.readString();
         mAmount = in.readString();
         mBIC = in.readString();
@@ -194,15 +192,15 @@ public class PaymentData implements Parcelable {
         dest.writeString(mPaymentReference);
     }
 
-    public static final Creator<PaymentData> CREATOR = new Creator<PaymentData>() {
+    public static final Creator<PaymentQRCodeData> CREATOR = new Creator<PaymentQRCodeData>() {
         @Override
-        public PaymentData createFromParcel(final Parcel in) {
-            return new PaymentData(in);
+        public PaymentQRCodeData createFromParcel(final Parcel in) {
+            return new PaymentQRCodeData(in);
         }
 
         @Override
-        public PaymentData[] newArray(final int size) {
-            return new PaymentData[size];
+        public PaymentQRCodeData[] newArray(final int size) {
+            return new PaymentQRCodeData[size];
         }
     };
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/PaymentQRCodeParser.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/PaymentQRCodeParser.java
@@ -2,8 +2,6 @@ package net.gini.android.vision.internal.qrcode;
 
 import android.support.annotation.NonNull;
 
-import net.gini.android.vision.PaymentData;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,11 +14,15 @@ import java.util.List;
 /**
  * Parser of QRCode content strings for payment data.
  * <p>
- * Currently supports the BezahlCode and EPC069-12 formats.
+ * Currently supports the
+ * <a href="http://www.bezahlcode.de/wp-content/uploads/BezahlCode_TechDok.pdf">BezahlCode</a>
+ * and <a href="https://www.europeanpaymentscouncil.eu/document-library/guidance-documents/quick-response-code-guidelines-enable-data-capture-initiation">EPC069-12</a>
+ * (<a href="https://www.stuzza.at/de/zahlungsverkehr/qr-code.html">Stuzza (AT)</a> and <a href="https://www.girocode.de/rechnungsempfaenger/">GiroCode (DE)</a>)
+ * QRCode formats.
  */
-class PaymentQRCodeParser implements QRCodeParser<PaymentData> {
+class PaymentQRCodeParser implements QRCodeParser<PaymentQRCodeData> {
 
-    private final List<QRCodeParser<PaymentData>> mParsers;
+    private final List<QRCodeParser<PaymentQRCodeData>> mParsers;
 
     PaymentQRCodeParser() {
         mParsers = new ArrayList<>(3);
@@ -32,14 +34,14 @@ class PaymentQRCodeParser implements QRCodeParser<PaymentData> {
      * Parses the content of a QRCode to retrieve the payment data.
      *
      * @param qrCodeContent content of a QRCode
-     * @return a {@link PaymentData} containing the payment information from the QRCode
+     * @return a {@link PaymentQRCodeData} containing the payment information from the QRCode
      * @throws IllegalArgumentException if the QRCode did not conform to any of the supported formats
      */
     @NonNull
     @Override
-    public PaymentData parse(@NonNull final String qrCodeContent)
+    public PaymentQRCodeData parse(@NonNull final String qrCodeContent)
             throws IllegalArgumentException {
-        for (final QRCodeParser<PaymentData> parser : mParsers) {
+        for (final QRCodeParser<PaymentQRCodeData> parser : mParsers) {
             try {
                 return parser.parse(qrCodeContent);
             } catch (final IllegalArgumentException ignore) {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/PaymentQRCodeReader.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/PaymentQRCodeReader.java
@@ -18,6 +18,8 @@ import java.util.List;
  * Reads the first supported QRCode payment data from images.
  * <p>
  * See {@link PaymentQRCodeParser} for supported formats.
+ *
+ * @exclude
  */
 public class PaymentQRCodeReader {
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/PaymentQRCodeReader.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/PaymentQRCodeReader.java
@@ -4,7 +4,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
-import net.gini.android.vision.PaymentData;
 import net.gini.android.vision.internal.util.Size;
 
 import java.util.List;
@@ -23,10 +22,10 @@ import java.util.List;
 public class PaymentQRCodeReader {
 
     private final QRCodeDetector mDetector;
-    private final QRCodeParser<PaymentData> mParser;
+    private final QRCodeParser<PaymentQRCodeData> mParser;
     private Listener mListener = new Listener() {
         @Override
-        public void onPaymentDataAvailable(@NonNull final PaymentData paymentData) {
+        public void onPaymentQRCodeDataAvailable(@NonNull final PaymentQRCodeData paymentQRCodeData) {
         }
     };
 
@@ -46,7 +45,7 @@ public class PaymentQRCodeReader {
 
     private PaymentQRCodeReader(
             @NonNull final QRCodeDetector detector,
-            @NonNull final QRCodeParser<PaymentData> parser) {
+            @NonNull final QRCodeParser<PaymentQRCodeData> parser) {
         mDetector = detector;
         mParser = parser;
         mDetector.setListener(new QRCodeDetector.Listener() {
@@ -54,8 +53,8 @@ public class PaymentQRCodeReader {
             public void onQRCodesDetected(@NonNull final List<String> qrCodes) {
                 for (final String qrCodeContent : qrCodes) {
                     try {
-                        final PaymentData paymentData = mParser.parse(qrCodeContent);
-                        mListener.onPaymentDataAvailable(paymentData);
+                        final PaymentQRCodeData paymentData = mParser.parse(qrCodeContent);
+                        mListener.onPaymentQRCodeDataAvailable(paymentData);
                         return;
                     } catch (final IllegalArgumentException ignored) {
                     }
@@ -97,8 +96,8 @@ public class PaymentQRCodeReader {
         /**
          * Called when a QRCode was found containing a supported payment data format.
          *
-         * @param paymentData the payment data found on the image
+         * @param paymentQRCodeData the payment data found on the image
          */
-        void onPaymentDataAvailable(@NonNull final PaymentData paymentData);
+        void onPaymentQRCodeDataAvailable(@NonNull final PaymentQRCodeData paymentQRCodeData);
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/QRCodeDetectorTask.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/QRCodeDetectorTask.java
@@ -14,6 +14,8 @@ import java.util.List;
 
 /**
  * Interface for synchronous detection of QRCodes from images.
+ *
+ * @exclude
  */
 public interface QRCodeDetectorTask {
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/QRCodeDetectorTaskGoogleVision.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/QRCodeDetectorTaskGoogleVision.java
@@ -28,6 +28,8 @@ import java.util.List;
 
 /**
  * QRCode detector task using the Google Mobile Vision API.
+ *
+ * @exclude
  */
 public class QRCodeDetectorTaskGoogleVision implements QRCodeDetectorTask {
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/QRCodeDetectorTaskGoogleVision.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/qrcode/QRCodeDetectorTaskGoogleVision.java
@@ -31,6 +31,7 @@ import java.util.List;
  */
 public class QRCodeDetectorTaskGoogleVision implements QRCodeDetectorTask {
 
+    private static final boolean DEBUG = false;
     private static final Logger LOG = LoggerFactory.getLogger(QRCodeDetectorTaskGoogleVision.class);
     private final BarcodeDetector mBarcodeDetector;
     private final Handler mRetryHandler;
@@ -54,7 +55,7 @@ public class QRCodeDetectorTaskGoogleVision implements QRCodeDetectorTask {
                 .setRotation(rotationForFrame)
                 .build();
         final SparseArray<Barcode> barcodes = mBarcodeDetector.detect(frame);
-        if (barcodes.size() > 0) {
+        if (barcodes.size() > 0 && DEBUG) {
             LOG.debug("Detected QRCodes:\n{}", barcodesToString(barcodes));
         }
         return barcodesToStrings(barcodes);

--- a/ginivision/src/main/res/layout-sw600dp-land/gv_fragment_camera.xml
+++ b/ginivision/src/main/res/layout-sw600dp-land/gv_fragment_camera.xml
@@ -104,46 +104,46 @@
     </RelativeLayout>
 
     <RelativeLayout
-        android:id="@+id/gv_payment_data_detected_popup_container"
-        android:layout_width="@dimen/gv_camera_payment_data_detected_popup_width"
+        android:id="@+id/gv_qrcode_detected_popup_container"
+        android:layout_width="@dimen/gv_camera_qrcode_detected_popup_width"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
         android:layout_alignParentBottom="true"
-        android:layout_marginEnd="@dimen/gv_camera_payment_data_detected_popup_horizontal_margin"
-        android:layout_marginRight="@dimen/gv_camera_payment_data_detected_popup_horizontal_margin"
-        android:layout_marginBottom="@dimen/gv_camera_payment_data_detected_popup_vertical_margin"
+        android:layout_marginEnd="@dimen/gv_camera_qrcode_detected_popup_horizontal_margin"
+        android:layout_marginRight="@dimen/gv_camera_qrcode_detected_popup_horizontal_margin"
+        android:layout_marginBottom="@dimen/gv_camera_qrcode_detected_popup_vertical_margin"
         android:alpha="0"
-        android:background="@color/gv_payment_data_detected_popup_background"
-        android:paddingBottom="@dimen/gv_camera_payment_data_detected_popup_vertical_padding"
-        android:paddingLeft="@dimen/gv_camera_payment_data_detected_popup_horizontal_padding"
-        android:paddingRight="@dimen/gv_camera_payment_data_detected_popup_horizontal_padding"
-        android:paddingTop="@dimen/gv_camera_payment_data_detected_popup_vertical_padding"
+        android:background="@color/gv_qrcode_detected_popup_background"
+        android:paddingBottom="@dimen/gv_camera_qrcode_detected_popup_vertical_padding"
+        android:paddingLeft="@dimen/gv_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingRight="@dimen/gv_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingTop="@dimen/gv_camera_qrcode_detected_popup_vertical_padding"
         android:visibility="gone"
         tools:alpha="1"
         tools:visibility="visible">
 
         <net.gini.android.vision.internal.ui.CustomFontTextView
-            style="@style/GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message1.TextStyle"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
             android:layout_centerVertical="true"
-            android:layout_marginEnd="@dimen/gv_camera_payment_data_detected_popup_text_right_margin"
-            android:layout_marginRight="@dimen/gv_camera_payment_data_detected_popup_text_right_margin"
-            android:layout_toLeftOf="@+id/gv_camera_payment_data_detected_popup_message_2"
-            android:layout_toStartOf="@+id/gv_camera_payment_data_detected_popup_message_2"
-            android:text="@string/gv_payment_data_detected_popup_message_1" />
+            android:layout_marginEnd="@dimen/gv_camera_qrcode_detected_popup_text_right_margin"
+            android:layout_marginRight="@dimen/gv_camera_qrcode_detected_popup_text_right_margin"
+            android:layout_toLeftOf="@+id/gv_camera_qrcode_detected_popup_message_2"
+            android:layout_toStartOf="@+id/gv_camera_qrcode_detected_popup_message_2"
+            android:text="@string/gv_qrcode_detected_popup_message_1" />
 
         <net.gini.android.vision.internal.ui.CustomFontTextView
-            android:id="@+id/gv_camera_payment_data_detected_popup_message_2"
-            style="@style/GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message2.TextStyle"
+            android:id="@+id/gv_camera_qrcode_detected_popup_message_2"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
-            android:text="@string/gv_payment_data_detected_popup_message_2" />
+            android:text="@string/gv_qrcode_detected_popup_message_2" />
 
     </RelativeLayout>
 

--- a/ginivision/src/main/res/layout-sw600dp/gv_fragment_camera.xml
+++ b/ginivision/src/main/res/layout-sw600dp/gv_fragment_camera.xml
@@ -114,44 +114,44 @@
     </RelativeLayout>
 
     <RelativeLayout
-        android:id="@+id/gv_payment_data_detected_popup_container"
-        android:layout_width="@dimen/gv_camera_payment_data_detected_popup_width"
+        android:id="@+id/gv_qrcode_detected_popup_container"
+        android:layout_width="@dimen/gv_camera_qrcode_detected_popup_width"
         android:layout_centerHorizontal="true"
         android:layout_height="wrap_content"
         android:layout_above="@+id/gv_button_camera_trigger"
-        android:layout_marginBottom="@dimen/gv_camera_payment_data_detected_popup_vertical_margin"
+        android:layout_marginBottom="@dimen/gv_camera_qrcode_detected_popup_vertical_margin"
         android:alpha="0"
-        android:background="@color/gv_payment_data_detected_popup_background"
-        android:paddingLeft="@dimen/gv_camera_payment_data_detected_popup_horizontal_padding"
-        android:paddingRight="@dimen/gv_camera_payment_data_detected_popup_horizontal_padding"
-        android:paddingTop="@dimen/gv_camera_payment_data_detected_popup_vertical_padding"
-        android:paddingBottom="@dimen/gv_camera_payment_data_detected_popup_vertical_padding"
+        android:background="@color/gv_qrcode_detected_popup_background"
+        android:paddingLeft="@dimen/gv_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingRight="@dimen/gv_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingTop="@dimen/gv_camera_qrcode_detected_popup_vertical_padding"
+        android:paddingBottom="@dimen/gv_camera_qrcode_detected_popup_vertical_padding"
         android:visibility="gone"
         tools:alpha="1"
         tools:visibility="visible">
 
         <net.gini.android.vision.internal.ui.CustomFontTextView
-            style="@style/GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message1.TextStyle"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
             android:layout_centerVertical="true"
-            android:layout_marginEnd="@dimen/gv_camera_payment_data_detected_popup_text_right_margin"
-            android:layout_marginRight="@dimen/gv_camera_payment_data_detected_popup_text_right_margin"
-            android:layout_toLeftOf="@+id/gv_camera_payment_data_detected_popup_message_2"
-            android:layout_toStartOf="@+id/gv_camera_payment_data_detected_popup_message_2"
-            android:text="@string/gv_payment_data_detected_popup_message_1" />
+            android:layout_marginEnd="@dimen/gv_camera_qrcode_detected_popup_text_right_margin"
+            android:layout_marginRight="@dimen/gv_camera_qrcode_detected_popup_text_right_margin"
+            android:layout_toLeftOf="@+id/gv_camera_qrcode_detected_popup_message_2"
+            android:layout_toStartOf="@+id/gv_camera_qrcode_detected_popup_message_2"
+            android:text="@string/gv_qrcode_detected_popup_message_1" />
 
         <net.gini.android.vision.internal.ui.CustomFontTextView
-            android:id="@+id/gv_camera_payment_data_detected_popup_message_2"
-            style="@style/GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message2.TextStyle"
+            android:id="@+id/gv_camera_qrcode_detected_popup_message_2"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
-            android:text="@string/gv_payment_data_detected_popup_message_2" />
+            android:text="@string/gv_qrcode_detected_popup_message_2" />
 
     </RelativeLayout>
 

--- a/ginivision/src/main/res/layout/gv_fragment_camera.xml
+++ b/ginivision/src/main/res/layout/gv_fragment_camera.xml
@@ -114,45 +114,45 @@
     </RelativeLayout>
 
     <RelativeLayout
-        android:id="@+id/gv_payment_data_detected_popup_container"
+        android:id="@+id/gv_qrcode_detected_popup_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_above="@+id/gv_button_camera_trigger"
-        android:layout_marginLeft="@dimen/gv_camera_payment_data_detected_popup_horizontal_margin"
-        android:layout_marginRight="@dimen/gv_camera_payment_data_detected_popup_horizontal_margin"
-        android:layout_marginBottom="@dimen/gv_camera_payment_data_detected_popup_vertical_margin"
+        android:layout_marginLeft="@dimen/gv_camera_qrcode_detected_popup_horizontal_margin"
+        android:layout_marginRight="@dimen/gv_camera_qrcode_detected_popup_horizontal_margin"
+        android:layout_marginBottom="@dimen/gv_camera_qrcode_detected_popup_vertical_margin"
         android:alpha="0"
-        android:background="@color/gv_payment_data_detected_popup_background"
-        android:paddingLeft="@dimen/gv_camera_payment_data_detected_popup_horizontal_padding"
-        android:paddingRight="@dimen/gv_camera_payment_data_detected_popup_horizontal_padding"
-        android:paddingTop="@dimen/gv_camera_payment_data_detected_popup_vertical_padding"
-        android:paddingBottom="@dimen/gv_camera_payment_data_detected_popup_vertical_padding"
+        android:background="@color/gv_qrcode_detected_popup_background"
+        android:paddingLeft="@dimen/gv_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingRight="@dimen/gv_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingTop="@dimen/gv_camera_qrcode_detected_popup_vertical_padding"
+        android:paddingBottom="@dimen/gv_camera_qrcode_detected_popup_vertical_padding"
         android:visibility="gone"
         tools:alpha="1"
         tools:visibility="visible">
 
         <net.gini.android.vision.internal.ui.CustomFontTextView
-            style="@style/GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message1.TextStyle"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
             android:layout_centerVertical="true"
-            android:layout_marginEnd="@dimen/gv_camera_payment_data_detected_popup_text_right_margin"
-            android:layout_marginRight="@dimen/gv_camera_payment_data_detected_popup_text_right_margin"
-            android:layout_toLeftOf="@+id/gv_camera_payment_data_detected_popup_message_2"
-            android:layout_toStartOf="@+id/gv_camera_payment_data_detected_popup_message_2"
-            android:text="@string/gv_payment_data_detected_popup_message_1" />
+            android:layout_marginEnd="@dimen/gv_camera_qrcode_detected_popup_text_right_margin"
+            android:layout_marginRight="@dimen/gv_camera_qrcode_detected_popup_text_right_margin"
+            android:layout_toLeftOf="@+id/gv_camera_qrcode_detected_popup_message_2"
+            android:layout_toStartOf="@+id/gv_camera_qrcode_detected_popup_message_2"
+            android:text="@string/gv_qrcode_detected_popup_message_1" />
 
         <net.gini.android.vision.internal.ui.CustomFontTextView
-            android:id="@+id/gv_camera_payment_data_detected_popup_message_2"
-            style="@style/GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message2.TextStyle"
+            android:id="@+id/gv_camera_qrcode_detected_popup_message_2"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
             android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
-            android:text="@string/gv_payment_data_detected_popup_message_2" />
+            android:text="@string/gv_qrcode_detected_popup_message_2" />
 
     </RelativeLayout>
 

--- a/ginivision/src/main/res/values-sw600dp/dimens.xml
+++ b/ginivision/src/main/res/values-sw600dp/dimens.xml
@@ -2,9 +2,9 @@
     <dimen name="gv_camera_upload_hint_container_horizontal_margin">136dp</dimen>
     <dimen name="gv_camera_upload_button_right_margin">72dp</dimen>
 
-    <dimen name="gv_camera_payment_data_detected_popup_width">320dp</dimen>
-    <dimen name="gv_camera_payment_data_detected_popup_horizontal_margin">32dp</dimen>
-    <dimen name="gv_camera_payment_data_detected_popup_vertical_margin">32dp</dimen>
+    <dimen name="gv_camera_qrcode_detected_popup_width">320dp</dimen>
+    <dimen name="gv_camera_qrcode_detected_popup_horizontal_margin">32dp</dimen>
+    <dimen name="gv_camera_qrcode_detected_popup_vertical_margin">32dp</dimen>
 
     <dimen name="gv_onboarding_illustration_size">200dp</dimen>
     <dimen name="gv_onboarding_message_horizontal_margin">64dp</dimen>

--- a/ginivision/src/main/res/values/colors.xml
+++ b/ginivision/src/main/res/values/colors.xml
@@ -17,9 +17,9 @@
     <color name="gv_camera_error_no_permission_button_title">#fff</color>
     <color name="gv_camera_error_no_permission_button_title_pressed">#ddd</color>
 
-    <color name="gv_payment_data_detected_popup_background">#ccffffff</color>
-    <color name="gv_payment_data_detected_popup_message_1">#000</color>
-    <color name="gv_payment_data_detected_popup_message_2">#009edc</color>
+    <color name="gv_qrcode_detected_popup_background">#ccffffff</color>
+    <color name="gv_qrcode_detected_popup_message_1">#000</color>
+    <color name="gv_qrcode_detected_popup_message_2">#009edc</color>
 
     <color name="gv_document_import_hint_background">#ffffff</color>
     <color name="gv_document_import_hint_text">#000000</color>

--- a/ginivision/src/main/res/values/dimens.xml
+++ b/ginivision/src/main/res/values/dimens.xml
@@ -10,12 +10,12 @@
     <dimen name="gv_camera_upload_button_right_margin">36dp</dimen>
     <dimen name="gv_camera_upload_button_top_margin">0dp</dimen>
     <dimen name="gv_camera_activity_indicator_padding">16dp</dimen>
-    <dimen name="gv_camera_payment_data_detected_popup_horizontal_margin">24dp</dimen>
-    <dimen name="gv_camera_payment_data_detected_popup_vertical_margin">16dp</dimen>
-    <dimen name="gv_camera_payment_data_detected_popup_horizontal_padding">12dp</dimen>
-    <dimen name="gv_camera_payment_data_detected_popup_vertical_padding">8dp</dimen>
-    <dimen name="gv_camera_payment_data_detected_popup_text_right_margin">16dp</dimen>
-    <dimen name="gv_camera_payment_data_detected_popup_width">0dp</dimen>
+    <dimen name="gv_camera_qrcode_detected_popup_horizontal_margin">24dp</dimen>
+    <dimen name="gv_camera_qrcode_detected_popup_vertical_margin">16dp</dimen>
+    <dimen name="gv_camera_qrcode_detected_popup_horizontal_padding">12dp</dimen>
+    <dimen name="gv_camera_qrcode_detected_popup_vertical_padding">8dp</dimen>
+    <dimen name="gv_camera_qrcode_detected_popup_text_right_margin">16dp</dimen>
+    <dimen name="gv_camera_qrcode_detected_popup_width">0dp</dimen>
 
     <dimen name="gv_onboarding_indicators_vertical_margin">41dp</dimen>
     <dimen name="gv_onboarding_indicator_width">10dp</dimen>

--- a/ginivision/src/main/res/values/strings.xml
+++ b/ginivision/src/main/res/values/strings.xml
@@ -14,8 +14,8 @@
     <string name="gv_camera_error_no_permission">Um Dokumente zu fotografieren, erlaube Gini Pay den Zugriff auf die Kamera.</string>
     <string name="gv_camera_error_no_permission_button_title">Zugriff erlauben</string>
 
-    <string name="gv_payment_data_detected_popup_message_1">QR verwenden?</string>
-    <string name="gv_payment_data_detected_popup_message_2">Hier geht’s weiter.</string>
+    <string name="gv_qrcode_detected_popup_message_1">QR verwenden?</string>
+    <string name="gv_qrcode_detected_popup_message_2">Hier geht’s weiter.</string>
 
     <string name="gv_onboarding_lighting">Beim Abfotografieren der Rechnung oder des Überweisungsträgers auf gute Beleuchtung achten</string>
     <string name="gv_onboarding_flat">Seite glatt streichen</string>

--- a/ginivision/src/main/res/values/styles.xml
+++ b/ginivision/src/main/res/values/styles.xml
@@ -58,15 +58,15 @@
         <item name="gvCustomFont"/>
     </style>
 
-    <style name="Root.GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message1.TextStyle" parent="TextAppearance.AppCompat">
+    <style name="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textSize">14sp</item>
-        <item name="android:textColor">@color/gv_payment_data_detected_popup_message_1</item>
+        <item name="android:textColor">@color/gv_qrcode_detected_popup_message_1</item>
         <item name="gvCustomFont" />
     </style>
 
-    <style name="Root.GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message2.TextStyle" parent="TextAppearance.AppCompat">
+    <style name="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textSize">14sp</item>
-        <item name="android:textColor">@color/gv_payment_data_detected_popup_message_2</item>
+        <item name="android:textColor">@color/gv_qrcode_detected_popup_message_2</item>
         <item name="gvCustomFont" />
     </style>
 
@@ -206,9 +206,9 @@
 
     <style name="GiniVisionTheme.Camera.DocumentImportHint.TextStyle" parent="Root.GiniVisionTheme.Camera.DocumentImportHint.TextStyle" />
 
-    <style name="GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message1.TextStyle" parent="Root.GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message1.TextStyle" />
+    <style name="GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle" parent="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle" />
 
-    <style name="GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message2.TextStyle" parent="Root.GiniVisionTheme.Camera.PaymentDataDetectedPopup.Message2.TextStyle" />
+    <style name="GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle" parent="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle" />
 
     <style name="GiniVisionTheme.Review.BottomPanel.TextStyle" parent="Root.GiniVisionTheme.Review.BottomPanel.TextStyle"/>
 

--- a/screenapiexample/build.gradle
+++ b/screenapiexample/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     compile 'com.github.tony19:logback-android-core:1.1.1-5'
     compile 'com.github.tony19:logback-android-classic:1.1.1-5'
 
-    compile('net.gini:gini-android-sdk:1.3.92@aar') {
+    compile('net.gini:gini-android-sdk:1.4.1@aar') {
         transitive = true
     }
 

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/AnalysisActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/AnalysisActivity.java
@@ -1,5 +1,6 @@
 package net.gini.android.vision.screen;
 
+import static net.gini.android.vision.example.ExampleUtil.getExtractionsBundle;
 import static net.gini.android.vision.example.ExampleUtil.hasNoPay5Extractions;
 
 import android.content.Intent;
@@ -28,12 +29,12 @@ public class AnalysisActivity extends net.gini.android.vision.analysis.AnalysisA
     private SingleDocumentAnalyzer mSingleDocumentAnalyzer;
 
     @Override
-    public void onAddDataToResult(@NonNull Intent result) {
+    public void onAddDataToResult(@NonNull final Intent result) {
         LOG.debug("Add data to result");
         // We add the extraction results here to the Intent. The payload format is up to you.
         // For the example we add the extractions as key-value pairs to a Bundle
         // We retrieve them when the CameraActivity has finished in MainActivity#onActivityResult()
-        Bundle extractionsBundle = getExtractionsBundle();
+        final Bundle extractionsBundle = getExtractionsBundle(mExtractions);
         result.putExtra(MainActivity.EXTRA_OUT_EXTRACTIONS, extractionsBundle);
     }
 
@@ -47,7 +48,7 @@ public class AnalysisActivity extends net.gini.android.vision.analysis.AnalysisA
         mSingleDocumentAnalyzer.analyzeDocument(document,
                 new DocumentAnalyzer.Listener() {
                     @Override
-                    public void onException(Exception exception) {
+                    public void onException(final Exception exception) {
                         stopScanAnimation();
                         String message = "Analysis failed: ";
                         if (exception != null) {
@@ -57,7 +58,7 @@ public class AnalysisActivity extends net.gini.android.vision.analysis.AnalysisA
                         showError(message, getString(R.string.gv_document_analysis_error_retry),
                                 new View.OnClickListener() {
                                     @Override
-                                    public void onClick(View v) {
+                                    public void onClick(final View v) {
                                         startScanAnimation();
                                         mSingleDocumentAnalyzer.cancelAnalysis();
                                         mSingleDocumentAnalyzer.analyzeDocument(document, listener);
@@ -66,7 +67,7 @@ public class AnalysisActivity extends net.gini.android.vision.analysis.AnalysisA
                     }
 
                     @Override
-                    public void onExtractionsReceived(Map<String, SpecificExtraction> extractions) {
+                    public void onExtractionsReceived(final Map<String, SpecificExtraction> extractions) {
                         mExtractions = extractions;
                         if (mExtractions == null || hasNoPay5Extractions(mExtractions.keySet())) {
                             onNoExtractionsFound();
@@ -82,7 +83,7 @@ public class AnalysisActivity extends net.gini.android.vision.analysis.AnalysisA
     }
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mSingleDocumentAnalyzer = ((BaseExampleApp) getApplication()).getSingleDocumentAnalyzer();
     }
@@ -91,13 +92,5 @@ public class AnalysisActivity extends net.gini.android.vision.analysis.AnalysisA
     protected void onDestroy() {
         super.onDestroy();
         ((BaseExampleApp) getApplication()).getSingleDocumentAnalyzer().cancelAnalysis();
-    }
-
-    private Bundle getExtractionsBundle() {
-        final Bundle extractionsBundle = new Bundle();
-        for (Map.Entry<String, SpecificExtraction> entry : mExtractions.entrySet()) {
-            extractionsBundle.putParcelable(entry.getKey(), entry.getValue());
-        }
-        return extractionsBundle;
     }
 }

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/CameraScreenApiActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/CameraScreenApiActivity.java
@@ -182,7 +182,7 @@ public class CameraScreenApiActivity extends CameraActivity {
                     @Override
                     public void onException(final Exception exception) {
                         hideActivityIndicatorAndEnableInteraction();
-                        showError("Could not use the QR Code. Try again or take a picture of your document.", 4000);
+                        showError(getString(R.string.qrcode_error), 4000);
                     }
 
                     @Override

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/CameraScreenApiActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/CameraScreenApiActivity.java
@@ -175,7 +175,6 @@ public class CameraScreenApiActivity extends CameraActivity {
 
     @Override
     public void onQRCodeAvailable(@NonNull final QRCodeDocument qrCodeDocument) {
-        super.onQRCodeAvailable(qrCodeDocument);
         showActivityIndicatorAndDisableInteraction();
         mSingleDocumentAnalyzer.cancelAnalysis();
         mSingleDocumentAnalyzer.analyzeDocument(qrCodeDocument,

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/CameraScreenApiActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/CameraScreenApiActivity.java
@@ -14,9 +14,13 @@ import android.os.ParcelFileDescriptor;
 import android.support.annotation.NonNull;
 import android.support.annotation.RequiresApi;
 
+import net.gini.android.models.SpecificExtraction;
 import net.gini.android.vision.Document;
-import net.gini.android.vision.PaymentData;
 import net.gini.android.vision.camera.CameraActivity;
+import net.gini.android.vision.document.QRCodeDocument;
+import net.gini.android.vision.example.BaseExampleApp;
+import net.gini.android.vision.example.DocumentAnalyzer;
+import net.gini.android.vision.example.SingleDocumentAnalyzer;
 import net.gini.android.vision.util.IntentHelper;
 import net.gini.android.vision.util.UriHelper;
 
@@ -26,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 
 public class CameraScreenApiActivity extends CameraActivity {
 
@@ -33,6 +38,14 @@ public class CameraScreenApiActivity extends CameraActivity {
 
     // Set to true to allow execution of the custom code check
     private static final boolean DO_CUSTOM_DOCUMENT_CHECK = false;
+
+    private SingleDocumentAnalyzer mSingleDocumentAnalyzer;
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mSingleDocumentAnalyzer = ((BaseExampleApp) getApplication()).getSingleDocumentAnalyzer();
+    }
 
     @Override
     public void onCheckImportedDocument(@NonNull final Document document,
@@ -161,12 +174,28 @@ public class CameraScreenApiActivity extends CameraActivity {
     }
 
     @Override
-    public void onPaymentDataAvailable(@NonNull final PaymentData paymentData) {
-        super.onPaymentDataAvailable(paymentData);
-        final Intent result = new Intent();
-        final Bundle extractionsBundle = getExtractionsBundle(paymentData);
-        result.putExtra(MainActivity.EXTRA_OUT_EXTRACTIONS, extractionsBundle);
-        setResult(RESULT_OK, result);
-        finish();
+    public void onQRCodeAvailable(@NonNull final QRCodeDocument qrCodeDocument) {
+        super.onQRCodeAvailable(qrCodeDocument);
+        showActivityIndicatorAndDisableInteraction();
+        mSingleDocumentAnalyzer.cancelAnalysis();
+        mSingleDocumentAnalyzer.analyzeDocument(qrCodeDocument,
+                new DocumentAnalyzer.Listener() {
+                    @Override
+                    public void onException(final Exception exception) {
+                        hideActivityIndicatorAndEnableInteraction();
+                        showError("Could not use the QR Code. Try again or take a picture of your document.", 4000);
+                    }
+
+                    @Override
+                    public void onExtractionsReceived(
+                            final Map<String, SpecificExtraction> extractions) {
+                        hideActivityIndicatorAndEnableInteraction();
+                        final Intent result = new Intent();
+                        final Bundle extractionsBundle = getExtractionsBundle(extractions);
+                        result.putExtra(MainActivity.EXTRA_OUT_EXTRACTIONS, extractionsBundle);
+                        setResult(RESULT_OK, result);
+                        finish();
+                    }
+                });
     }
 }

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/ReviewActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/ReviewActivity.java
@@ -1,5 +1,6 @@
 package net.gini.android.vision.screen;
 
+import static net.gini.android.vision.example.ExampleUtil.getExtractionsBundle;
 import static net.gini.android.vision.example.ExampleUtil.hasNoPay5Extractions;
 
 import android.content.Intent;
@@ -35,35 +36,24 @@ public class ReviewActivity extends net.gini.android.vision.review.ReviewActivit
     }
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
     }
 
     @Override
-    public void onAddDataToResult(@NonNull Intent result) {
+    public void onAddDataToResult(@NonNull final Intent result) {
         LOG.debug("Add data to result");
         // We add the extraction results here to the Intent. The payload format is up to you.
         // For the example we add the extractions as key-value pairs to a Bundle
         // We retrieve them when the CameraActivity has finished in MainActivity#onActivityResult()
-        Bundle extractionsBundle = getExtractionsBundle();
+        final Bundle extractionsBundle = getExtractionsBundle(mExtractions);
         if (extractionsBundle != null) {
             result.putExtra(MainActivity.EXTRA_OUT_EXTRACTIONS, extractionsBundle);
         }
     }
 
-    private Bundle getExtractionsBundle() {
-        if (mExtractions == null) {
-            return null;
-        }
-        final Bundle extractionsBundle = new Bundle();
-        for (Map.Entry<String, SpecificExtraction> entry : mExtractions.entrySet()) {
-            extractionsBundle.putParcelable(entry.getKey(), entry.getValue());
-        }
-        return extractionsBundle;
-    }
-
     @Override
-    public void onShouldAnalyzeDocument(@NonNull Document document) {
+    public void onShouldAnalyzeDocument(@NonNull final Document document) {
         LOG.debug("Should analyze document");
         GiniVisionDebug.writeDocumentToFile(this, document, "_for_review");
 
@@ -76,18 +66,18 @@ public class ReviewActivity extends net.gini.android.vision.review.ReviewActivit
     }
 
     @Override
-    public void onDocumentWasRotated(@NonNull Document document, int oldRotation, int newRotation) {
+    public void onDocumentWasRotated(@NonNull final Document document, final int oldRotation, final int newRotation) {
         super.onDocumentWasRotated(document, oldRotation, newRotation);
         LOG.debug("Document was rotated");
         // We need to cancel the analysis here, we will have to upload the rotated document in the Analysis Screen
         getSingleDocumentAnalyzer().cancelAnalysis();
     }
 
-    private void analyzeDocument(Document document) {
+    private void analyzeDocument(final Document document) {
         getSingleDocumentAnalyzer().cancelAnalysis();
         getSingleDocumentAnalyzer().analyzeDocument(document, new DocumentAnalyzer.Listener() {
             @Override
-            public void onExtractionsReceived(Map<String, SpecificExtraction> extractions) {
+            public void onExtractionsReceived(final Map<String, SpecificExtraction> extractions) {
                 mExtractions = extractions;
                 if (mExtractions == null || hasNoPay5Extractions(mExtractions.keySet())) {
                     onNoExtractionsFound();
@@ -99,7 +89,7 @@ public class ReviewActivity extends net.gini.android.vision.review.ReviewActivit
             }
 
             @Override
-            public void onException(Exception exception) {
+            public void onException(final Exception exception) {
                 if (exception != null) {
                     String message = "unknown";
                     if (exception.getMessage() != null) {
@@ -113,7 +103,7 @@ public class ReviewActivity extends net.gini.android.vision.review.ReviewActivit
     }
 
     @Override
-    public void onProceedToAnalysisScreen(@NonNull Document document) {
+    public void onProceedToAnalysisScreen(@NonNull final Document document) {
         LOG.debug("Proceed to analysis screen");
         // As the library will go to the Analysis Screen we should only remove the listener.
         // We should not cancel the analysis here as we don't know, if we proceed because the analysis didn't complete or

--- a/screenapiexample/src/main/res/values/strings.xml
+++ b/screenapiexample/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="storage_permission_rationale">Um gespeicherte Bilder oder PDFs zu analysieren, wird Datei-Zugriff auf dem Gerät benötigt.</string>
     <string name="camera_permission_denied_message">Nur mit Kamera-Zugriff können Sie die Gini Vision Library verwenden.</string>
     <string name="camera_permission_rationale">Um Rechnungen fotografieren zu können, wird Kamera-Zugriff benötigt.</string>
+    <string name="qrcode_error">Could not use the QR Code. Try again or take a picture of your document.</string>
 
     <!-- String customization examples -->
 


### PR DESCRIPTION
To track QR Codes we had to change our beta QR Code public api quite a bit. We don't expose the payment data anymore directly. We create a json containing the raw QR Code string and the payment data we parsed from it (#135). This json is publicly available as an utf-8 encoded byte array which should be uploaded to the Gini API to get the payment data from the QR Code. Feedback should also be sent for it.

The example apps were updated to upload the QR Code. Documentation was also updated.

**Note:**
The previous beta QR Code public api used the term `Payment Data` to cover future cases where other sources than QR Codes are used to read payment data (e.g. NFC). The requirement to upload the QR Code required us to drop that naming and mention QR Codes explicitly for clarity and convenience. That's why there are so many changed files.

### How to test
Run the example apps and scan BezahlCode, Stuzza or GiroCode.

### Ticket 
Issue #137
