### PR TITLE
Feature multi page loading indicators

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
@@ -9,6 +9,7 @@ import net.gini.android.vision.analysis.AnalysisActivity;
 import net.gini.android.vision.camera.CameraActivity;
 import net.gini.android.vision.document.DocumentFactory;
 import net.gini.android.vision.document.ImageDocument;
+import net.gini.android.vision.document.ImageDocument.ImportMethod;
 import net.gini.android.vision.document.ImageMultiPageDocument;
 import net.gini.android.vision.internal.util.ActivityHelper;
 import net.gini.android.vision.internal.util.DeviceHelper;
@@ -181,7 +182,7 @@ public final class GiniVisionFileImport {
         if (fileImportValidator.matchesCriteria(intent, uri)) {
             return DocumentFactory.newDocumentFromIntent(intent, context,
                     DeviceHelper.getDeviceOrientation(context), DeviceHelper.getDeviceType(context),
-                    "openwith");
+                    ImportMethod.OPEN_WITH);
         } else {
             throw new ImportedFileValidationException(fileImportValidator.getError());
         }
@@ -206,7 +207,7 @@ public final class GiniVisionFileImport {
                         IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
                     final ImageDocument document = DocumentFactory.newImageDocumentFromUri(uri,
                             intent, context, DeviceHelper.getDeviceOrientation(context),
-                            DeviceHelper.getDeviceType(context), "openwith");
+                            DeviceHelper.getDeviceType(context), ImportMethod.OPEN_WITH);
                     multiPageDocument.addDocument(document);
                 }
             } else {

--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
@@ -31,6 +31,7 @@ import android.widget.TextView;
 
 import net.gini.android.vision.Document;
 import net.gini.android.vision.GiniVision;
+import net.gini.android.vision.GiniVisionDebug;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.R;
 import net.gini.android.vision.document.GiniVisionDocument;
@@ -392,6 +393,7 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
             final GiniVisionNetworkService networkService = GiniVision.getInstance()
                     .internal().getGiniVisionNetworkService();
             if (networkService != null) {
+                GiniVisionDebug.writeDocumentToFile(activity, mDocument, "_for_analysis");
                 networkService.analyze(mDocument,
                         new GiniVisionNetworkCallback<AnalysisResult, Error>() {
                             @Override

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -4,6 +4,7 @@ import static android.app.Activity.RESULT_CANCELED;
 import static android.app.Activity.RESULT_OK;
 
 import static net.gini.android.vision.camera.Util.cameraExceptionToGiniVisionError;
+import static net.gini.android.vision.document.ImageDocument.ImportMethod;
 import static net.gini.android.vision.internal.util.ActivityHelper.forcePortraitOrientationOnPhones;
 import static net.gini.android.vision.internal.util.AndroidHelper.isMarshmallowOrLater;
 import static net.gini.android.vision.internal.util.ContextHelper.getClientApplicationId;
@@ -948,7 +949,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                     activity,
                     DeviceHelper.getDeviceOrientation(activity),
                     DeviceHelper.getDeviceType(activity),
-                    "picker");
+                    ImportMethod.PICKER);
             LOG.info("Document imported: {}", document);
             requestClientDocumentCheck(document);
         } catch (final IllegalArgumentException e) {

--- a/ginivision/src/main/java/net/gini/android/vision/camera/ImportUrisAsyncTask.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/ImportUrisAsyncTask.java
@@ -10,6 +10,7 @@ import net.gini.android.vision.R;
 import net.gini.android.vision.document.DocumentFactory;
 import net.gini.android.vision.document.GiniVisionDocumentError;
 import net.gini.android.vision.document.ImageDocument;
+import net.gini.android.vision.document.ImageDocument.ImportMethod;
 import net.gini.android.vision.document.ImageMultiPageDocument;
 import net.gini.android.vision.internal.AsyncCallback;
 import net.gini.android.vision.internal.storage.ImageDiskStore;
@@ -79,7 +80,7 @@ class ImportUrisAsyncTask extends AsyncTask<List<Uri>, Void, ImageMultiPageDocum
                         final ImageDocument document = DocumentFactory.newImageDocumentFromUri(
                                 localUri,
                                 mIntent, mContext, DeviceHelper.getDeviceOrientation(mContext),
-                                DeviceHelper.getDeviceType(mContext), "openwith");
+                                DeviceHelper.getDeviceType(mContext), ImportMethod.OPEN_WITH);
                         multiPageDocument.addDocument(document);
                     } catch (final IllegalArgumentException e) {
                         LOG.error("Failed to import selected document", e);

--- a/ginivision/src/main/java/net/gini/android/vision/camera/ImportUrisAsyncTask.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/ImportUrisAsyncTask.java
@@ -1,0 +1,115 @@
+package net.gini.android.vision.camera;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.support.annotation.NonNull;
+
+import net.gini.android.vision.R;
+import net.gini.android.vision.document.DocumentFactory;
+import net.gini.android.vision.document.GiniVisionDocumentError;
+import net.gini.android.vision.document.ImageDocument;
+import net.gini.android.vision.document.ImageMultiPageDocument;
+import net.gini.android.vision.internal.AsyncCallback;
+import net.gini.android.vision.internal.storage.ImageDiskStore;
+import net.gini.android.vision.internal.util.DeviceHelper;
+import net.gini.android.vision.internal.util.FileImportValidator;
+import net.gini.android.vision.util.IntentHelper;
+import net.gini.android.vision.util.UriHelper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Created by Alpar Szotyori on 23.03.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+
+class ImportUrisAsyncTask extends AsyncTask<List<Uri>, Void, ImageMultiPageDocument> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ImportUrisAsyncTask.class);
+
+    private final Context mContext;
+    private final Intent mIntent;
+    private final AsyncCallback<ImageMultiPageDocument> mListener;
+    private final ImageDiskStore mImageDiskStore;
+
+    ImportUrisAsyncTask(@NonNull final Context context,
+            @NonNull final Intent intent,
+            @NonNull final ImageDiskStore imageDiskStore,
+            @NonNull final AsyncCallback<ImageMultiPageDocument> listener) {
+        mContext = context;
+        mIntent = intent;
+        mImageDiskStore = imageDiskStore;
+        mListener = listener;
+    }
+
+    @Override
+    protected ImageMultiPageDocument doInBackground(final List<Uri>[] urisList) {
+        final List<Uri> uris = urisList[0];
+        final ImageMultiPageDocument multiPageDocument = new ImageMultiPageDocument(true);
+        for (final Uri uri : uris) {
+            if (isCancelled()) {
+                return multiPageDocument;
+            }
+            if (!UriHelper.isUriInputStreamAvailable(uri, mContext)) {
+                LOG.error("Document import failed: InputStream not available for the Uri");
+                addMultiPageDocumentError(mContext.getString(
+                        R.string.gv_document_import_invalid_document), multiPageDocument);
+                break;
+            }
+            final FileImportValidator fileImportValidator = new FileImportValidator(mContext);
+            if (fileImportValidator.matchesCriteria(uri)) {
+                if (IntentHelper.hasMimeTypeWithPrefix(uri, mContext,
+                        IntentHelper.MimeType.IMAGE_PREFIX.asString())) {
+                    try {
+                        final Uri localUri = mImageDiskStore.save(mContext, uri);
+                        if (localUri == null) {
+                            LOG.error("Failed to import selected document: "
+                                    + "could not copy to app storage");
+                            addMultiPageDocumentError(mContext.getString(
+                                    R.string.gv_document_import_invalid_document),
+                                    multiPageDocument);
+                            break;
+                        }
+                        final ImageDocument document = DocumentFactory.newImageDocumentFromUri(
+                                localUri,
+                                mIntent, mContext, DeviceHelper.getDeviceOrientation(mContext),
+                                DeviceHelper.getDeviceType(mContext), "openwith");
+                        multiPageDocument.addDocument(document);
+                    } catch (final IllegalArgumentException e) {
+                        LOG.error("Failed to import selected document", e);
+                        addMultiPageDocumentError(mContext.getString(
+                                R.string.gv_document_import_invalid_document), multiPageDocument);
+                    }
+                }
+            } else {
+                String errorMessage = mContext.getString(
+                        R.string.gv_document_import_invalid_document);
+                final FileImportValidator.Error error = fileImportValidator.getError();
+                if (error != null) {
+                    errorMessage = mContext.getString(error.getTextResource());
+                }
+                addMultiPageDocumentError(errorMessage, multiPageDocument);
+            }
+        }
+        return multiPageDocument;
+    }
+
+    @Override
+    protected void onPostExecute(final ImageMultiPageDocument multiPageDocument) {
+        mListener.onSuccess(multiPageDocument);
+    }
+
+    private void addMultiPageDocumentError(@NonNull final String string,
+            @NonNull final ImageMultiPageDocument multiPageDocument) {
+        final ImageDocument document = DocumentFactory.newEmptyImageDocument();
+        multiPageDocument.addDocument(document);
+        final GiniVisionDocumentError documentError = new GiniVisionDocumentError(string);
+        multiPageDocument.addErrorForDocument(document, documentError);
+    }
+}

