### PR TITLE
Feature multi page copy imported images

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/GiniVision.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVision.java
@@ -64,9 +64,9 @@ public class GiniVision {
         if (sInstance != null) {
             sInstance.mDocumentDataMemoryCache.clear();
             sInstance.mPhotoMemoryCache.clear();
-            sInstance.mImageDiskStore.clear(context);
             sInstance = null;
         }
+        ImageDiskStore.clear(context);
     }
 
     private GiniVision(@NonNull final Builder builder) {

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
@@ -204,7 +204,7 @@ public final class GiniVisionFileImport {
             if (fileImportValidator.matchesCriteria(uri)) {
                 if (IntentHelper.hasMimeTypeWithPrefix(uri, context,
                         IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
-                    final ImageDocument document = DocumentFactory.newImageDocumentFromUri(uri,
+                    final ImageDocument document = DocumentFactory.newImageDocumentFromExternalUri(uri,
                             intent, context, DeviceHelper.getDeviceOrientation(context),
                             DeviceHelper.getDeviceType(context), "openwith");
                     multiPageDocument.addDocument(document);

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
@@ -204,7 +204,7 @@ public final class GiniVisionFileImport {
             if (fileImportValidator.matchesCriteria(uri)) {
                 if (IntentHelper.hasMimeTypeWithPrefix(uri, context,
                         IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
-                    final ImageDocument document = DocumentFactory.newImageDocumentFromExternalUri(uri,
+                    final ImageDocument document = DocumentFactory.newImageDocumentFromUri(uri,
                             intent, context, DeviceHelper.getDeviceOrientation(context),
                             DeviceHelper.getDeviceType(context), "openwith");
                     multiPageDocument.addDocument(document);

--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
@@ -38,6 +38,7 @@ import net.gini.android.vision.document.PdfDocument;
 import net.gini.android.vision.internal.AsyncCallback;
 import net.gini.android.vision.internal.document.DocumentRenderer;
 import net.gini.android.vision.internal.document.DocumentRendererFactory;
+import net.gini.android.vision.internal.storage.ImageDiskStore;
 import net.gini.android.vision.internal.ui.ErrorSnackbar;
 import net.gini.android.vision.internal.ui.FragmentImplCallback;
 import net.gini.android.vision.internal.util.Size;
@@ -132,7 +133,7 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
 
     @Override
     public void onDocumentAnalyzed() {
-
+        clearSavedImages();
     }
 
     @Override
@@ -416,6 +417,8 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
                                 } else {
                                     mListener.onExtractionsAvailable(extractions);
                                 }
+                                // Remove all stored images
+                                clearSavedImages();
                             }
 
                             @Override
@@ -429,6 +432,14 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
         } else {
             mListener.onAnalyzeDocument(mDocument);
         }
+    }
+
+    private void clearSavedImages() {
+        final Activity activity = mFragment.getActivity();
+        if (activity == null) {
+            return;
+        }
+        ImageDiskStore.clear(activity);
     }
 
     private void bindViews(@NonNull final View view) {

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -906,7 +906,6 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                 showInvalidFileError(null);
                 return;
             }
-            // TODO: make copy of imported images
             handleMultiPageDocumentAndCallListener(activity, data, uris);
         } else {
             final Uri uri = IntentHelper.getUri(data);

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -992,17 +992,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                 if (IntentHelper.hasMimeTypeWithPrefix(uri, context,
                         IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
                     try {
-                        final Uri localUri = GiniVision.getInstance().internal().getImageDiskStore()
-                                .save(context, uri);
-                        if (localUri == null) {
-                            LOG.error("Failed to import selected document: "
-                                    + "could not copy to app storage");
-                            addMultiPageDocumentError(context.getString(
-                                    R.string.gv_document_import_invalid_document));
-                            break;
-                        }
-                        final ImageDocument document = DocumentFactory.newImageDocumentFromLocalUri(
-                                localUri,
+                        final ImageDocument document = DocumentFactory.newImageDocumentFromUri(uri,
                                 intent, context, DeviceHelper.getDeviceOrientation(context),
                                 DeviceHelper.getDeviceType(context), "openwith");
                         mMultiPageDocument.addDocument(document);

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -993,7 +993,17 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                 if (IntentHelper.hasMimeTypeWithPrefix(uri, context,
                         IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
                     try {
-                        final ImageDocument document = DocumentFactory.newImageDocumentFromUri(uri,
+                        final Uri localUri = GiniVision.getInstance().internal().getImageDiskStore()
+                                .save(context, uri);
+                        if (localUri == null) {
+                            LOG.error("Failed to import selected document: "
+                                    + "could not copy to app storage");
+                            addMultiPageDocumentError(context.getString(
+                                    R.string.gv_document_import_invalid_document));
+                            break;
+                        }
+                        final ImageDocument document = DocumentFactory.newImageDocumentFromLocalUri(
+                                localUri,
                                 intent, context, DeviceHelper.getDeviceOrientation(context),
                                 DeviceHelper.getDeviceType(context), "openwith");
                         mMultiPageDocument.addDocument(document);

--- a/ginivision/src/main/java/net/gini/android/vision/document/DocumentFactory.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/DocumentFactory.java
@@ -44,25 +44,14 @@ public final class DocumentFactory {
         throw new IllegalArgumentException("Unknown Intent Uri mime type.");
     }
 
-    @NonNull
-    public static ImageDocument newImageDocumentFromLocalUri(@NonNull final Uri uri,
+   @NonNull
+    public static ImageDocument newImageDocumentFromUri(@NonNull final Uri externalUri,
             @NonNull final Intent intent,
             @NonNull final Context context,
             @NonNull final String deviceOrientation,
             @NonNull final String deviceType,
             @NonNull final String importMethod) {
-        return ImageDocument.fromLocalUri(uri, intent, context, deviceOrientation, deviceType,
-                importMethod);
-    }
-
-    @NonNull
-    public static ImageDocument newImageDocumentFromExternalUri(@NonNull final Uri externalUri,
-            @NonNull final Intent intent,
-            @NonNull final Context context,
-            @NonNull final String deviceOrientation,
-            @NonNull final String deviceType,
-            @NonNull final String importMethod) {
-        return ImageDocument.fromExternalUri(externalUri, intent, context, deviceOrientation, deviceType,
+        return ImageDocument.fromUri(externalUri, intent, context, deviceOrientation, deviceType,
                 importMethod);
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/document/DocumentFactory.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/DocumentFactory.java
@@ -45,21 +45,25 @@ public final class DocumentFactory {
     }
 
     @NonNull
-    public static ImageDocument newImageDocumentFromUri(@NonNull final Uri uri,
+    public static ImageDocument newImageDocumentFromLocalUri(@NonNull final Uri uri,
             @NonNull final Intent intent,
             @NonNull final Context context,
             @NonNull final String deviceOrientation,
             @NonNull final String deviceType,
             @NonNull final String importMethod) {
-        if (hasMimeType(uri, context, IntentHelper.MimeType.PDF.asString())) {
-            throw new UnsupportedOperationException(
-                    "Creating a PdfDocument from an Uri is not implemented.");
-        } else if (hasMimeTypeWithPrefix(uri, context,
-                IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
-            return ImageDocument.fromUri(uri, intent, context, deviceOrientation, deviceType,
-                    importMethod);
-        }
-        throw new IllegalArgumentException("Unknown Intent Uri mime type.");
+        return ImageDocument.fromLocalUri(uri, intent, context, deviceOrientation, deviceType,
+                importMethod);
+    }
+
+    @NonNull
+    public static ImageDocument newImageDocumentFromExternalUri(@NonNull final Uri externalUri,
+            @NonNull final Intent intent,
+            @NonNull final Context context,
+            @NonNull final String deviceOrientation,
+            @NonNull final String deviceType,
+            @NonNull final String importMethod) {
+        return ImageDocument.fromExternalUri(externalUri, intent, context, deviceOrientation, deviceType,
+                importMethod);
     }
 
     public static ImageDocument newEmptyImageDocument() {

--- a/ginivision/src/main/java/net/gini/android/vision/document/ImageDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/ImageDocument.java
@@ -108,7 +108,7 @@ public final class ImageDocument extends GiniVisionDocument {
     }
 
     @NonNull
-    static ImageDocument fromLocalUri(@NonNull final Uri uri,
+    static ImageDocument fromUri(@NonNull final Uri uri,
             @NonNull final Intent intent,
             @NonNull final Context context,
             @NonNull final String deviceOrientation,
@@ -120,29 +120,12 @@ public final class ImageDocument extends GiniVisionDocument {
             throw new IllegalArgumentException("Intent must have a mime type of image/*");
         }
         final String source = getDocumentSource(intent, context);
-        return new ImageDocument(uri, ImageFormat.fromMimeType(mimeType), deviceOrientation,
-                deviceType, source, importMethod);
-    }
-
-    @NonNull
-    static ImageDocument fromExternalUri(@NonNull final Uri externalUri,
-            @NonNull final Intent intent,
-            @NonNull final Context context,
-            @NonNull final String deviceOrientation,
-            @NonNull final String deviceType,
-            @NonNull final String importMethod) {
-        final String mimeType = getMimeType(externalUri, context);
-        if (mimeType == null || !hasMimeTypeWithPrefix(externalUri, context,
-                IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
-            throw new IllegalArgumentException("Intent must have a mime type of image/*");
-        }
-        final String source = getDocumentSource(intent, context);
         final Uri localUri = GiniVision.getInstance().internal().getImageDiskStore()
-                .save(context, externalUri);
+                .save(context, uri);
         if (localUri == null) {
             throw new IllegalArgumentException("Failed to copy to app storage");
         }
-        return new ImageDocument(externalUri, ImageFormat.fromMimeType(mimeType), deviceOrientation,
+        return new ImageDocument(localUri, ImageFormat.fromMimeType(mimeType), deviceOrientation,
                 deviceType, source, importMethod);
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/document/ImageDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/ImageDocument.java
@@ -98,12 +98,17 @@ public final class ImageDocument extends GiniVisionDocument {
         if (uri == null) {
             throw new IllegalArgumentException("Intent must have a Uri");
         }
-        final Uri localUri = GiniVision.getInstance().internal().getImageDiskStore()
-                .save(context, uri);
-        if (localUri == null) {
-            throw new IllegalArgumentException("Failed to copy to app storage");
+        final Uri imageUri;
+        if (/*multipage enabled*/ true) { // TODO: mutipage feature toggle
+            imageUri = GiniVision.getInstance().internal().getImageDiskStore()
+                    .save(context, uri);
+            if (imageUri == null) {
+                throw new IllegalArgumentException("Failed to copy to app storage");
+            }
+        } else {
+            imageUri = uri;
         }
-        return new ImageDocument(intent, localUri, ImageFormat.fromMimeType(mimeType), deviceOrientation,
+        return new ImageDocument(intent, imageUri, ImageFormat.fromMimeType(mimeType), deviceOrientation,
                 deviceType, source, importMethod);
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/document/ImageDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/ImageDocument.java
@@ -1,9 +1,9 @@
 package net.gini.android.vision.document;
 
-import static net.gini.android.vision.util.IntentHelper.getMimeType;
 import static net.gini.android.vision.util.IntentHelper.getMimeTypes;
 import static net.gini.android.vision.util.IntentHelper.getSourceAppName;
 import static net.gini.android.vision.util.IntentHelper.hasMimeTypeWithPrefix;
+import static net.gini.android.vision.util.UriHelper.getMimeType;
 
 import android.content.Context;
 import android.content.Intent;
@@ -13,6 +13,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import net.gini.android.vision.Document;
+import net.gini.android.vision.GiniVision;
 import net.gini.android.vision.internal.camera.photo.Photo;
 import net.gini.android.vision.util.IntentHelper;
 
@@ -93,12 +94,21 @@ public final class ImageDocument extends GiniVisionDocument {
         }
         final String mimeType = mimeTypes.get(0);
         final String source = getDocumentSource(intent, context);
-        return new ImageDocument(intent, ImageFormat.fromMimeType(mimeType), deviceOrientation,
+        final Uri uri = IntentHelper.getUri(intent);
+        if (uri == null) {
+            throw new IllegalArgumentException("Intent must have a Uri");
+        }
+        final Uri localUri = GiniVision.getInstance().internal().getImageDiskStore()
+                .save(context, uri);
+        if (localUri == null) {
+            throw new IllegalArgumentException("Failed to copy to app storage");
+        }
+        return new ImageDocument(intent, localUri, ImageFormat.fromMimeType(mimeType), deviceOrientation,
                 deviceType, source, importMethod);
     }
 
     @NonNull
-    static ImageDocument fromUri(@NonNull final Uri uri,
+    static ImageDocument fromLocalUri(@NonNull final Uri uri,
             @NonNull final Intent intent,
             @NonNull final Context context,
             @NonNull final String deviceOrientation,
@@ -111,6 +121,28 @@ public final class ImageDocument extends GiniVisionDocument {
         }
         final String source = getDocumentSource(intent, context);
         return new ImageDocument(uri, ImageFormat.fromMimeType(mimeType), deviceOrientation,
+                deviceType, source, importMethod);
+    }
+
+    @NonNull
+    static ImageDocument fromExternalUri(@NonNull final Uri externalUri,
+            @NonNull final Intent intent,
+            @NonNull final Context context,
+            @NonNull final String deviceOrientation,
+            @NonNull final String deviceType,
+            @NonNull final String importMethod) {
+        final String mimeType = getMimeType(externalUri, context);
+        if (mimeType == null || !hasMimeTypeWithPrefix(externalUri, context,
+                IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
+            throw new IllegalArgumentException("Intent must have a mime type of image/*");
+        }
+        final String source = getDocumentSource(intent, context);
+        final Uri localUri = GiniVision.getInstance().internal().getImageDiskStore()
+                .save(context, externalUri);
+        if (localUri == null) {
+            throw new IllegalArgumentException("Failed to copy to app storage");
+        }
+        return new ImageDocument(externalUri, ImageFormat.fromMimeType(mimeType), deviceOrientation,
                 deviceType, source, importMethod);
     }
 
@@ -150,12 +182,13 @@ public final class ImageDocument extends GiniVisionDocument {
         mImportMethod = photo.getImportMethod();
     }
 
-    private ImageDocument(@Nullable final Intent intent, @NonNull final ImageFormat format,
+    private ImageDocument(@Nullable final Intent intent, @Nullable final Uri uri,
+            @NonNull final ImageFormat format,
             @NonNull final String deviceOrientation,
             @NonNull final String deviceType,
             @NonNull final String source,
             @NonNull final String importMethod) {
-        super(Type.IMAGE, null, intent, null, true, true);
+        super(Type.IMAGE, null, intent, uri, true, true);
         mRotationForDisplay = 0;
         mFormat = format;
         mDeviceOrientation = deviceOrientation;

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Exif.java
@@ -237,11 +237,15 @@ class Exif {
 
         @NonNull
         public Builder setOrientationFromDegrees(final int degrees) {
-            final byte[] bytes = new byte[1];
-            bytes[0] = (byte) rotationToExifOrientation(degrees);
-            final TiffOutputField orientationOutputField = new TiffOutputField(
-                    TiffTagConstants.TIFF_TAG_ORIENTATION, FieldType.SHORT, 1, bytes);
-            mIfd0Directory.add(orientationOutputField);
+            try {
+                final short orientation = rotationToExifOrientation(degrees);
+                final byte[] bytes = FieldType.SHORT.writeData(orientation,
+                        mTiffOutputSet.byteOrder);
+                final TiffOutputField orientationOutputField = new TiffOutputField(
+                        TiffTagConstants.TIFF_TAG_ORIENTATION, FieldType.SHORT, 1, bytes);
+                mIfd0Directory.add(orientationOutputField);
+            } catch (final ImageWriteException ignore) {
+            }
             return this;
         }
 
@@ -271,8 +275,8 @@ class Exif {
             outputDirectory.add(outputField);
         }
 
-        private static int rotationToExifOrientation(final int degrees) {
-            final int exifOrientation;
+        private static short rotationToExifOrientation(final int degrees) {
+            final short exifOrientation;
             switch (degrees) {
                 case 0:
                     exifOrientation = 1; // 0CW

--- a/ginivision/src/main/java/net/gini/android/vision/internal/storage/ImageDiskStore.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/storage/ImageDiskStore.java
@@ -1,5 +1,7 @@
 package net.gini.android.vision.internal.storage;
 
+import static net.gini.android.vision.util.UriHelper.getFileExtension;
+
 import android.content.Context;
 import android.net.Uri;
 import android.support.annotation.NonNull;
@@ -8,14 +10,13 @@ import android.support.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
 
 /**
  * Created by Alpar Szotyori on 20.03.2018.
@@ -29,7 +30,7 @@ public class ImageDiskStore {
 
     @Nullable
     public Uri save(@NonNull final Context context, @NonNull final byte[] bytes) {
-        final Uri uri = generateUri(context);
+        final Uri uri = generateUri(context, null);
         final File file = createFile(uri);
         if (file == null) {
             return null;
@@ -43,11 +44,41 @@ public class ImageDiskStore {
         }
     }
 
+    @Nullable
+    public Uri save(@NonNull final Context context, @NonNull final Uri fromUri) {
+        InputStream inputStream = null;
+        try {
+            inputStream = context.getContentResolver().openInputStream(fromUri);
+            if (inputStream == null) {
+                return null;
+            }
+            final String extension = getFileExtension(fromUri, context);
+            final Uri uri = generateUri(context, extension);
+            final File file = createFile(uri);
+            if (file == null) {
+                return null;
+            }
+            writeToFile(file, inputStream);
+            return uri;
+        } catch (final FileNotFoundException e) {
+            LOG.error("Failed to open uri", e);
+            return null;
+        } catch (final IOException e) {
+            LOG.error("Failed to write file", e);
+            return null;
+        } finally {
+            if (inputStream != null) {
+                try {
+                    inputStream.close();
+                } catch (final IOException ignored) {
+                }
+            }
+        }
+    }
+
     @NonNull
-    private Uri generateUri(@NonNull final Context context) {
-        final Date now = new Date();
-        final DateFormat dateFormat = new SimpleDateFormat("ddMMyyyyHHmmssS", Locale.US);
-        final String filename = dateFormat.format(now);
+    private Uri generateUri(@NonNull final Context context, @Nullable final String extension) {
+        final String filename = System.currentTimeMillis() + (extension != null ? "." + extension : "");
         final String storePath = getStorePath(context);
         return new Uri.Builder().scheme("file").path(storePath).appendPath(filename).build();
     }
@@ -73,6 +104,27 @@ public class ImageDiskStore {
         try {
             outputStream = new FileOutputStream(file);
             outputStream.write(bytes);
+            outputStream.flush();
+        } finally {
+            if (outputStream != null) {
+                try {
+                    outputStream.close();
+                } catch (final IOException ignore) {
+                }
+            }
+        }
+    }
+
+    private void writeToFile(@NonNull final File file, @NonNull final InputStream inputStream)
+            throws IOException {
+        OutputStream outputStream = null;
+        try {
+            outputStream = new BufferedOutputStream(new FileOutputStream(file), 65536);
+            final byte[] buffer = new byte[8192];
+            int read;
+            while((read = inputStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, read);
+            }
             outputStream.flush();
         } finally {
             if (outputStream != null) {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/storage/ImageDiskStore.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/storage/ImageDiskStore.java
@@ -156,7 +156,7 @@ public class ImageDiskStore {
         file.delete();
     }
 
-    public void clear(@NonNull final Context context) {
+    public static void clear(@NonNull final Context context) {
         final String storePath = getStorePath(context);
         final File storeDir = new File(storePath);
         if (!storeDir.isDirectory()) {
@@ -172,7 +172,7 @@ public class ImageDiskStore {
     }
 
     @NonNull
-    private String getStorePath(final @NonNull Context context) {
+    private static String getStorePath(final @NonNull Context context) {
         return context.getFilesDir().getAbsolutePath();
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/util/FileImportValidator.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/util/FileImportValidator.java
@@ -1,6 +1,8 @@
 package net.gini.android.vision.internal.util;
 
 
+import static net.gini.android.vision.util.UriHelper.getMimeType;
+
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -64,8 +66,7 @@ public class FileImportValidator {
     }
 
     public boolean matchesCriteria(@NonNull final Uri fileUri) {
-        final List<String> mimeTypes = Collections.singletonList(
-                IntentHelper.getMimeType(fileUri, mContext));
+        final List<String> mimeTypes = Collections.singletonList(getMimeType(fileUri, mContext));
         return matchesCriteria(fileUri, mimeTypes);
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/util/IntentHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/util/IntentHelper.java
@@ -1,5 +1,8 @@
 package net.gini.android.vision.util;
 
+import static net.gini.android.vision.util.UriHelper.getMimeType;
+import static net.gini.android.vision.util.UriHelper.getMimeTypeFromUrl;
+
 import android.content.ClipData;
 import android.content.ClipDescription;
 import android.content.ComponentName;
@@ -11,7 +14,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.webkit.MimeTypeMap;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -111,25 +113,6 @@ public final class IntentHelper {
         return null;
     }
 
-    @Nullable
-    public static String getMimeType(@NonNull final Uri uri, @NonNull final Context context) {
-        final String type = context.getContentResolver().getType(uri);
-        if (type == null) {
-            return getMimeTypeFromUrl(uri.getPath());
-        }
-        return type;
-    }
-
-    @Nullable
-    private static String getMimeTypeFromUrl(@NonNull final String url) {
-        final String extension = MimeTypeMap.getFileExtensionFromUrl(url);
-        if (extension != null) {
-            final MimeTypeMap mime = MimeTypeMap.getSingleton();
-            return mime.getMimeTypeFromExtension(extension);
-        }
-        return null;
-    }
-
     /**
      * Check whether the Intent has a specific mime-type.
      *
@@ -148,12 +131,6 @@ public final class IntentHelper {
             }
         }
         return false;
-    }
-
-    public static boolean hasMimeType(@NonNull final Uri uri,
-            @NonNull final Context context, @NonNull final String mimeType) {
-        final String actualMimeType = getMimeType(uri, context);
-        return actualMimeType != null && actualMimeType.equals(mimeType);
     }
 
     /**

--- a/ginivision/src/main/java/net/gini/android/vision/util/UriHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/util/UriHelper.java
@@ -9,6 +9,7 @@ import android.provider.OpenableColumns;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
+import android.webkit.MimeTypeMap;
 
 import java.io.File;
 import java.io.IOException;
@@ -148,6 +149,41 @@ public final class UriHelper {
             return (int) file.length();
         }
         return -1;
+    }
+
+    @Nullable
+    public static String getMimeType(@NonNull final Uri uri, @NonNull final Context context) {
+        final String type = context.getContentResolver().getType(uri);
+        if (type == null) {
+            return getMimeTypeFromUrl(uri.getPath());
+        }
+        return type;
+    }
+
+    @Nullable
+    public static String getMimeTypeFromUrl(@NonNull final String url) {
+        final String extension = MimeTypeMap.getFileExtensionFromUrl(url);
+        if (extension != null) {
+            final MimeTypeMap mime = MimeTypeMap.getSingleton();
+            return mime.getMimeTypeFromExtension(extension);
+        }
+        return null;
+    }
+
+    @Nullable
+    public static String getFileExtension(@NonNull final Uri uri, @NonNull final Context context) {
+        final String type = getMimeType(uri, context);
+        if (type != null) {
+            final MimeTypeMap mime = MimeTypeMap.getSingleton();
+            return mime.getExtensionFromMimeType(type);
+        }
+        return null;
+    }
+
+    public static boolean hasMimeType(@NonNull final Uri uri,
+            @NonNull final Context context, @NonNull final String mimeType) {
+        final String actualMimeType = getMimeType(uri, context);
+        return actualMimeType != null && actualMimeType.equals(mimeType);
     }
 
     private UriHelper() {

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
@@ -112,6 +112,8 @@ public class MainActivity extends AppCompatActivity {
 
     private void doStartGiniVisionLibraryForImportedFile(final Intent importedFileIntent) {
         try {
+            // Configure the Gini Vision Library
+            configureGiniVision();
             final Intent giniVisionIntent = GiniVisionFileImport.createIntentForImportedFile(
                     importedFileIntent,
                     this,
@@ -197,25 +199,8 @@ public class MainActivity extends AppCompatActivity {
 //            return;
 //        }
 
-        final BaseExampleApp app = (BaseExampleApp) getApplication();
-
         // Configure the Gini Vision Library
-        GiniVision.cleanup(this);
-        GiniVision.newInstance()
-                .setGiniVisionNetworkService(app.getGiniVisionNetworkService())
-                .setGiniVisionNetworkApi(app.getGiniVisionNetworkApi())
-                .setDocumentImportEnabledFileTypes(DocumentImportEnabledFileTypes.PDF_AND_IMAGES)
-                .setFileImportEnabled(true)
-                .setQRCodeScanningEnabled(true)
-                // Uncomment to add an extra page to the Onboarding pages
-//                .setCustomOnboardingPages(getOnboardingPages())
-                // Uncomment to disable automatically showing the OnboardingActivity the
-                // first time the CameraActivity is launched - we highly recommend letting the
-                // Gini Vision Library show the OnboardingActivity at first run
-//                .setShouldShowOnboardingAtFirstRun(false)
-                // Uncomment to show the OnboardingActivity every time the CameraActivity starts
-//                .setShouldShowOnboarding(true)
-                .build();
+        configureGiniVision();
 
         final Intent intent = new Intent(this, CameraScreenApiActivity.class);
 
@@ -260,6 +245,26 @@ public class MainActivity extends AppCompatActivity {
         // To receive the extractions add it to the result Intent in ReviewActivity#onAddDataToResult(Intent) or
         // AnalysisActivity#onAddDataToResult(Intent) and retrieve them here in onActivityResult()
         startActivityForResult(intent, REQUEST_SCAN);
+    }
+
+    private void configureGiniVision() {
+        final BaseExampleApp app = (BaseExampleApp) getApplication();
+        GiniVision.cleanup(this);
+        GiniVision.newInstance()
+                .setGiniVisionNetworkService(app.getGiniVisionNetworkService())
+                .setGiniVisionNetworkApi(app.getGiniVisionNetworkApi())
+                .setDocumentImportEnabledFileTypes(DocumentImportEnabledFileTypes.PDF_AND_IMAGES)
+                .setFileImportEnabled(true)
+                .setQRCodeScanningEnabled(true)
+                // Uncomment to add an extra page to the Onboarding pages
+//                .setCustomOnboardingPages(getOnboardingPages())
+                // Uncomment to disable automatically showing the OnboardingActivity the
+                // first time the CameraActivity is launched - we highly recommend letting the
+                // Gini Vision Library show the OnboardingActivity at first run
+//                .setShouldShowOnboardingAtFirstRun(false)
+                // Uncomment to show the OnboardingActivity every time the CameraActivity starts
+//                .setShouldShowOnboarding(true)
+                .build();
     }
 
     private void showUnfulfilledRequirementsToast(final RequirementsReport report) {
@@ -307,6 +312,11 @@ public class MainActivity extends AppCompatActivity {
                 return;
             }
             switch (resultCode) {
+                case RESULT_CANCELED:
+                    if (isIntentActionViewOrSend(getIntent())) {
+                        finish();
+                    }
+                    break;
                 case RESULT_OK:
                     // Retrieve the extra we set in our ReviewActivity or AnalysisActivity subclasses' onAddDataToResult()
                     // method


### PR DESCRIPTION
Imported images are copied to the apps internal storage to be editable.

### How to test
Run the Screen API Example App and import images from the Camera Screen, rotate them and verify that the images in the image stack are rotated accordingly.
Also import images with "open with". In this case you can check that copies exist and rotation was applied using Android Studio's Device File Explorer (or with adb using run-as to copy the images from the app internal storage to the SDCard).

### Ticket 
Issue #154
