### PR TITLE
Feature always show multi page review and hide "+" button for "open with"

### DIFF
--- a/ginivision/src/androidTest/java/net/gini/android/vision/analysis/AnalysisScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/analysis/AnalysisScreenTest.java
@@ -94,7 +94,7 @@ public class AnalysisScreenTest {
         assertThat(activity.analyzeDocument).isNotNull();
 
         assertAbout(document()).that(activity.analyzeDocument).isEqualToDocument(
-                DocumentFactory.newDocumentFromPhoto(
+                DocumentFactory.newImageDocumentFromPhoto(
                         PhotoFactory.newPhotoFromJpeg(TEST_JPEG, 0, "portrait", "phone",
                                 ImageDocument.Source.newCameraSource())));
     }
@@ -351,7 +351,7 @@ public class AnalysisScreenTest {
         assertThat(activity.analyzeDocument).isNotNull();
 
         assertAbout(document()).that(activity.analyzeDocument)
-                .isEqualToDocument(DocumentFactory.newDocumentFromPhoto(
+                .isEqualToDocument(DocumentFactory.newImageDocumentFromPhoto(
                         PhotoFactory.newPhotoFromJpeg(TEST_JPEG, 0, "portrait", "phone",
                                 ImageDocument.Source.newCameraSource())));
     }
@@ -378,7 +378,7 @@ public class AnalysisScreenTest {
     private AnalysisActivityTestSpy startAnalysisActivity(final byte[] jpeg,
             final int orientation) {
         final Intent intent = getAnalysisActivityIntent();
-        intent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, DocumentFactory.newDocumentFromPhoto(
+        intent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, DocumentFactory.newImageDocumentFromPhoto(
                 PhotoFactory.newPhotoFromJpeg(jpeg, orientation, "portrait", "phone", ImageDocument.Source.newCameraSource())));
         return mActivityTestRule.launchActivity(intent);
     }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
@@ -395,7 +395,7 @@ public class CameraScreenTest {
         // Prevent really starting the ReviewActivity
         doNothing().when(cameraActivitySpy).startActivityForResult(any(Intent.class), anyInt());
         // Fake taking of a picture, which will cause the ReviewActivity to be launched
-        cameraActivitySpy.onDocumentAvailable(DocumentFactory.newDocumentFromPhoto(
+        cameraActivitySpy.onDocumentAvailable(DocumentFactory.newImageDocumentFromPhoto(
                 PhotoFactory.newPhotoFromJpeg(new byte[]{}, 0, "portrait", "phone", ImageDocument.Source.newCameraSource())));
 
         // Check that the extra was passed on to the ReviewActivity

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/photo/PhotoTest.java
@@ -56,7 +56,7 @@ public class PhotoTest {
         // When
         final MutablePhoto fromDocument =
                 (MutablePhoto) PhotoFactory.newPhotoFromDocument(
-                        (ImageDocument) DocumentFactory.newDocumentFromPhoto(photo));
+                        (ImageDocument) DocumentFactory.newImageDocumentFromPhoto(photo));
         // Then
         assertAbout(photo()).that(photo).hasSameUserCommentAs(fromDocument);
     }
@@ -69,7 +69,7 @@ public class PhotoTest {
         // When
         final MutablePhoto fromDocument =
                 (MutablePhoto) PhotoFactory.newPhotoFromDocument(
-                        (ImageDocument) DocumentFactory.newDocumentFromPhoto(photo));
+                        (ImageDocument) DocumentFactory.newImageDocumentFromPhoto(photo));
         // Then
         assertThat(photo.getContentId()).isEqualTo(fromDocument.getContentId());
     }
@@ -84,7 +84,7 @@ public class PhotoTest {
         photo.edit().rotateTo(90).apply();
         final MutablePhoto fromDocument =
                 (MutablePhoto) PhotoFactory.newPhotoFromDocument(
-                        (ImageDocument) DocumentFactory.newDocumentFromPhoto(photo));
+                        (ImageDocument) DocumentFactory.newImageDocumentFromPhoto(photo));
         // Then
         assertThat(photo.getRotationDelta()).isEqualTo(fromDocument.getRotationDelta());
     }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/test/Helpers.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/test/Helpers.java
@@ -79,7 +79,7 @@ public class Helpers {
     public static Document createDocument(final byte[] jpeg, final int orientation,
             final String deviceOrientation,
             final String deviceType, final ImageDocument.Source source) {
-        return DocumentFactory.newDocumentFromPhoto(
+        return DocumentFactory.newImageDocumentFromPhoto(
                 PhotoFactory.newPhotoFromJpeg(jpeg, orientation, deviceOrientation, deviceType,
                         source));
     }

--- a/ginivision/src/main/java/net/gini/android/vision/document/DocumentFactory.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/DocumentFactory.java
@@ -60,16 +60,16 @@ public final class DocumentFactory {
         return ImageDocument.empty(source, importMethod);
     }
 
-    public static GiniVisionDocument newDocumentFromPhoto(@NonNull final Photo photo) {
+    public static ImageDocument newImageDocumentFromPhoto(@NonNull final Photo photo) {
         return ImageDocument.fromPhoto(photo);
     }
 
-    public static GiniVisionDocument newDocumentFromPhoto(@NonNull final Photo photo,
+    public static ImageDocument newImageDocumentFromPhoto(@NonNull final Photo photo,
             @NonNull final Uri storedAtUri) {
         return ImageDocument.fromPhoto(photo, storedAtUri);
     }
 
-    public static GiniVisionDocument newDocumentFromPhotoAndDocument(@NonNull final Photo photo,
+    public static ImageDocument newImageDocumentFromPhotoAndDocument(@NonNull final Photo photo,
             @NonNull final GiniVisionDocument document) {
         return ImageDocument.fromPhotoAndDocument(photo, document);
     }

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
@@ -212,11 +212,6 @@ public class ReviewActivity extends AppCompatActivity implements ReviewFragmentL
     }
 
     @Override
-    public void onGoBackToCameraScreen() {
-        finish();
-    }
-
-    @Override
     protected void onSaveInstanceState(final Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putBoolean(NO_EXTRACTIONS_FOUND_KEY, mNoExtractionsFound);

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
@@ -29,7 +29,6 @@ import net.gini.android.vision.R;
 import net.gini.android.vision.document.DocumentFactory;
 import net.gini.android.vision.document.GiniVisionDocument;
 import net.gini.android.vision.document.ImageDocument;
-import net.gini.android.vision.document.ImageMultiPageDocument;
 import net.gini.android.vision.internal.AsyncCallback;
 import net.gini.android.vision.internal.camera.photo.Photo;
 import net.gini.android.vision.internal.camera.photo.PhotoEdit;
@@ -77,11 +76,6 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         }
 
         @Override
-        public void onGoBackToCameraScreen() {
-
-        }
-
-        @Override
         public void onExtractionsAvailable(
                 @NonNull final Map<String, GiniVisionSpecificExtraction> extractions) {
 
@@ -103,7 +97,6 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
     private TouchImageView mImageDocument;
     @VisibleForTesting
     ImageButton mButtonRotate;
-    private ImageButton mButtonAddPage;
     private ImageButton mButtonNext;
     private ProgressBar mActivityIndicator;
 
@@ -117,7 +110,6 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
     private boolean mNextClicked;
     private boolean mStopped;
     private String mDocumentAnalysisErrorMessage;
-    private boolean mWillAddMorePages;
 
     ReviewFragmentImpl(@NonNull final FragmentImplCallback fragment,
             @NonNull final Document document) {
@@ -153,19 +145,6 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
 
     @Override
     public void onNoExtractionsFound() {
-    }
-
-    private void addMorePages() {
-        mWillAddMorePages = true;
-        if (GiniVision.hasInstance()) {
-            final ImageDocument document =
-                    (ImageDocument) DocumentFactory.newDocumentFromPhotoAndDocument(mPhoto,
-                            mDocument);
-            final ImageMultiPageDocument multiPageDocument = new ImageMultiPageDocument(document);
-            GiniVision.getInstance().internal().getImageMultiPageDocumentMemoryStore()
-                    .setMultiPageDocument(multiPageDocument);
-            mListener.onGoBackToCameraScreen();
-        }
     }
 
     public void onCreate(@Nullable final Bundle savedInstanceState) {
@@ -312,7 +291,6 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         mActivityIndicator.setVisibility(View.VISIBLE);
         disableNextButton();
         disableRotateButton();
-        disableAddPageButton();
     }
 
     private void hideActivityIndicatorAndEnableButtons() {
@@ -322,7 +300,6 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         mActivityIndicator.setVisibility(View.GONE);
         enableNextButton();
         enableRotateButton();
-        enableAddPageButton();
     }
 
     private void disableNextButton() {
@@ -357,22 +334,6 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         mButtonRotate.setAlpha(1f);
     }
 
-    private void disableAddPageButton() {
-        if (mButtonAddPage == null) {
-            return;
-        }
-        mButtonAddPage.setEnabled(false);
-        mButtonAddPage.setAlpha(0.5f);
-    }
-
-    private void enableAddPageButton() {
-        if (mButtonAddPage == null) {
-            return;
-        }
-        mButtonAddPage.setEnabled(true);
-        mButtonAddPage.setAlpha(1f);
-    }
-
     private void showDocument() {
         if (mPhoto == null) {
             return;
@@ -390,8 +351,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
     }
 
     public void onDestroy() {
-        if (!mWillAddMorePages
-                && !mNextClicked) {
+        if (!mNextClicked) {
             deleteUploadedDocument();
         }
         mPhoto = null; // NOPMD
@@ -403,7 +363,6 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         mImageDocument = view.findViewById(R.id.gv_image_document);
         mButtonRotate = view.findViewById(R.id.gv_button_rotate);
         mButtonNext = view.findViewById(R.id.gv_button_next);
-        mButtonAddPage = view.findViewById(R.id.gv_button_add_page);
         mActivityIndicator = view.findViewById(R.id.gv_activity_indicator);
     }
 
@@ -428,12 +387,6 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
             @Override
             public void onClick(final View v) {
                 onRotateClicked();
-            }
-        });
-        mButtonAddPage.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(final View v) {
-                addMorePages();
             }
         });
         mButtonNext.setOnClickListener(new View.OnClickListener() {

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
@@ -205,7 +205,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         if (activity == null) {
             return;
         }
-        final GiniVisionDocument document = DocumentFactory.newDocumentFromPhotoAndDocument(mPhoto,
+        final GiniVisionDocument document = DocumentFactory.newImageDocumentFromPhotoAndDocument(mPhoto,
                 mDocument);
         if (GiniVision.hasInstance()) {
             final NetworkRequestsManager networkRequestsManager = GiniVision.getInstance()
@@ -438,7 +438,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
                 if (mStopped) {
                     return;
                 }
-                final GiniVisionDocument document = DocumentFactory.newDocumentFromPhotoAndDocument(
+                final GiniVisionDocument document = DocumentFactory.newImageDocumentFromPhotoAndDocument(
                         photo, mDocument);
                 mListener.onDocumentWasRotated(
                         document,
@@ -515,7 +515,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         if (activity == null) {
             return;
         }
-        final GiniVisionDocument document = DocumentFactory.newDocumentFromPhotoAndDocument(mPhoto,
+        final GiniVisionDocument document = DocumentFactory.newImageDocumentFromPhotoAndDocument(mPhoto,
                 mDocument);
         if (GiniVision.hasInstance()) {
             final NetworkRequestsManager networkRequestsManager =
@@ -532,7 +532,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
 
     private void proceedToAnalysisScreen() {
         LOG.info("Proceed to Analysis Screen");
-        final GiniVisionDocument document = DocumentFactory.newDocumentFromPhotoAndDocument(mPhoto,
+        final GiniVisionDocument document = DocumentFactory.newImageDocumentFromPhotoAndDocument(mPhoto,
                 mDocument);
         if (GiniVision.hasInstance()) {
             mListener.onProceedToAnalysisScreen(document, mDocumentAnalysisErrorMessage);

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentListener.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentListener.java
@@ -93,8 +93,6 @@ public interface ReviewFragmentListener {
      */
     void onError(@NonNull GiniVisionError error);
 
-    void onGoBackToCameraScreen();
-
     /**
      * Called when the document has been analyzed and extractions are available.
      *

--- a/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewFragment.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewFragment.java
@@ -231,7 +231,7 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
         };
 
         mThumbnailsAdapter = new ThumbnailsAdapter(activity, mMultiPageDocument,
-                mThumbnailsAdapterListener);
+                mThumbnailsAdapterListener, shouldShowPlusButton());
         mThumbnailsRecycler.setAdapter(mThumbnailsAdapter);
 
         mThumbnailsScroller = new LinearSmoothScroller(activity);
@@ -246,6 +246,10 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
         final RecyclerView.ItemAnimator itemAnimator = new DefaultItemAnimator();
         itemAnimator.setChangeDuration(0);
         mThumbnailsRecycler.setItemAnimator(itemAnimator);
+    }
+
+    private boolean shouldShowPlusButton() {
+        return mMultiPageDocument.getImportMethod() != Document.ImportMethod.OPEN_WITH;
     }
 
     private void bindViews(final View view) {

--- a/ginivision/src/main/java/net/gini/android/vision/review/multipage/thumbnails/ThumbnailsAdapter.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/multipage/thumbnails/ThumbnailsAdapter.java
@@ -40,14 +40,17 @@ public class ThumbnailsAdapter extends
     private final ImageMultiPageDocument mMultiPageDocument;
     private final ThumbnailsAdapterListener mListener;
     private final List<Thumbnail> mThumbnails;
+    private final boolean mShowPlusButton;
     private ItemTouchHelper mItemTouchHelper;
     private RecyclerView mRecyclerView;
 
     public ThumbnailsAdapter(@NonNull final Context context,
             @NonNull final ImageMultiPageDocument multiPageDocument,
-            @NonNull final ThumbnailsAdapterListener listener) {
+            @NonNull final ThumbnailsAdapterListener listener,
+            final boolean showPlusButton) {
         mContext = context;
         mMultiPageDocument = multiPageDocument;
+        mShowPlusButton = showPlusButton;
         final List<ImageDocument> documents = mMultiPageDocument.getDocuments();
         mThumbnails = new ArrayList<>(documents.size());
         for (final ImageDocument document : documents) {
@@ -100,8 +103,7 @@ public class ThumbnailsAdapter extends
 
     @Override
     public int getItemCount() {
-        // Plus button is always shown at the end
-        return mThumbnails.size() + 1;
+        return mThumbnails.size() + (mShowPlusButton ? 1 : 0);
     }
 
     @Override
@@ -292,7 +294,7 @@ public class ThumbnailsAdapter extends
 
     public int getScrollTargetPosition(final int position) {
         // When scrolling to the last thumbnail scroll to the plus button item instead
-        if (position == mThumbnails.size() - 1) {
+        if (mShowPlusButton && position == mThumbnails.size() - 1) {
             return position + 1;
         } else {
             return position;

--- a/ginivision/src/main/res/layout/gv_fragment_review.xml
+++ b/ginivision/src/main/res/layout/gv_fragment_review.xml
@@ -38,19 +38,6 @@
         android:id="@+id/gv_button_rotate"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_above="@+id/gv_button_add_page"
-        android:layout_alignEnd="@+id/gv_button_next"
-        android:layout_alignRight="@+id/gv_button_next"
-        android:layout_marginBottom="@dimen/gv_review_button_rotate_vertical_margin"
-        android:layout_marginEnd="@dimen/gv_review_button_rotate_horizontal_margin"
-        android:layout_marginRight="@dimen/gv_review_button_rotate_horizontal_margin"
-        android:background="@drawable/gv_review_fab_mini_background"
-        android:src="@drawable/gv_review_button_rotate" />
-
-    <ImageButton
-        android:id="@+id/gv_button_add_page"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
         android:layout_above="@+id/gv_button_next"
         android:layout_alignEnd="@+id/gv_button_next"
         android:layout_alignRight="@+id/gv_button_next"
@@ -58,7 +45,7 @@
         android:layout_marginEnd="@dimen/gv_review_button_rotate_horizontal_margin"
         android:layout_marginRight="@dimen/gv_review_button_rotate_horizontal_margin"
         android:background="@drawable/gv_review_fab_mini_background"
-        android:src="@drawable/gv_review_fab_add_page" />
+        android:src="@drawable/gv_review_button_rotate" />
 
     <ImageButton
         android:id="@+id/gv_button_next"


### PR DESCRIPTION
When multi-page is enabled (which it currently always is) it goes directly to the Multi-Page Review Screen.

Removed the "+" floating action button from the Single Page Review Screen.

Also the "+" is hidden for "open with" imported documents in the Multi-Page Review Screen.

### How to test
Run one of the example apps.

### Ticket 
Issue #199, #163 
