### PR TITLE
Feature multi page import or open multiple images

### DIFF
--- a/componentapiexample/build.gradle
+++ b/componentapiexample/build.gradle
@@ -21,6 +21,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode appVersionCode
         versionName appVersionName
+
+        multiDexEnabled true
     }
 
     signingConfigs {
@@ -63,6 +65,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation deps.appCompatv7
+    implementation 'com.android.support:multidex:1.0.3'
 
     implementation 'com.karumi:dexter:4.2.0'
 

--- a/exampleShared/java/net/gini/android/vision/example/BaseExampleApp.java
+++ b/exampleShared/java/net/gini/android/vision/example/BaseExampleApp.java
@@ -1,7 +1,7 @@
 package net.gini.android.vision.example;
 
-import android.app.Application;
 import android.support.annotation.NonNull;
+import android.support.multidex.MultiDexApplication;
 import android.text.TextUtils;
 
 import net.gini.android.Gini;
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  *     only started when the Analysis Screen was shown where the reviewed final document is available.
  * </p>
  */
-public abstract class BaseExampleApp extends Application {
+public abstract class BaseExampleApp extends MultiDexApplication {
 
     private static final Logger LOG = LoggerFactory.getLogger(BaseExampleApp.class);
 

--- a/ginivision/src/main/java/net/gini/android/vision/Document.java
+++ b/ginivision/src/main/java/net/gini/android/vision/Document.java
@@ -1,6 +1,7 @@
 package net.gini.android.vision;
 
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -81,6 +82,16 @@ public interface Document extends Parcelable {
      */
     @Nullable
     Intent getIntent();
+
+    /**
+     * <p>
+     *     The {@link Uri} of the imported document.
+     * </p>
+     *
+     * @return {@link Uri}
+     */
+    @Nullable
+    Uri getUri();
 
     /**
      * <p> Document is imported if it was picked from another app from the Camera Screen's document

--- a/ginivision/src/main/java/net/gini/android/vision/Document.java
+++ b/ginivision/src/main/java/net/gini/android/vision/Document.java
@@ -133,6 +133,6 @@ public interface Document extends Parcelable {
         /**
          * The document contains multiple images.
          */
-        MULTI_PAGE
+        IMAGE_MULTI_PAGE
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
@@ -9,7 +9,7 @@ import net.gini.android.vision.analysis.AnalysisActivity;
 import net.gini.android.vision.camera.CameraActivity;
 import net.gini.android.vision.document.DocumentFactory;
 import net.gini.android.vision.document.ImageDocument;
-import net.gini.android.vision.document.MultiPageDocument;
+import net.gini.android.vision.document.ImageMultiPageDocument;
 import net.gini.android.vision.internal.util.ActivityHelper;
 import net.gini.android.vision.internal.util.DeviceHelper;
 import net.gini.android.vision.internal.util.FileImportValidator;
@@ -62,11 +62,11 @@ public final class GiniVisionFileImport {
             throws ImportedFileValidationException {
         final Document document = createDocumentForImportedFile(intent, context);
         final Intent giniVisionIntent;
-        if (document.getType() == Document.Type.MULTI_PAGE) {
-            final MultiPageDocument multiPageDocument = (MultiPageDocument) document;
-            final List<ImageDocument> imageDocuments = multiPageDocument.getImageDocuments();
+        if (document.getType() == Document.Type.IMAGE_MULTI_PAGE) {
+            final ImageMultiPageDocument multiPageDocument = (ImageMultiPageDocument) document;
+            final List<ImageDocument> imageDocuments = multiPageDocument.getDocuments();
             if (imageDocuments.size() > 1) {
-                giniVisionIntent = MultiPageReviewActivity.createIntent(context, document);
+                giniVisionIntent = MultiPageReviewActivity.createIntent(context, multiPageDocument);
             } else {
                 final ImageDocument imageDocument = imageDocuments.get(0);
                 giniVisionIntent = createReviewActivityIntent(context, ReviewActivity.class,
@@ -118,11 +118,11 @@ public final class GiniVisionFileImport {
             throws ImportedFileValidationException {
         final Document document = createDocumentForImportedFile(intent, context);
         final Intent giniVisionIntent;
-        if (document.getType() == Document.Type.MULTI_PAGE) {
-            final MultiPageDocument multiPageDocument = (MultiPageDocument) document;
-            final List<ImageDocument> imageDocuments = multiPageDocument.getImageDocuments();
+        if (document.getType() == Document.Type.IMAGE_MULTI_PAGE) {
+            final ImageMultiPageDocument multiPageDocument = (ImageMultiPageDocument) document;
+            final List<ImageDocument> imageDocuments = multiPageDocument.getDocuments();
             if (imageDocuments.size() > 1) {
-                giniVisionIntent = MultiPageReviewActivity.createIntent(context, document);
+                giniVisionIntent = MultiPageReviewActivity.createIntent(context, multiPageDocument);
             } else {
                 final ImageDocument imageDocument = imageDocuments.get(0);
                 giniVisionIntent = createReviewActivityIntent(context, ReviewActivity.class,
@@ -194,7 +194,7 @@ public final class GiniVisionFileImport {
         if (uris == null) {
             throw new ImportedFileValidationException("Intent data did not contain Uris");
         }
-        final MultiPageDocument multiPageDocument = new MultiPageDocument(true);
+        final ImageMultiPageDocument multiPageDocument = new ImageMultiPageDocument(true);
         for (final Uri uri : uris) {
             if (!UriHelper.isUriInputStreamAvailable(uri, context)) {
                 throw new ImportedFileValidationException(
@@ -207,13 +207,13 @@ public final class GiniVisionFileImport {
                     final ImageDocument document = DocumentFactory.newImageDocumentFromUri(uri,
                             intent, context, DeviceHelper.getDeviceOrientation(context),
                             DeviceHelper.getDeviceType(context), "openwith");
-                    multiPageDocument.addImageDocument(document);
+                    multiPageDocument.addDocument(document);
                 }
             } else {
                 throw new ImportedFileValidationException(fileImportValidator.getError());
             }
         }
-        if (multiPageDocument.getImageDocuments().isEmpty()) {
+        if (multiPageDocument.getDocuments().isEmpty()) {
             throw new ImportedFileValidationException("Intent did not contain images");
         }
         return multiPageDocument;

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
@@ -68,23 +68,30 @@ public final class GiniVisionFileImport {
             if (imageDocuments.size() > 1) {
                 giniVisionIntent = MultiPageReviewActivity.createIntent(context, document);
             } else {
-                giniVisionIntent = new Intent(context, ReviewActivity.class);
                 final ImageDocument imageDocument = imageDocuments.get(0);
-                giniVisionIntent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, imageDocument);
-                ActivityHelper.setActivityExtra(giniVisionIntent,
-                        ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY, context, AnalysisActivity.class);
+                giniVisionIntent = createReviewActivityIntent(context, ReviewActivity.class,
+                        AnalysisActivity.class, imageDocument);
             }
+        } else if (document.isReviewable()) {
+            giniVisionIntent = createReviewActivityIntent(context, reviewActivityClass,
+                    analysisActivityClass, document);
         } else {
-            if (document.isReviewable()) {
-                giniVisionIntent = new Intent(context, reviewActivityClass);
-                giniVisionIntent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, document);
-                ActivityHelper.setActivityExtra(giniVisionIntent,
-                        ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY, context, analysisActivityClass);
-            } else {
-                giniVisionIntent = new Intent(context, analysisActivityClass);
-                giniVisionIntent.putExtra(AnalysisActivity.EXTRA_IN_DOCUMENT, document);
-            }
+            giniVisionIntent = new Intent(context, analysisActivityClass);
+            giniVisionIntent.putExtra(AnalysisActivity.EXTRA_IN_DOCUMENT, document);
         }
+        return giniVisionIntent;
+    }
+
+    @NonNull
+    private static Intent createReviewActivityIntent(final @NonNull Context context,
+            @NonNull final Class<? extends ReviewActivity> reviewActivityClass,
+            @NonNull final Class<? extends AnalysisActivity> analysisActivityClass,
+            final Document document) {
+        final Intent giniVisionIntent;
+        giniVisionIntent = new Intent(context, reviewActivityClass);
+        giniVisionIntent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, document);
+        ActivityHelper.setActivityExtra(giniVisionIntent,
+                ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY, context, analysisActivityClass);
         return giniVisionIntent;
     }
 
@@ -117,18 +124,14 @@ public final class GiniVisionFileImport {
             if (imageDocuments.size() > 1) {
                 giniVisionIntent = MultiPageReviewActivity.createIntent(context, document);
             } else {
-                giniVisionIntent = new Intent(context, ReviewActivity.class);
                 final ImageDocument imageDocument = imageDocuments.get(0);
-                giniVisionIntent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, imageDocument);
-                ActivityHelper.setActivityExtra(giniVisionIntent,
-                        ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY, context, AnalysisActivity.class);
+                giniVisionIntent = createReviewActivityIntent(context, ReviewActivity.class,
+                        AnalysisActivity.class, imageDocument);
             }
         } else {
             if (document.isReviewable()) {
-                giniVisionIntent = new Intent(context, ReviewActivity.class);
-                giniVisionIntent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, document);
-                ActivityHelper.setActivityExtra(giniVisionIntent,
-                        ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY, context, AnalysisActivity.class);
+                giniVisionIntent = createReviewActivityIntent(context, ReviewActivity.class,
+                        AnalysisActivity.class, document);
             } else {
                 giniVisionIntent = new Intent(context, AnalysisActivity.class);
                 giniVisionIntent.putExtra(AnalysisActivity.EXTRA_IN_DOCUMENT, document);

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
@@ -6,12 +6,14 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 
 import net.gini.android.vision.analysis.AnalysisActivity;
+import net.gini.android.vision.camera.CameraActivity;
 import net.gini.android.vision.document.DocumentFactory;
 import net.gini.android.vision.document.ImageDocument;
 import net.gini.android.vision.document.MultiPageDocument;
 import net.gini.android.vision.internal.util.ActivityHelper;
 import net.gini.android.vision.internal.util.DeviceHelper;
 import net.gini.android.vision.internal.util.FileImportValidator;
+import net.gini.android.vision.network.GiniVisionNetworkService;
 import net.gini.android.vision.review.MultiPageReviewActivity;
 import net.gini.android.vision.review.ReviewActivity;
 import net.gini.android.vision.util.IntentHelper;
@@ -44,8 +46,14 @@ public final class GiniVisionFileImport {
      * @throws ImportedFileValidationException if the file didn't pass validation
      * @throws IllegalArgumentException        if the Intent's data is not valid or the mime type is not
      *                                         supported
+     *
+     * @deprecated Use {@link GiniVisionFileImport#createDocumentForImportedFile(Intent, Context)} instead
+     * when a {@link GiniVision} instance is available. The document
+     * is analyzed internally by using the configured {@link GiniVisionNetworkService}
+     * implementation. The extractions will be returned in the extra called
+     * {@link CameraActivity#EXTRA_OUT_EXTRACTIONS} of the {@link CameraActivity}'s result Intent.
      */
-    // TODO: deprecate and create one without activity classes - passing in activity classes not required when using GiniVision
+    @Deprecated
     @NonNull
     public static Intent createIntentForImportedFile(@NonNull final Intent intent,
             @NonNull final Context context,
@@ -74,6 +82,55 @@ public final class GiniVisionFileImport {
                         ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY, context, analysisActivityClass);
             } else {
                 giniVisionIntent = new Intent(context, analysisActivityClass);
+                giniVisionIntent.putExtra(AnalysisActivity.EXTRA_IN_DOCUMENT, document);
+            }
+        }
+        return giniVisionIntent;
+    }
+
+    /**
+     * <b>Screen API</b>
+     * <p>
+     * When your application receives a file from another application you can use this method to
+     * create an Intent for launching the Gini Vision Library.
+     * <p>
+     *     Start the Intent with {@link android.app.Activity#startActivityForResult(Intent,
+     *     int)} to receive the extractions or a {@link GiniVisionError} in case there was an error.
+     * </p>
+     *
+     * @param intent                the Intent your app received
+     * @param context               Android context subclass
+     * @return an Intent for launching the Gini Vision Library
+     * @throws ImportedFileValidationException if the file didn't pass validation
+     * @throws IllegalArgumentException        if the Intent's data is not valid or the mime type is not
+     *                                         supported
+     */
+    @NonNull
+    public static Intent createIntentForImportedFile(@NonNull final Intent intent,
+            @NonNull final Context context)
+            throws ImportedFileValidationException {
+        final Document document = createDocumentForImportedFile(intent, context);
+        final Intent giniVisionIntent;
+        if (document.getType() == Document.Type.MULTI_PAGE) {
+            final MultiPageDocument multiPageDocument = (MultiPageDocument) document;
+            final List<ImageDocument> imageDocuments = multiPageDocument.getImageDocuments();
+            if (imageDocuments.size() > 1) {
+                giniVisionIntent = MultiPageReviewActivity.createIntent(context, document);
+            } else {
+                giniVisionIntent = new Intent(context, ReviewActivity.class);
+                final ImageDocument imageDocument = imageDocuments.get(0);
+                giniVisionIntent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, imageDocument);
+                ActivityHelper.setActivityExtra(giniVisionIntent,
+                        ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY, context, AnalysisActivity.class);
+            }
+        } else {
+            if (document.isReviewable()) {
+                giniVisionIntent = new Intent(context, ReviewActivity.class);
+                giniVisionIntent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, document);
+                ActivityHelper.setActivityExtra(giniVisionIntent,
+                        ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY, context, AnalysisActivity.class);
+            } else {
+                giniVisionIntent = new Intent(context, AnalysisActivity.class);
                 giniVisionIntent.putExtra(AnalysisActivity.EXTRA_IN_DOCUMENT, document);
             }
         }

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
@@ -202,7 +202,8 @@ public final class GiniVisionFileImport {
             }
             final FileImportValidator fileImportValidator = new FileImportValidator(context);
             if (fileImportValidator.matchesCriteria(uri)) {
-                if (IntentHelper.hasMimeTypeWithPrefix(uri, context, "image/")) {
+                if (IntentHelper.hasMimeTypeWithPrefix(uri, context,
+                        IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
                     final ImageDocument document = DocumentFactory.newImageDocumentFromUri(uri,
                             intent, context, DeviceHelper.getDeviceOrientation(context),
                             DeviceHelper.getDeviceType(context), "openwith");

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
@@ -22,7 +22,8 @@ import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.GiniVisionFeatureConfiguration;
 import net.gini.android.vision.R;
 import net.gini.android.vision.analysis.AnalysisActivity;
-import net.gini.android.vision.document.MultiPageDocument;
+import net.gini.android.vision.document.GiniVisionMultiPageDocument;
+import net.gini.android.vision.document.ImageMultiPageDocument;
 import net.gini.android.vision.document.QRCodeDocument;
 import net.gini.android.vision.help.HelpActivity;
 import net.gini.android.vision.internal.util.ActivityHelper;
@@ -678,9 +679,14 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
 
     @Override
     public void onProceedToMultiPageReviewScreen(
-            @NonNull final MultiPageDocument multiPageDocument) {
-        final Intent intent = MultiPageReviewActivity.createIntent(this, multiPageDocument);
-        startActivityForResult(intent, MULTI_PAGE_REVIEW_REQUEST);
+            @NonNull final GiniVisionMultiPageDocument multiPageDocument) {
+        if (multiPageDocument.getType() == Document.Type.IMAGE_MULTI_PAGE) {
+            final Intent intent = MultiPageReviewActivity.createIntent(this,
+                    (ImageMultiPageDocument) multiPageDocument);
+            startActivityForResult(intent, MULTI_PAGE_REVIEW_REQUEST);
+        } else {
+            throw new UnsupportedOperationException("Unsupported multi-page document type.");
+        }
     }
 
     @Override

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
@@ -666,13 +666,6 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
         mOnboardingShown = true;
     }
 
-    /**
-     * @deprecated When a {@link GiniVision} instance is available the document
-     * is analyzed internally by using the configured {@link GiniVisionNetworkService}
-     * implementation. The extractions will be returned in the extra called
-     * {@link CameraActivity#EXTRA_OUT_EXTRACTIONS} of the {@link CameraActivity}'s result Intent.
-     */
-    @Deprecated
     @Override
     public void onDocumentAvailable(@NonNull final Document document) {
         mDocument = document;
@@ -683,13 +676,6 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
         }
     }
 
-    /**
-     * @deprecated When a {@link GiniVision} instance is available the document
-     * is analyzed internally by using the configured {@link GiniVisionNetworkService}
-     * implementation. The extractions will be returned in the extra called
-     * {@link CameraActivity#EXTRA_OUT_EXTRACTIONS} of the {@link CameraActivity}'s result Intent.
-     */
-    @Deprecated
     @Override
     public void onProceedToMultiPageReviewScreen(
             @NonNull final MultiPageDocument multiPageDocument) {

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -967,7 +967,8 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
             }
             final FileImportValidator fileImportValidator = new FileImportValidator(context);
             if (fileImportValidator.matchesCriteria(uri)) {
-                if (IntentHelper.hasMimeTypeWithPrefix(uri, context, "image/")) {
+                if (IntentHelper.hasMimeTypeWithPrefix(uri, context,
+                        IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
                     try {
                         final ImageDocument document = DocumentFactory.newImageDocumentFromUri(uri,
                                 intent, context, DeviceHelper.getDeviceOrientation(context),

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -52,8 +52,9 @@ import net.gini.android.vision.GiniVisionFeatureConfiguration;
 import net.gini.android.vision.R;
 import net.gini.android.vision.document.DocumentFactory;
 import net.gini.android.vision.document.GiniVisionDocument;
+import net.gini.android.vision.document.GiniVisionMultiPageDocument;
 import net.gini.android.vision.document.ImageDocument;
-import net.gini.android.vision.document.MultiPageDocument;
+import net.gini.android.vision.document.ImageMultiPageDocument;
 import net.gini.android.vision.document.QRCodeDocument;
 import net.gini.android.vision.internal.camera.api.CameraController;
 import net.gini.android.vision.internal.camera.api.CameraException;
@@ -106,7 +107,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
 
         @Override
         public void onProceedToMultiPageReviewScreen(
-                @NonNull final MultiPageDocument multiPageDocument) {
+                @NonNull final GiniVisionMultiPageDocument multiPageDocument) {
         }
 
         @Override
@@ -145,7 +146,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     private CameraFragmentListener mListener = NO_OP_LISTENER;
     private final UIExecutor mUIExecutor = new UIExecutor();
     private CameraInterface mCameraController;
-    private MultiPageDocument mMultiPageDocument;
+    private ImageMultiPageDocument mMultiPageDocument;
     private PaymentQRCodeReader mPaymentQRCodeReader;
 
     private RelativeLayout mLayoutRoot;
@@ -939,9 +940,9 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                     public void documentAccepted() {
                         LOG.debug("Client accepted the document");
                         hideActivityIndicatorAndEnableInteraction();
-                        if (document.getType() == Document.Type.MULTI_PAGE) {
+                        if (document.getType() == Document.Type.IMAGE_MULTI_PAGE) {
                             mListener.onProceedToMultiPageReviewScreen(
-                                    (MultiPageDocument) document);
+                                    (ImageMultiPageDocument) document);
                         } else {
                             mListener.onDocumentAvailable(document);
                         }
@@ -958,7 +959,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
 
     private void createMultiPageDocumentAndCallListener(@NonNull final Context context,
             @NonNull final Intent intent, @NonNull final List<Uri> uris) {
-        final MultiPageDocument multiPageDocument = new MultiPageDocument(true);
+        final ImageMultiPageDocument multiPageDocument = new ImageMultiPageDocument(true);
         for (final Uri uri : uris) {
             if (!UriHelper.isUriInputStreamAvailable(uri, context)) {
                 LOG.error("Document import failed: InputStream not available for the Uri");
@@ -973,7 +974,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                         final ImageDocument document = DocumentFactory.newImageDocumentFromUri(uri,
                                 intent, context, DeviceHelper.getDeviceOrientation(context),
                                 DeviceHelper.getDeviceType(context), "openwith");
-                        multiPageDocument.addImageDocument(document);
+                        multiPageDocument.addDocument(document);
                     } catch (final IllegalArgumentException e) {
                         LOG.error("Failed to import selected document", e);
                         showInvalidFileError(null);
@@ -985,7 +986,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                 return;
             }
         }
-        if (multiPageDocument.getImageDocuments().isEmpty()) {
+        if (multiPageDocument.getDocuments().isEmpty()) {
             LOG.error("Document import failed: Intent did not contain images");
             showInvalidFileError(null);
             return;
@@ -1038,7 +1039,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         final Bitmap rotatedBitmap = getRotatedBitmap(photo);
         mImageStack.addImage(rotatedBitmap);
         mIsMultiPage = true;
-        mMultiPageDocument = new MultiPageDocument(imageDocument, false);
+        mMultiPageDocument = new ImageMultiPageDocument(imageDocument, false);
     }
 
     private void enableInteraction() {
@@ -1100,7 +1101,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
             if (photo != null) {
                 LOG.info("Picture taken");
                 if (mIsMultiPage) {
-                    mMultiPageDocument.addImageDocument(
+                    mMultiPageDocument.addDocument(
                             (ImageDocument) DocumentFactory.newDocumentFromPhoto(photo));
                     final Bitmap rotatedBitmap = getRotatedBitmap(photo);
                     mImageStack.addImage(rotatedBitmap);

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -879,7 +879,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         return false;
     }
 
-    private void importDocumentFromIntent(final Intent data) {
+    private void importDocumentFromIntent(@NonNull final Intent data) {
         final Activity activity = mFragment
                 .getActivity();
         if (activity == null) {

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentListener.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentListener.java
@@ -5,7 +5,7 @@ import android.support.annotation.NonNull;
 import net.gini.android.vision.Document;
 import net.gini.android.vision.GiniVision;
 import net.gini.android.vision.GiniVisionError;
-import net.gini.android.vision.document.MultiPageDocument;
+import net.gini.android.vision.document.GiniVisionMultiPageDocument;
 import net.gini.android.vision.document.QRCodeDocument;
 import net.gini.android.vision.network.GiniVisionNetworkService;
 import net.gini.android.vision.network.model.GiniVisionSpecificExtraction;
@@ -27,7 +27,7 @@ public interface CameraFragmentListener {
      */
     void onDocumentAvailable(@NonNull Document document);
 
-    void onProceedToMultiPageReviewScreen(@NonNull final MultiPageDocument multiPageDocument);
+    void onProceedToMultiPageReviewScreen(@NonNull final GiniVisionMultiPageDocument multiPageDocument);
 
     /**
      * <p>

--- a/ginivision/src/main/java/net/gini/android/vision/document/DocumentFactory.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/DocumentFactory.java
@@ -11,6 +11,7 @@ import android.support.annotation.NonNull;
 
 import net.gini.android.vision.Document;
 import net.gini.android.vision.internal.camera.photo.Photo;
+import net.gini.android.vision.util.IntentHelper;
 
 /**
  * @exclude
@@ -33,9 +34,10 @@ public final class DocumentFactory {
         if (data == null) {
             throw new IllegalArgumentException("Intent data must contain a Uri");
         }
-        if (hasMimeType(intent, context, "application/pdf")) {
+        if (hasMimeType(intent, context, IntentHelper.MimeType.PDF.asString())) {
             return PdfDocument.fromIntent(intent);
-        } else if (hasMimeTypeWithPrefix(intent, context, "image/")) {
+        } else if (hasMimeTypeWithPrefix(intent, context,
+                IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
             return ImageDocument.fromIntent(intent, context, deviceOrientation, deviceType,
                     importMethod);
         }
@@ -49,9 +51,11 @@ public final class DocumentFactory {
             @NonNull final String deviceOrientation,
             @NonNull final String deviceType,
             @NonNull final String importMethod) {
-        if (hasMimeType(uri, context, "application/pdf")) {
-            throw new UnsupportedOperationException("Creating a PdfDocument from an Uri is not implemented.");
-        } else if (hasMimeTypeWithPrefix(uri, context, "image/")) {
+        if (hasMimeType(uri, context, IntentHelper.MimeType.PDF.asString())) {
+            throw new UnsupportedOperationException(
+                    "Creating a PdfDocument from an Uri is not implemented.");
+        } else if (hasMimeTypeWithPrefix(uri, context,
+                IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
             return ImageDocument.fromUri(uri, intent, context, deviceOrientation, deviceType,
                     importMethod);
         }

--- a/ginivision/src/main/java/net/gini/android/vision/document/DocumentFactory.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/DocumentFactory.java
@@ -42,6 +42,22 @@ public final class DocumentFactory {
         throw new IllegalArgumentException("Unknown Intent Uri mime type.");
     }
 
+    @NonNull
+    public static ImageDocument newImageDocumentFromUri(@NonNull final Uri uri,
+            @NonNull final Intent intent,
+            @NonNull final Context context,
+            @NonNull final String deviceOrientation,
+            @NonNull final String deviceType,
+            @NonNull final String importMethod) {
+        if (hasMimeType(uri, context, "application/pdf")) {
+            throw new UnsupportedOperationException("Creating a PdfDocument from an Uri is not implemented.");
+        } else if (hasMimeTypeWithPrefix(uri, context, "image/")) {
+            return ImageDocument.fromUri(uri, intent, context, deviceOrientation, deviceType,
+                    importMethod);
+        }
+        throw new IllegalArgumentException("Unknown Intent Uri mime type.");
+    }
+
     public static GiniVisionDocument newDocumentFromPhoto(@NonNull final Photo photo) {
         return ImageDocument.fromPhoto(photo);
     }

--- a/ginivision/src/main/java/net/gini/android/vision/document/GiniVisionMultiPageDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/GiniVisionMultiPageDocument.java
@@ -15,47 +15,48 @@ import java.util.List;
  * Copyright (c) 2018 Gini GmbH.
  */
 
-public class MultiPageDocument extends GiniVisionDocument {
+public class GiniVisionMultiPageDocument<T extends GiniVisionDocument> extends GiniVisionDocument {
 
-    public static final Creator<MultiPageDocument> CREATOR =
-            new Creator<MultiPageDocument>() {
+    public static final Creator<GiniVisionMultiPageDocument> CREATOR =
+            new Creator<GiniVisionMultiPageDocument>() {
                 @Override
-                public MultiPageDocument createFromParcel(final Parcel in) {
-                    return new MultiPageDocument(in);
+                public GiniVisionMultiPageDocument createFromParcel(final Parcel in) {
+                    return new GiniVisionMultiPageDocument(in);
                 }
 
                 @Override
-                public MultiPageDocument[] newArray(final int size) {
-                    return new MultiPageDocument[size];
+                public GiniVisionMultiPageDocument[] newArray(final int size) {
+                    return new GiniVisionMultiPageDocument[size];
                 }
             };
 
-    private final List<ImageDocument> mImageDocuments = new ArrayList<>();
+    private final List<T> mDocuments = new ArrayList<>();
 
-    public MultiPageDocument(final boolean isImported) {
-        super(Type.MULTI_PAGE, null, null, null, true, isImported);
+    public GiniVisionMultiPageDocument(@NonNull final Type type, final boolean isImported) {
+        super(type, null, null, null, true, isImported);
     }
 
-    public MultiPageDocument(@NonNull final ImageDocument imageDocument, final boolean isImported) {
-        super(Type.MULTI_PAGE, null, null, null, true, isImported);
-        mImageDocuments.add(imageDocument);
+    public GiniVisionMultiPageDocument(@NonNull final Type type, @NonNull final T document, final boolean isImported) {
+        super(type, null, null, null, true, isImported);
+        mDocuments.add(document);
     }
 
-    private MultiPageDocument(final Parcel in) {
+    GiniVisionMultiPageDocument(final Parcel in) {
         super(in);
         final int size = in.readInt();
         for (int i = 0; i < size; i++) {
-            mImageDocuments.add((ImageDocument)
-                    in.readParcelable(ImageDocument.class.getClassLoader()));
+            //noinspection unchecked
+            mDocuments.add(
+                    (T) in.readParcelable(ImageDocument.class.getClassLoader()));
         }
     }
 
-    public void addImageDocument(@NonNull final ImageDocument document) {
-        mImageDocuments.add(document);
+    public void addDocument(@NonNull final T document) {
+        mDocuments.add(document);
     }
 
-    public List<ImageDocument> getImageDocuments() {
-        return mImageDocuments;
+    public List<T> getDocuments() {
+        return mDocuments;
     }
 
     @Override
@@ -66,14 +67,14 @@ public class MultiPageDocument extends GiniVisionDocument {
     @Override
     public void writeToParcel(@NonNull final Parcel dest, final int flags) {
         super.writeToParcel(dest, flags);
-        dest.writeInt(mImageDocuments.size());
-        for (final ImageDocument imageDocument : mImageDocuments) {
-            dest.writeParcelable(imageDocument, flags);
+        dest.writeInt(mDocuments.size());
+        for (final T document : mDocuments) {
+            dest.writeParcelable(document, flags);
         }
     }
 
     public void removeImageDocumentAtPosition(final int position) {
-        mImageDocuments.remove(position);
+        mDocuments.remove(position);
     }
 
     @Override
@@ -85,8 +86,8 @@ public class MultiPageDocument extends GiniVisionDocument {
     private void loadImageDocuments(final int currentIndex,
             @NonNull final Context context,
             @NonNull final AsyncCallback<byte[]> callback) {
-        if (currentIndex < mImageDocuments.size()) {
-            final ImageDocument imageDocument = mImageDocuments.get(currentIndex);
+        if (currentIndex < mDocuments.size()) {
+            final T imageDocument = mDocuments.get(currentIndex);
             imageDocument.loadData(context, new AsyncCallback<byte[]>() {
                 @Override
                 public void onSuccess(final byte[] result) {

--- a/ginivision/src/main/java/net/gini/android/vision/document/ImageDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/ImageDocument.java
@@ -14,6 +14,7 @@ import android.support.annotation.Nullable;
 
 import net.gini.android.vision.Document;
 import net.gini.android.vision.internal.camera.photo.Photo;
+import net.gini.android.vision.util.IntentHelper;
 
 import java.util.List;
 
@@ -75,7 +76,8 @@ public final class ImageDocument extends GiniVisionDocument {
             @NonNull final String deviceType,
             @NonNull final String importMethod) {
         final List<String> mimeTypes = getMimeTypes(intent, context);
-        if (mimeTypes.isEmpty() || !hasMimeTypeWithPrefix(intent, context, "image/")) {
+        if (mimeTypes.isEmpty() || !hasMimeTypeWithPrefix(intent, context,
+                IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
             throw new IllegalArgumentException("Intent must have a mime type of image/*");
         }
         final String mimeType = mimeTypes.get(0);
@@ -92,7 +94,8 @@ public final class ImageDocument extends GiniVisionDocument {
             @NonNull final String deviceType,
             @NonNull final String importMethod) {
         final String mimeType = getMimeType(uri, context);
-        if (mimeType == null || !hasMimeTypeWithPrefix(uri, context, "image/")) {
+        if (mimeType == null || !hasMimeTypeWithPrefix(uri, context,
+                IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
             throw new IllegalArgumentException("Intent must have a mime type of image/*");
         }
         final String source = getDocumentSource(intent, context);

--- a/ginivision/src/main/java/net/gini/android/vision/document/ImageDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/ImageDocument.java
@@ -1,11 +1,13 @@
 package net.gini.android.vision.document;
 
+import static net.gini.android.vision.util.IntentHelper.getMimeType;
 import static net.gini.android.vision.util.IntentHelper.getMimeTypes;
 import static net.gini.android.vision.util.IntentHelper.getSourceAppName;
 import static net.gini.android.vision.util.IntentHelper.hasMimeTypeWithPrefix;
 
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Parcel;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -82,6 +84,22 @@ public final class ImageDocument extends GiniVisionDocument {
                 deviceType, source, importMethod);
     }
 
+    @NonNull
+    static ImageDocument fromUri(@NonNull final Uri uri,
+            @NonNull final Intent intent,
+            @NonNull final Context context,
+            @NonNull final String deviceOrientation,
+            @NonNull final String deviceType,
+            @NonNull final String importMethod) {
+        final String mimeType = getMimeType(uri, context);
+        if (mimeType == null || !hasMimeTypeWithPrefix(uri, context, "image/")) {
+            throw new IllegalArgumentException("Intent must have a mime type of image/*");
+        }
+        final String source = getDocumentSource(intent, context);
+        return new ImageDocument(uri, ImageFormat.fromMimeType(mimeType), deviceOrientation,
+                deviceType, source, importMethod);
+    }
+
     private static String getDocumentSource(@NonNull final Intent data,
             @NonNull final Context context) {
         final String appName = getSourceAppName(data, context);
@@ -99,7 +117,7 @@ public final class ImageDocument extends GiniVisionDocument {
 
     private ImageDocument(@NonNull final Photo photo,
             @Nullable final Intent intent) {
-        super(Type.IMAGE, photo.getData(), intent, true, photo.isImported());
+        super(Type.IMAGE, photo.getData(), intent, null, true, photo.isImported());
         mRotationForDisplay = photo.getRotationForDisplay();
         mFormat = photo.getImageFormat();
         mDeviceOrientation = photo.getDeviceOrientation();
@@ -113,7 +131,21 @@ public final class ImageDocument extends GiniVisionDocument {
             @NonNull final String deviceType,
             @NonNull final String source,
             @NonNull final String importMethod) {
-        super(Type.IMAGE, null, intent, true, true);
+        super(Type.IMAGE, null, intent, null, true, true);
+        mRotationForDisplay = 0;
+        mFormat = format;
+        mDeviceOrientation = deviceOrientation;
+        mDeviceType = deviceType;
+        mSource = source;
+        mImportMethod = importMethod;
+    }
+
+    private ImageDocument(@Nullable final Uri uri, @NonNull final ImageFormat format,
+            @NonNull final String deviceOrientation,
+            @NonNull final String deviceType,
+            @NonNull final String source,
+            @NonNull final String importMethod) {
+        super(Type.IMAGE, null, null, uri, true, true);
         mRotationForDisplay = 0;
         mFormat = format;
         mDeviceOrientation = deviceOrientation;

--- a/ginivision/src/main/java/net/gini/android/vision/document/ImageMultiPageDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/ImageMultiPageDocument.java
@@ -1,0 +1,50 @@
+package net.gini.android.vision.document;
+
+import android.os.Parcel;
+import android.support.annotation.NonNull;
+
+/**
+ * Created by Alpar Szotyori on 14.03.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+
+public class ImageMultiPageDocument extends GiniVisionMultiPageDocument<ImageDocument> {
+
+    public static final Creator<ImageMultiPageDocument> CREATOR =
+            new Creator<ImageMultiPageDocument>() {
+                @Override
+                public ImageMultiPageDocument createFromParcel(final Parcel in) {
+                    return new ImageMultiPageDocument(in);
+                }
+
+                @Override
+                public ImageMultiPageDocument[] newArray(final int size) {
+                    return new ImageMultiPageDocument[size];
+                }
+            };
+
+    public ImageMultiPageDocument(final boolean isImported) {
+        super(Type.IMAGE_MULTI_PAGE, isImported);
+    }
+
+    public ImageMultiPageDocument(
+            @NonNull final ImageDocument document,
+            final boolean isImported) {
+        super(Type.IMAGE_MULTI_PAGE, document, isImported);
+    }
+
+    private ImageMultiPageDocument(final Parcel in) {
+        super(in);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull final Parcel dest, final int flags) {
+        super.writeToParcel(dest, flags);
+    }
+}

--- a/ginivision/src/main/java/net/gini/android/vision/document/MultiPageDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/MultiPageDocument.java
@@ -30,23 +30,20 @@ public class MultiPageDocument extends GiniVisionDocument {
                 }
             };
 
-    private final List<ImageDocument> mImageDocuments;
+    private final List<ImageDocument> mImageDocuments = new ArrayList<>();
 
     public MultiPageDocument(final boolean isImported) {
         super(Type.MULTI_PAGE, null, null, null, true, isImported);
-        mImageDocuments = new ArrayList<>();
     }
 
     public MultiPageDocument(@NonNull final ImageDocument imageDocument, final boolean isImported) {
         super(Type.MULTI_PAGE, null, null, null, true, isImported);
-        mImageDocuments = new ArrayList<>();
         mImageDocuments.add(imageDocument);
     }
 
     private MultiPageDocument(final Parcel in) {
         super(in);
         final int size = in.readInt();
-        mImageDocuments = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             mImageDocuments.add((ImageDocument)
                     in.readParcelable(ImageDocument.class.getClassLoader()));

--- a/ginivision/src/main/java/net/gini/android/vision/document/PdfDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/PdfDocument.java
@@ -16,8 +16,6 @@ import net.gini.android.vision.util.IntentHelper;
  */
 public final class PdfDocument extends GiniVisionDocument {
 
-    private final Uri mUri;
-
     /**
      * Creates an instance using the resource pointed to by the Intent's Uri.
      *
@@ -27,7 +25,11 @@ public final class PdfDocument extends GiniVisionDocument {
      */
     @NonNull
     static PdfDocument fromIntent(final Intent intent) {
-        return new PdfDocument(intent);
+        final Uri uri = IntentHelper.getUri(intent);
+        if (uri == null) {
+            throw new IllegalArgumentException("Intent data must contain a Uri");
+        }
+        return new PdfDocument(intent, uri);
     }
 
     /**
@@ -35,24 +37,8 @@ public final class PdfDocument extends GiniVisionDocument {
      * @param intent an Intent that must point to a PDF
      * @throws IllegalArgumentException if the Intent's data is null
      */
-    private PdfDocument(@NonNull final Intent intent) {
-        super(Type.PDF, null, intent, false, true);
-        mUri = IntentHelper.getUri(intent);
-        if (mUri == null) {
-            throw new IllegalArgumentException("Intent data must contain a Uri");
-        }
-    }
-
-    /**
-     * <p>
-     *     Retrieve the Uri of the PDF.
-     * </p>
-     *
-     * @return the Uri pointing to the PDF
-     */
-    @NonNull
-    public Uri getUri() {
-        return mUri;
+    private PdfDocument(@NonNull final Intent intent, @NonNull final Uri uri) {
+        super(Type.PDF, null, intent, uri, false, true);
     }
 
     /**
@@ -69,7 +55,6 @@ public final class PdfDocument extends GiniVisionDocument {
     @Override
     public void writeToParcel(final Parcel dest, final int flags) {
         super.writeToParcel(dest, flags);
-        dest.writeParcelable(mUri, flags);
     }
 
     /**
@@ -92,6 +77,5 @@ public final class PdfDocument extends GiniVisionDocument {
      */
     private PdfDocument(final Parcel in) {
         super(in);
-        mUri = in.readParcelable(Uri.class.getClassLoader());
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/document/QRCodeDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/QRCodeDocument.java
@@ -57,7 +57,7 @@ public final class QRCodeDocument extends GiniVisionDocument {
 
     private QRCodeDocument(@NonNull final byte[] data,
             @NonNull final PaymentQRCodeData paymentQRCodeData) {
-        super(Type.QRCode, data, null, false, false);
+        super(Type.QRCode, data, null, null,false, false);
         mPaymentData = paymentQRCodeData;
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/document/QRCodeDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/QRCodeDocument.java
@@ -57,7 +57,7 @@ public final class QRCodeDocument extends GiniVisionDocument {
 
     private QRCodeDocument(@NonNull final byte[] data,
             @NonNull final PaymentQRCodeData paymentQRCodeData) {
-        super(Type.QRCode, data, null, null,false, false);
+        super(Type.QRCode, data, null, null, false, false);
         mPaymentData = paymentQRCodeData;
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
@@ -292,6 +292,9 @@ public class FileChooserActivity extends AppCompatActivity {
     private static Intent createImagePickerIntent() {
         final Intent intent = new Intent(ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
         intent.setType("image/*");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+        }
         return intent;
     }
 
@@ -312,6 +315,9 @@ public class FileChooserActivity extends AppCompatActivity {
         }
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("image/*");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+        }
         return intent;
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/util/FileImportValidator.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/util/FileImportValidator.java
@@ -16,6 +16,7 @@ import net.gini.android.vision.util.UriHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -59,7 +60,16 @@ public class FileImportValidator {
 
     public boolean matchesCriteria(@NonNull final Intent intent, @NonNull final Uri fileUri) {
         final List<String> mimeTypes = IntentHelper.getMimeTypes(intent, mContext);
+        return matchesCriteria(fileUri, mimeTypes);
+    }
 
+    public boolean matchesCriteria(@NonNull final Uri fileUri) {
+        final List<String> mimeTypes = Collections.singletonList(
+                IntentHelper.getMimeType(fileUri, mContext));
+        return matchesCriteria(fileUri, mimeTypes);
+    }
+
+    private boolean matchesCriteria(final @NonNull Uri fileUri, final List<String> mimeTypes) {
         if (!isSupportedFileType(mimeTypes)) {
             mError = Error.TYPE_NOT_SUPPORTED;
             return false;

--- a/ginivision/src/main/java/net/gini/android/vision/review/MultiPageReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/MultiPageReviewActivity.java
@@ -24,10 +24,9 @@ import android.widget.ImageButton;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import net.gini.android.vision.Document;
 import net.gini.android.vision.R;
 import net.gini.android.vision.document.ImageDocument;
-import net.gini.android.vision.document.MultiPageDocument;
+import net.gini.android.vision.document.ImageMultiPageDocument;
 import net.gini.android.vision.internal.AsyncCallback;
 import net.gini.android.vision.internal.camera.photo.Photo;
 import net.gini.android.vision.internal.camera.photo.PhotoFactory;
@@ -44,7 +43,7 @@ public class MultiPageReviewActivity extends AppCompatActivity {
     public static final String EXTRA_IN_DOCUMENT = "GV_EXTRA_IN_DOCUMENT";
     private ViewPager mImagesPager;
     private ImagesPagerChangeListener mImagesPagerChangeListener;
-    private MultiPageDocument mMultiPageDocument;
+    private ImageMultiPageDocument mMultiPageDocument;
     private TextView mPageIndicator;
     private List<Photo> mPhotos;
     private RelativeLayout mRootView;
@@ -54,7 +53,7 @@ public class MultiPageReviewActivity extends AppCompatActivity {
     private ImageButton mDeleteButton;
 
     public static Intent createIntent(@NonNull final Context context,
-            @NonNull final Document multiPageDocument) {
+            @NonNull final ImageMultiPageDocument multiPageDocument) {
         final Intent intent = new Intent(context, MultiPageReviewActivity.class);
         intent.putExtra(EXTRA_IN_DOCUMENT, multiPageDocument);
         return intent;
@@ -169,7 +168,7 @@ public class MultiPageReviewActivity extends AppCompatActivity {
         mMultiPageDocument.loadData(this, new AsyncCallback<byte[]>() {
             @Override
             public void onSuccess(final byte[] result) {
-                for (final ImageDocument imageDocument : mMultiPageDocument.getImageDocuments()) {
+                for (final ImageDocument imageDocument : mMultiPageDocument.getDocuments()) {
                     mPhotos.add(PhotoFactory.newPhotoFromDocument(imageDocument));
                 }
                 showPhotos();
@@ -248,7 +247,7 @@ public class MultiPageReviewActivity extends AppCompatActivity {
     private void checkRequiredExtras() {
         if (mMultiPageDocument == null) {
             throw new IllegalStateException(
-                    "MultiPageReviewActivity requires a MultiPageDocument. Set it as an extra using the EXTRA_IN_DOCUMENT key.");
+                    "MultiPageReviewActivity requires a GiniVisionMultiPageDocument. Set it as an extra using the EXTRA_IN_DOCUMENT key.");
         }
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/review/MultiPageReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/MultiPageReviewActivity.java
@@ -51,6 +51,7 @@ public class MultiPageReviewActivity extends AppCompatActivity {
     private RecyclerView mThumbnailsRV;
     private RecyclerView.SmoothScroller mThumbnailsScroller;
     private ImageButton mButtonNext;
+    private ImageButton mDeleteButton;
 
     public static Intent createIntent(@NonNull final Context context,
             @NonNull final Document multiPageDocument) {
@@ -75,20 +76,6 @@ public class MultiPageReviewActivity extends AppCompatActivity {
         });
 
         mPhotos = new ArrayList<>();
-        mMultiPageDocument.loadData(this, new AsyncCallback<byte[]>() {
-            @Override
-            public void onSuccess(final byte[] result) {
-                for (final ImageDocument imageDocument : mMultiPageDocument.getImageDocuments()) {
-                    mPhotos.add(PhotoFactory.newPhotoFromDocument(imageDocument));
-                }
-                showPhotos();
-            }
-
-            @Override
-            public void onError(final Exception exception) {
-
-            }
-        });
 
         mImagesPager = findViewById(R.id.gv_view_pager);
 
@@ -134,8 +121,6 @@ public class MultiPageReviewActivity extends AppCompatActivity {
             }
         });
 
-
-
         final LinearLayoutManager layoutManager = new LinearLayoutManager(this,
                 LinearLayoutManager.HORIZONTAL, false);
         mThumbnailsRV.setLayoutManager(layoutManager);
@@ -157,13 +142,9 @@ public class MultiPageReviewActivity extends AppCompatActivity {
             }
         });
 
-        final ImageButton deleteButton = findViewById(R.id.gv_button_delete);
-        if (mPhotos.size() == 1) {
-            deleteButton.setEnabled(false);
-            deleteButton.setAlpha(0.2f);
-        }
+        mDeleteButton = findViewById(R.id.gv_button_delete);
 
-        deleteButton.setOnClickListener(new View.OnClickListener() {
+        mDeleteButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(final View v) {
                 final int deletedItem = mImagesPager.getCurrentItem();
@@ -179,9 +160,24 @@ public class MultiPageReviewActivity extends AppCompatActivity {
                 mThumbnailsScroller.setTargetPosition(newPosition);
                 mThumbnailsRV.getLayoutManager().startSmoothScroll(mThumbnailsScroller);
                 if (mPhotos.size() == 1) {
-                    deleteButton.setEnabled(false);
-                    deleteButton.setAlpha(0.2f);
+                    mDeleteButton.setEnabled(false);
+                    mDeleteButton.setAlpha(0.2f);
                 }
+            }
+        });
+
+        mMultiPageDocument.loadData(this, new AsyncCallback<byte[]>() {
+            @Override
+            public void onSuccess(final byte[] result) {
+                for (final ImageDocument imageDocument : mMultiPageDocument.getImageDocuments()) {
+                    mPhotos.add(PhotoFactory.newPhotoFromDocument(imageDocument));
+                }
+                showPhotos();
+            }
+
+            @Override
+            public void onError(final Exception exception) {
+
             }
         });
     }
@@ -205,6 +201,11 @@ public class MultiPageReviewActivity extends AppCompatActivity {
                 mImagesPager.setCurrentItem(position);
             }
         };
+
+        if (mPhotos.size() == 1) {
+            mDeleteButton.setEnabled(false);
+            mDeleteButton.setAlpha(0.2f);
+        }
 
         mImagesPager.setAdapter(imagesPagerAdapter);
         final ThumbnailsAdapter thumbnailsAdapter = new ThumbnailsAdapter(mPhotos,

--- a/ginivision/src/main/java/net/gini/android/vision/util/IntentHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/util/IntentHelper.java
@@ -78,6 +78,34 @@ public final class IntentHelper {
     }
 
     @Nullable
+    public static List<Uri> getUris(@NonNull final Intent intent) {
+        final ArrayList<Uri> uris = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
+        if (uris != null) {
+            return uris;
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            final ClipData clipData = intent.getClipData();
+            if (clipData != null) {
+                final int count = clipData.getItemCount();
+                final ArrayList<Uri> clipDataUris = new ArrayList<>(count);
+                for (int i = 0; i < count; i++) {
+                    clipDataUris.add(clipData.getItemAt(i).getUri());
+                }
+                return clipDataUris;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    public static String getMimeType(@NonNull final Uri uri, @NonNull final Context context) {
+        final String type = context.getContentResolver().getType(uri);
+        if (type == null) {
+            return getMimeTypeFromUrl(uri.getPath());
+        }
+        return type;
+    }
+
+    @Nullable
     private static String getMimeTypeFromUrl(@NonNull final String url) {
         final String extension = MimeTypeMap.getFileExtensionFromUrl(url);
         if (extension != null) {
@@ -107,6 +135,12 @@ public final class IntentHelper {
         return false;
     }
 
+    public static boolean hasMimeType(@NonNull final Uri uri,
+            @NonNull final Context context, @NonNull final String mimeType) {
+        final String actualMimeType = getMimeType(uri, context);
+        return actualMimeType != null && actualMimeType.equals(mimeType);
+    }
+
     /**
      * Check whether the Intent has a mime-type starting the provided prefix.
      *
@@ -125,6 +159,12 @@ public final class IntentHelper {
             }
         }
         return false;
+    }
+
+    public static boolean hasMimeTypeWithPrefix(@NonNull final Uri uri,
+            @NonNull final Context context, @NonNull final String prefix) {
+        final String actualMimeType = getMimeType(uri, context);
+        return actualMimeType != null && actualMimeType.startsWith(prefix);
     }
 
     /**
@@ -150,6 +190,11 @@ public final class IntentHelper {
             // Ignore
         }
         return null;
+    }
+
+    public static boolean hasMultipleUris(@NonNull final Intent intent) {
+        final List<Uri> uris = getUris(intent);
+        return uris != null && uris.size() > 1;
     }
 
     private IntentHelper() {

--- a/ginivision/src/main/java/net/gini/android/vision/util/IntentHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/util/IntentHelper.java
@@ -21,6 +21,21 @@ import java.util.List;
  */
 public final class IntentHelper {
 
+    public enum MimeType {
+        IMAGE_PREFIX("image/"),
+        PDF("application/pdf");
+
+        private final String mMimeType;
+
+        MimeType(final String mimeType) {
+            mMimeType = mimeType;
+        }
+
+        public String asString() {
+            return mMimeType;
+        }
+    }
+
     /**
      * Retrieves the Uri from the Intent.
      *

--- a/screenapiexample/build.gradle
+++ b/screenapiexample/build.gradle
@@ -31,6 +31,7 @@ android {
             }
         }
 
+        multiDexEnabled true
     }
 
     signingConfigs {
@@ -67,6 +68,7 @@ repositories {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation deps.appCompatv7
+    implementation 'com.android.support:multidex:1.0.3'
 
     implementation 'com.karumi:dexter:4.2.0'
 

--- a/screenapiexample/src/main/AndroidManifest.xml
+++ b/screenapiexample/src/main/AndroidManifest.xml
@@ -31,8 +31,14 @@
             <intent-filter android:label="@string/app_name">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.SEND" />
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
+            </intent-filter>
+            <intent-filter android:label="@string/app_name">
+                <action android:name="android.intent.action.VIEW" />
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="application/pdf" />
             </intent-filter>
         </activity>

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
@@ -148,7 +148,9 @@ public class MainActivity extends AppCompatActivity {
 
     private boolean isIntentActionViewOrSend(@NonNull final Intent intent) {
         final String action = intent.getAction();
-        return Intent.ACTION_VIEW.equals(action) || Intent.ACTION_SEND.equals(action);
+        return Intent.ACTION_VIEW.equals(action)
+                || Intent.ACTION_SEND.equals(action)
+                || Intent.ACTION_SEND_MULTIPLE.equals(action);
     }
 
     private void showVersions() {
@@ -310,7 +312,8 @@ public class MainActivity extends AppCompatActivity {
                     // method
                     // The payload format is up to you. For the example we added all the extractions as key-value pairs to
                     // a Bundle.
-                    Bundle extractionsBundle = data.getBundleExtra(CameraActivity.EXTRA_OUT_EXTRACTIONS);
+                    Bundle extractionsBundle = data.getBundleExtra(
+                            CameraActivity.EXTRA_OUT_EXTRACTIONS);
                     if (extractionsBundle == null) {
                         extractionsBundle = data.getBundleExtra(MainActivity.EXTRA_OUT_EXTRACTIONS);
                     }


### PR DESCRIPTION
Added support for opening and importing multiple images.

Received files that have unsupported mime types are ignored. Only images are used. Not showing any warnings in this PR.

### How to test
Run the Screen API Example app (Component API Example app doesn't work as the Multi-Page Review Screen is not usable with the Component API currently).

### Ticket 
#149 