--- a/ginivision/src/main/java/net/gini/android/vision/document/DocumentFactory.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/DocumentFactory.java
@@ -10,6 +10,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 
 import net.gini.android.vision.Document;
+import net.gini.android.vision.document.ImageDocument.ImportMethod;
 import net.gini.android.vision.internal.camera.photo.Photo;
 import net.gini.android.vision.util.IntentHelper;
 
@@ -29,7 +30,7 @@ public final class DocumentFactory {
             @NonNull final Context context,
             @NonNull final String deviceOrientation,
             @NonNull final String deviceType,
-            @NonNull final String importMethod) {
+            @NonNull final ImportMethod importMethod) {
         final Uri data = getUri(intent);
         if (data == null) {
             throw new IllegalArgumentException("Intent data must contain a Uri");
@@ -50,7 +51,7 @@ public final class DocumentFactory {
             @NonNull final Context context,
             @NonNull final String deviceOrientation,
             @NonNull final String deviceType,
-            @NonNull final String importMethod) {
+            @NonNull final ImportMethod importMethod) {
         return ImageDocument.fromUri(externalUri, intent, context, deviceOrientation, deviceType,
                 importMethod);
     }

--- a/ginivision/src/main/java/net/gini/android/vision/document/GiniVisionMultiPageDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/GiniVisionMultiPageDocument.java
@@ -119,6 +119,10 @@ public class GiniVisionMultiPageDocument<T extends GiniVisionDocument, E extends
         loadImageDocuments(0, context, callback);
     }
 
+    public void addDocuments(@NonNull final List<T> documents) {
+        mDocuments.addAll(documents);
+    }
+
     private void loadImageDocuments(final int currentIndex,
             @NonNull final Context context,
             @NonNull final AsyncCallback<byte[]> callback) {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/cache/MemoryCache.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/cache/MemoryCache.java
@@ -6,9 +6,16 @@ import android.util.LruCache;
 
 import net.gini.android.vision.internal.AsyncCallback;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Queue;
 
 /**
@@ -19,48 +26,103 @@ import java.util.Queue;
 
 public abstract class MemoryCache<K, V> {
 
+    private static final boolean DEBUG = false;
+    private final Logger mLog;
     private final LruCache<K, V> mCache;
     private final Queue<Worker<K, V>> mWorkerQueue = new LinkedList<>();
     private final List<Worker<K, V>> mRunningWorkers;
     private final int mRunningWorkersLimit;
+    private final Map<K, List<AsyncCallback<V>>> mWaitingCallbacks = new HashMap<>();
 
     public MemoryCache(final int runningWorkersLimit) {
         mRunningWorkersLimit = runningWorkersLimit;
         mRunningWorkers = new ArrayList<>(runningWorkersLimit);
         mCache = createCache();
+        if (DEBUG) {
+            mLog = LoggerFactory.getLogger(getClass());
+        } else {
+            mLog = NOPLogger.NOP_LOGGER;
+        }
     }
 
     protected abstract LruCache<K, V> createCache();
 
-    public void get(@NonNull final Context context, @NonNull final K key, @NonNull final
-    AsyncCallback<V> callback) {
+    public void get(@NonNull final Context context, @NonNull final K key,
+            @NonNull final AsyncCallback<V> callback) {
+        mLog.debug("Get for key {}", getNameForLog(key));
         if (mCache.get(key) != null) {
-            callback.onSuccess(mCache.get(key));
+            final V value = mCache.get(key);
+            mLog.debug("Return cached {}", getNameForLog(value));
+            callback.onSuccess(value);
             return;
         }
 
-        final Worker worker = createWorker(mRunningWorkers, key,
+        mLog.debug("Create worker");
+        final Worker<K, V> worker = createWorker(mRunningWorkers, key,
                 new AsyncCallback<V>() {
                     @Override
                     public void onSuccess(final V result) {
+                        mLog.debug("Worker finished with result {}", getNameForLog(result));
                         mCache.put(key, result);
-                        callback.onSuccess(result);
+                        final List<AsyncCallback<V>> callbacks = mWaitingCallbacks.get(key);
+                        if (callbacks != null) {
+                            for (final AsyncCallback<V> waitingCallback : callbacks) {
+                                mLog.debug("Invoke callback {} for key {}",
+                                        getNameForLog(waitingCallback), getNameForLog(key));
+                                waitingCallback.onSuccess(result);
+                            }
+                        }
+                        mLog.debug("Remove callbacks for key {}", getNameForLog(key));
+                        mWaitingCallbacks.remove(key);
                         executeNextWorker(context);
                     }
 
                     @Override
                     public void onError(final Exception exception) {
-                        callback.onError(exception);
+                        mLog.error("Worker finished with error", exception);
+                        final List<AsyncCallback<V>> callbacks = mWaitingCallbacks.get(key);
+                        if (callbacks != null) {
+                            for (final AsyncCallback<V> waitingCallback : callbacks) {
+                                mLog.debug("Invoke callback {} for key {}",
+                                        getNameForLog(waitingCallback), getNameForLog(key));
+                                waitingCallback.onError(exception);
+                            }
+                        }
+                        mLog.debug("Remove callbacks for key {}", getNameForLog(key));
+                        mWaitingCallbacks.remove(key);
                         executeNextWorker(context);
                     }
                 });
 
+        List<AsyncCallback<V>> callbacks = mWaitingCallbacks.get(key);
+        if (callbacks == null) {
+            mLog.debug("First callback {} registered for key {}", getNameForLog(callback),
+                    getNameForLog(key));
+            callbacks = new ArrayList<>();
+            callbacks.add(callback);
+            mWaitingCallbacks.put(key, callbacks);
+        } else {
+            mLog.debug("Additional callback {} registered for key {}", getNameForLog(callback),
+                    getNameForLog(key));
+            callbacks.add(callback);
+        }
+
+        mLog.debug("Schedule worker for key {}", getNameForLog(key));
         if (!mRunningWorkers.contains(worker) && mRunningWorkers.size() < mRunningWorkersLimit) {
+            mLog.debug("Execute worker for key {}", getNameForLog(key));
             mRunningWorkers.add(worker);
             worker.execute(context);
         } else if (!mWorkerQueue.contains(worker)) {
+            mLog.debug("Queue worker for key {}", getNameForLog(key));
             mWorkerQueue.add(worker);
+        } else {
+            mLog.debug("Worker already queued for key {}", getNameForLog(key));
         }
+    }
+
+    private <T> String getNameForLog(final T object) {
+        return String.format(Locale.US, "%s[%d]", object.getClass().getSimpleName(),
+                object.hashCode());
     }
 
     protected abstract Worker<K, V> createWorker(
@@ -70,13 +132,35 @@ public abstract class MemoryCache<K, V> {
 
 
     private void executeNextWorker(@NonNull final Context context) {
+        mLog.debug("Execute next worker");
         final Worker worker = mWorkerQueue.peek();
         if (worker != null) {
             if (!mRunningWorkers.contains(worker)
                     && mRunningWorkers.size() < mRunningWorkersLimit) {
                 mRunningWorkers.add(worker);
                 mWorkerQueue.poll();
+                mLog.debug("Execute queued worker for key {}", getNameForLog(worker.getSubject()));
                 worker.execute(context);
+            } else {
+                mLog.debug("Cannot execute worker for key {}. Running worker limit reached.",
+                        getNameForLog(worker.getSubject()));
+            }
+        } else {
+            mLog.debug("No queued workers");
+            if (mRunningWorkers.isEmpty() && !mWaitingCallbacks.isEmpty()) {
+                mLog.error("{} dangling callbacks", mWaitingCallbacks.size());
+                if (DEBUG) {
+                    logDanglingCallbacks();
+                }
+            }
+        }
+    }
+
+    private void logDanglingCallbacks() {
+        for (final Map.Entry<K, List<AsyncCallback<V>>> entry : mWaitingCallbacks.entrySet()) {
+            for (final AsyncCallback<V> waitingCallback : entry.getValue()) {
+                mLog.error("Dangling callback {} for key {}", getNameForLog(waitingCallback),
+                        getNameForLog(entry.getKey()));
             }
         }
     }
@@ -91,16 +175,26 @@ public abstract class MemoryCache<K, V> {
 
     protected static abstract class Worker<S, V> {
 
+        private final Logger mLog;
         private final List<Worker<S, V>> mRunningWorkers;
         private final S mSubject;
         private final AsyncCallback<V> mCallback;
 
-        protected Worker(@NonNull final List<Worker<S, V>> runningWorkers,
+        Worker(@NonNull final List<Worker<S, V>> runningWorkers,
                 @NonNull final S subject,
                 @NonNull final AsyncCallback<V> callback) {
             mRunningWorkers = runningWorkers;
             mSubject = subject;
             mCallback = callback;
+            if (DEBUG) {
+                mLog = LoggerFactory.getLogger(getClass());
+            } else {
+                mLog = NOPLogger.NOP_LOGGER;
+            }
+        }
+
+        public S getSubject() {
+            return mSubject;
         }
 
         @Override
@@ -123,15 +217,20 @@ public abstract class MemoryCache<K, V> {
         }
 
         public void execute(@NonNull final Context context) {
+            mLog.debug("Execute");
             doExecute(context, mSubject, new AsyncCallback<V>() {
                 @Override
                 public void onSuccess(final V result) {
+                    mLog.debug("Succeded");
+                    mLog.debug("Remove self from running workers");
                     mRunningWorkers.remove(Worker.this);
                     mCallback.onSuccess(result);
                 }
 
                 @Override
                 public void onError(final Exception exception) {
+                    mLog.debug("Failed");
+                    mLog.debug("Remove self from running workers");
                     mRunningWorkers.remove(Worker.this);
                     mCallback.onError(exception);
                 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
@@ -23,6 +23,7 @@ import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.View;
 
+import net.gini.android.vision.document.ImageDocument.Source;
 import net.gini.android.vision.internal.camera.photo.Photo;
 import net.gini.android.vision.internal.camera.photo.PhotoFactory;
 import net.gini.android.vision.internal.util.Size;
@@ -365,7 +366,7 @@ public class CameraController implements CameraInterface {
                                 getDisplayOrientationForCamera(mActivity),
                                 getDeviceOrientation(mActivity),
                                 getDeviceType(mActivity),
-                                "camera");
+                                Source.newCameraSource());
                         LOG.info("Picture taken");
                         pictureTaken.complete(photo);
                     }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ImmutablePhoto.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ImmutablePhoto.java
@@ -9,6 +9,8 @@ import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
 import net.gini.android.vision.document.ImageDocument;
+import net.gini.android.vision.document.ImageDocument.ImportMethod;
+import net.gini.android.vision.document.ImageDocument.Source;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,12 +131,12 @@ class ImmutablePhoto implements Photo {
     }
 
     @Override
-    public String getSource() {
+    public Source getSource() {
         return null;
     }
 
     @Override
-    public String getImportMethod() {
+    public ImportMethod getImportMethod() {
         return null;
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
@@ -4,6 +4,8 @@ import android.graphics.Bitmap;
 import android.os.Parcelable;
 
 import net.gini.android.vision.document.ImageDocument;
+import net.gini.android.vision.document.ImageDocument.ImportMethod;
+import net.gini.android.vision.document.ImageDocument.Source;
 
 import java.io.File;
 
@@ -26,9 +28,9 @@ public interface Photo extends Parcelable {
 
     String getDeviceType();
 
-    String getSource();
+    Source getSource();
 
-    String getImportMethod();
+    ImportMethod getImportMethod();
 
     Bitmap getBitmapPreview();
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoFactory.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoFactory.java
@@ -3,6 +3,8 @@ package net.gini.android.vision.internal.camera.photo;
 import android.support.annotation.NonNull;
 
 import net.gini.android.vision.document.ImageDocument;
+import net.gini.android.vision.document.ImageDocument.ImportMethod;
+import net.gini.android.vision.document.ImageDocument.Source;
 
 /**
  * @exclude
@@ -13,9 +15,9 @@ public final class PhotoFactory {
             final int orientation,
             @NonNull final String deviceOrientation,
             @NonNull final String deviceType,
-            @NonNull final String source) {
+            @NonNull final Source source) {
         return new MutablePhoto(bytes, orientation, deviceOrientation, deviceType, source,
-                "", ImageDocument.ImageFormat.JPEG, false);
+                ImportMethod.NONE, ImageDocument.ImageFormat.JPEG, false);
     }
 
     public static Photo newPhotoFromDocument(final ImageDocument document) {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/storage/SaveUriAsyncTask.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/storage/SaveUriAsyncTask.java
@@ -1,0 +1,52 @@
+package net.gini.android.vision.internal.storage;
+
+import android.content.Context;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.support.annotation.NonNull;
+
+import net.gini.android.vision.internal.AsyncCallback;
+
+/**
+ * Created by Alpar Szotyori on 23.03.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+
+public class SaveUriAsyncTask extends AsyncTask<Uri, Void, Uri> {
+
+    private final Context mContext;
+    private final AsyncCallback<Uri> mListener;
+    private final ImageDiskStore mImageDiskStore;
+
+    public static SaveUriAsyncTask execute(@NonNull final Uri uri,
+            @NonNull final Context context,
+            @NonNull final ImageDiskStore imageDiskStore,
+            @NonNull final AsyncCallback<Uri> listener) {
+        final SaveUriAsyncTask asyncTask = new SaveUriAsyncTask(context, imageDiskStore, listener);
+        asyncTask.execute(uri);
+        return asyncTask;
+    }
+
+    public SaveUriAsyncTask(@NonNull final Context context,
+            @NonNull final ImageDiskStore imageDiskStore,
+            @NonNull final AsyncCallback<Uri> listener) {
+        mContext = context;
+        mImageDiskStore = imageDiskStore;
+        mListener = listener;
+    }
+
+    @Override
+    protected Uri doInBackground(final Uri... uris) {
+        final Uri uri = uris[0];
+        if (uri == null) {
+            return null;
+        }
+        return mImageDiskStore.save(mContext, uri);
+    }
+
+    @Override
+    protected void onPostExecute(final Uri uri) {
+        mListener.onSuccess(uri);
+    }
+}

--- a/ginivision/src/main/java/net/gini/android/vision/review/ImageFragment.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ImageFragment.java
@@ -5,9 +5,11 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import net.gini.android.vision.GiniVision;
@@ -31,6 +33,8 @@ public class ImageFragment extends Fragment {
     private ImageDocument mDocument;
     private String mErrorMessage;
     private TextView mErrorView;
+    private ProgressBar mActivityIndicator;
+    private boolean mStopped = true;
 
     public static ImageFragment createInstance(@Nullable final ImageDocument document,
             @Nullable final String errorMessage) {
@@ -60,6 +64,7 @@ public class ImageFragment extends Fragment {
             final Bundle savedInstanceState) {
         final View view = inflater.inflate(R.layout.gv_fragment_image, container, false);
         mImageViewContainer = view.findViewById(R.id.gv_image_container);
+        mActivityIndicator = view.findViewById(R.id.gv_activity_indicator);
         mErrorView = view.findViewById(R.id.gv_text_error);
         mErrorView.setText(mErrorMessage);
         return view;
@@ -68,24 +73,63 @@ public class ImageFragment extends Fragment {
     @Override
     public void onStart() {
         super.onStart();
+        mStopped = false;
+        LOG.debug("Started ({})", this);
         final Context context = getContext();
-        if (context != null && mDocument != null) {
-            // TODO: show loading indicator
+        if (context != null && shouldShowPreviewImage()) {
+            LOG.debug("Loading preview bitmap ({})", this);
+            showActivityIndicator();
             GiniVision.getInstance().internal().getPhotoMemoryCache()
                     .get(context, mDocument, new AsyncCallback<Photo>() {
                         @Override
                         public void onSuccess(final Photo result) {
+                            LOG.debug("Preview bitmap received ({})", this);
+                            if (mStopped) {
+                                LOG.debug("Stopped: preview discarded ({})", this);
+                                return;
+                            }
+                            hideActivityIndicator();
+                            LOG.debug("Showing preview ({})", this);
                             mImageViewContainer.getImageView().setImageBitmap(
                                     result.getBitmapPreview());
+                            LOG.debug("Applying rotation ({})", this);
                             rotateImageView(mDocument.getRotationForDisplay(), false);
                         }
 
                         @Override
                         public void onError(final Exception exception) {
-                            LOG.error("Failed to create preview bitmap", exception);
+                            LOG.error("Failed to create preview bitmap ({})", this, exception);
+                            if (mStopped) {
+                                LOG.debug("Stopped: ignoring error ({})", this);
+                                return;
+                            }
+                            hideActivityIndicator();
+                            LOG.debug("Showing error ({})", this);
+                            mErrorView.setText(R.string.gv_multi_page_review_image_preview_error);
                         }
                     });
         }
+    }
+
+    private boolean shouldShowPreviewImage() {
+        return mDocument != null
+                && mImageViewContainer.getImageView().getDrawable() == null
+                && TextUtils.isEmpty(mErrorView.getText());
+    }
+
+    private void showActivityIndicator() {
+        mActivityIndicator.setVisibility(View.VISIBLE);
+    }
+
+    private void hideActivityIndicator() {
+        mActivityIndicator.setVisibility(View.GONE);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        LOG.debug("Stopped ({})", this);
+        mStopped = true;
     }
 
     private void rotateImageView(final int degrees, final boolean animated) {

--- a/ginivision/src/main/java/net/gini/android/vision/review/MultiPageReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/MultiPageReviewActivity.java
@@ -99,7 +99,6 @@ public class MultiPageReviewActivity extends AppCompatActivity {
                         final ThumbnailsAdapter thumbnailsAdapter =
                                 (ThumbnailsAdapter) mThumbnailsRV.getAdapter();
                         thumbnailsAdapter.highlightPosition(position);
-                        thumbnailsAdapter.notifyDataSetChanged();
                         mThumbnailsScroller.setTargetPosition(position);
                         mThumbnailsRV.getLayoutManager().startSmoothScroll(mThumbnailsScroller);
                     }
@@ -451,7 +450,7 @@ public class MultiPageReviewActivity extends AppCompatActivity {
                                 public void onSuccess(final Photo result) {
                                     if (holder.getAdapterPosition() == position) {
                                         holder.hideActivityIndicator();
-                                        showPhoto(result, position, holder);
+                                        showPhoto(result, holder);
                                     }
                                 }
 
@@ -468,8 +467,7 @@ public class MultiPageReviewActivity extends AppCompatActivity {
                             });
         }
 
-        private void showPhoto(@NonNull final Photo photo, final int position,
-                @NonNull final ViewHolder holder) {
+        private void showPhoto(@NonNull final Photo photo, @NonNull final ViewHolder holder) {
             final ImageView imageView = holder.thumbnailContainer.getImageView();
             final Bitmap bitmap = photo.getBitmapPreview();
             if (bitmap != null) {
@@ -492,7 +490,6 @@ public class MultiPageReviewActivity extends AppCompatActivity {
                     final int adapterPosition = holder.getAdapterPosition();
                     highlightPosition(adapterPosition);
                     mThumbnailChangeListener.onThumbnailSelected(adapterPosition);
-                    notifyDataSetChanged();
                 }
             });
             holder.handle.setOnTouchListener(new View.OnTouchListener() {
@@ -569,10 +566,26 @@ public class MultiPageReviewActivity extends AppCompatActivity {
         }
 
         void highlightPosition(final int position) {
-            for (final Thumbnail image : mThumbnails) {
-                image.highlighted = false;
+            for (int i = 0; i < mThumbnails.size(); i++) {
+                final Thumbnail thumbnail = mThumbnails.get(i);
+                thumbnail.highlighted = false;
+                final ThumbnailsAdapter.ViewHolder holder =
+                        (ViewHolder) mRecyclerView.findViewHolderForAdapterPosition(i);
+                if (holder != null) {
+                    holder.highlight.setAlpha(0f);
+                }
             }
             mThumbnails.get(position).highlighted = true;
+            if (mRecyclerView != null) {
+                for (int i = 0; i < mThumbnails.size(); i++) {
+                    final Thumbnail thumbnail = mThumbnails.get(i);
+                    final ThumbnailsAdapter.ViewHolder holder =
+                            (ViewHolder) mRecyclerView.findViewHolderForAdapterPosition(i);
+                    if (holder != null) {
+                        holder.highlight.setAlpha(thumbnail.highlighted ? 1f : 0f);
+                    }
+                }
+            }
         }
 
         void rotateHighlightedThumbnailBy(final int degrees) {

--- a/ginivision/src/main/java/net/gini/android/vision/review/MultiPageReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/MultiPageReviewActivity.java
@@ -24,6 +24,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
 import android.widget.ImageView;
+import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -440,13 +441,16 @@ public class MultiPageReviewActivity extends AppCompatActivity {
         @Override
         public void onBindViewHolder(final ViewHolder holder,
                 final int position) {
-            // TODO: show loading indicator
+            holder.resetImageView();
+            holder.showActivityIndicator();
+            showPosition(position, holder);
             GiniVision.getInstance().internal().getPhotoMemoryCache()
                     .get(mContext, mMultiPageDocument.getDocuments().get(position),
                             new AsyncCallback<Photo>() {
                                 @Override
                                 public void onSuccess(final Photo result) {
                                     if (holder.getAdapterPosition() == position) {
+                                        holder.hideActivityIndicator();
                                         showPhoto(result, position, holder);
                                     }
                                 }
@@ -454,11 +458,11 @@ public class MultiPageReviewActivity extends AppCompatActivity {
                                 @Override
                                 public void onError(final Exception exception) {
                                     if (holder.getAdapterPosition() == position) {
+                                        holder.hideActivityIndicator();
                                         final ImageView imageView =
                                                 holder.thumbnailContainer.getImageView();
                                         imageView.setBackgroundColor(Color.TRANSPARENT);
                                         imageView.setImageBitmap(null);
-                                        showPosition(position, holder);
                                     }
                                 }
                             });
@@ -477,7 +481,6 @@ public class MultiPageReviewActivity extends AppCompatActivity {
             }
             holder.thumbnailContainer.rotateImageView(
                         photo.getRotationForDisplay(), false);
-            showPosition(position, holder);
         }
 
         private void showPosition(final int position, final @NonNull ViewHolder holder) {
@@ -600,6 +603,7 @@ public class MultiPageReviewActivity extends AppCompatActivity {
             final View handle;
             final View highlight;
             final RotatableImageViewContainer thumbnailContainer;
+            final ProgressBar activityIndicator;
 
             ViewHolder(final View itemView) {
                 super(itemView);
@@ -607,6 +611,20 @@ public class MultiPageReviewActivity extends AppCompatActivity {
                 badge = itemView.findViewById(R.id.gv_badge);
                 highlight = itemView.findViewById(R.id.gv_highlight);
                 handle = itemView.findViewById(R.id.gv_handle);
+                activityIndicator = itemView.findViewById(R.id.gv_activity_indicator);
+            }
+
+            void showActivityIndicator() {
+                activityIndicator.setVisibility(View.VISIBLE);
+            }
+
+            void hideActivityIndicator() {
+                activityIndicator.setVisibility(View.INVISIBLE);
+            }
+
+            void resetImageView() {
+                thumbnailContainer.rotateImageView(0, false);
+                thumbnailContainer.getImageView().setImageDrawable(null);
             }
         }
 

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
@@ -22,6 +22,7 @@ import com.ortiz.touch.TouchImageView;
 
 import net.gini.android.vision.Document;
 import net.gini.android.vision.GiniVision;
+import net.gini.android.vision.GiniVisionDebug;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.R;
 import net.gini.android.vision.document.DocumentFactory;
@@ -221,6 +222,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
             final GiniVisionNetworkService networkService = GiniVision.getInstance()
                     .internal().getGiniVisionNetworkService();
             if (networkService != null) {
+                GiniVisionDebug.writeDocumentToFile(activity, document, "_for_review");
                 networkService.analyze(document,
                         new GiniVisionNetworkCallback<AnalysisResult, Error>() {
                             @Override

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
@@ -305,6 +305,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         mActivityIndicator.setVisibility(View.VISIBLE);
         disableNextButton();
         disableRotateButton();
+        disableAddPageButton();
     }
 
     private void hideActivityIndicatorAndEnableButtons() {
@@ -314,6 +315,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         mActivityIndicator.setVisibility(View.GONE);
         enableNextButton();
         enableRotateButton();
+        enableAddPageButton();
     }
 
     private void disableNextButton() {
@@ -346,6 +348,22 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         }
         mButtonRotate.setEnabled(true);
         mButtonRotate.setAlpha(1f);
+    }
+
+    private void disableAddPageButton() {
+        if (mButtonAddPage == null) {
+            return;
+        }
+        mButtonAddPage.setEnabled(false);
+        mButtonAddPage.setAlpha(0.5f);
+    }
+
+    private void enableAddPageButton() {
+        if (mButtonAddPage == null) {
+            return;
+        }
+        mButtonAddPage.setEnabled(true);
+        mButtonAddPage.setAlpha(1f);
     }
 
     private void showDocument() {

--- a/ginivision/src/main/java/net/gini/android/vision/review/RotatableImageViewContainer.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/RotatableImageViewContainer.java
@@ -90,7 +90,7 @@ public class RotatableImageViewContainer extends FrameLayout {
     }
 
     void rotateImageView(final int degrees, final boolean animated) {
-        if (degrees == 0 || isRotating) {
+        if (degrees == mImageView.getRotation() || isRotating) {
             return;
         }
 

--- a/ginivision/src/main/res/layout/gv_fragment_image.xml
+++ b/ginivision/src/main/res/layout/gv_fragment_image.xml
@@ -21,5 +21,18 @@
 
     </net.gini.android.vision.review.RotatableTouchImageViewContainer>
 
+    <ProgressBar
+        android:id="@+id/gv_activity_indicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:indeterminateOnly="true"
+        android:indeterminateTint="@color/gv_analysis_activity_indicator"
+        android:indeterminateTintMode="src_in"
+        android:padding="@dimen/gv_review_progressbar_padding"
+        android:visibility="gone"
+        tools:targetApi="lollipop"
+        tools:visibility="visible" />
+
 </RelativeLayout>
 

--- a/ginivision/src/main/res/layout/gv_item_thumbnail.xml
+++ b/ginivision/src/main/res/layout/gv_item_thumbnail.xml
@@ -18,19 +18,34 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
+        <ProgressBar
+            android:id="@+id/gv_activity_indicator"
+            android:layout_width="64dp"
+            android:layout_height="match_parent"
+            android:layout_alignParentTop="true"
+            android:layout_centerHorizontal="true"
+            android:layout_above="@id/gv_handle"
+            android:indeterminateOnly="true"
+            android:indeterminateTint="@color/gv_analysis_activity_indicator"
+            android:indeterminateTintMode="src_in"
+            android:padding="@dimen/gv_review_progressbar_padding"
+            android:visibility="invisible"
+            tools:targetApi="lollipop"
+            tools:visibility="visible" />
+
         <net.gini.android.vision.review.RotatableImageViewContainer
             android:id="@+id/gv_thumbnail_container"
             android:layout_width="match_parent"
-            android:layout_height="126dp"
+            android:layout_height="match_parent"
+            android:layout_above="@id/gv_handle"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"/>
 
         <RelativeLayout
             android:id="@+id/gv_handle"
-            android:layout_below="@id/gv_thumbnail_container"
             android:layout_alignParentBottom="true"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="32dp">
 
             <TextView
                 android:id="@+id/gv_badge"

--- a/ginivision/src/main/res/values/strings.xml
+++ b/ginivision/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
 
     <string name="gv_review_bottom_panel_text">Dokument vollständig, scharf und in Leserichtung fotografiert?\n\nDoppeltippen um Schärfe zu prüfen.</string>
 
+    <string name="gv_multi_page_review_image_preview_error">Vorschaubild leider nicht verfügbar.</string>
+
     <string name="gv_document_analysis_error_retry">Wiederholen</string>
     <string name="gv_analysis_activity_indicator_message">Dokument wird analysiert</string>
 

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
@@ -305,6 +305,7 @@ public class MainActivity extends AppCompatActivity {
     protected void onActivityResult(final int requestCode, final int resultCode,
             final Intent data) {
         if (requestCode == REQUEST_SCAN) {
+            GiniVision.cleanup(this);
             if (data == null) {
                 if (isIntentActionViewOrSend(getIntent())) {
                     finish();


### PR DESCRIPTION
Showing loading indicators in:
* Camera Screen: while imported files are processed (copied over)
* Multi-Page Review Screen:
  * In the ViewPager fragments until the image is loaded
  * In the thumbnails for reordering until the image is loaded

Improved the MemoryCache to keep track of callbacks for the same key and invoke all callbacks belonging to a key.

Removed unnecessary RecyclerView updates (used to display the thumbnails for reordering).

### How to test
Run the Screen API Example App and take multiple pictures and/or import images and play around with the Multi-Page Review Screen.

### Ticket 
Issue #155 
