### PR TITLE
Feature multi page jpeg exif and compression (after #207)

### DIFF
--- a/ginivision-network/src/main/java/net/gini/android/vision/network/GiniVisionDefaultNetworkService.java
+++ b/ginivision-network/src/main/java/net/gini/android/vision/network/GiniVisionDefaultNetworkService.java
@@ -18,6 +18,7 @@ import net.gini.android.vision.document.GiniVisionMultiPageDocument;
 import net.gini.android.vision.network.model.GiniVisionExtraction;
 import net.gini.android.vision.network.model.GiniVisionSpecificExtraction;
 import net.gini.android.vision.util.CancellationToken;
+import net.gini.android.vision.util.NoOpCancellationToken;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -458,13 +459,6 @@ public class GiniVisionDefaultNetworkService implements GiniVisionNetworkService
         public Builder setBackoffMultiplier(final float backoffMultiplier) {
             mBackoffMultiplier = backoffMultiplier;
             return this;
-        }
-    }
-
-    private static class NoOpCancellationToken implements CancellationToken {
-
-        @Override
-        public void cancel() {
         }
     }
 

--- a/ginivision-network/src/main/java/net/gini/android/vision/network/GiniVisionDefaultNetworkService.java
+++ b/ginivision-network/src/main/java/net/gini/android/vision/network/GiniVisionDefaultNetworkService.java
@@ -17,6 +17,7 @@ import net.gini.android.vision.Document;
 import net.gini.android.vision.document.GiniVisionMultiPageDocument;
 import net.gini.android.vision.network.model.GiniVisionExtraction;
 import net.gini.android.vision.network.model.GiniVisionSpecificExtraction;
+import net.gini.android.vision.util.CancellationToken;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/network/GiniVisionNetworkServiceStub.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/network/GiniVisionNetworkServiceStub.java
@@ -4,7 +4,7 @@ import android.support.annotation.NonNull;
 
 import net.gini.android.vision.Document;
 import net.gini.android.vision.network.AnalysisResult;
-import net.gini.android.vision.network.CancellationToken;
+import net.gini.android.vision.util.CancellationToken;
 import net.gini.android.vision.network.Error;
 import net.gini.android.vision.network.GiniVisionNetworkCallback;
 import net.gini.android.vision.network.GiniVisionNetworkService;

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/network/NetworkRequestsManagerTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/network/NetworkRequestsManagerTest.java
@@ -23,7 +23,7 @@ import net.gini.android.vision.document.ImageDocument;
 import net.gini.android.vision.document.ImageMultiPageDocument;
 import net.gini.android.vision.internal.cache.DocumentDataMemoryCache;
 import net.gini.android.vision.network.AnalysisResult;
-import net.gini.android.vision.network.CancellationToken;
+import net.gini.android.vision.util.CancellationToken;
 import net.gini.android.vision.network.Error;
 import net.gini.android.vision.network.GiniVisionNetworkCallback;
 import net.gini.android.vision.network.GiniVisionNetworkService;

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
@@ -1,27 +1,29 @@
 package net.gini.android.vision;
 
-import static net.gini.android.vision.internal.util.FeatureConfiguration.isMultiPageEnabled;
-
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.support.annotation.NonNull;
 
 import net.gini.android.vision.analysis.AnalysisActivity;
-import net.gini.android.vision.camera.CameraActivity;
 import net.gini.android.vision.document.DocumentFactory;
 import net.gini.android.vision.document.ImageDocument;
 import net.gini.android.vision.document.ImageMultiPageDocument;
+import net.gini.android.vision.internal.camera.photo.Photo;
+import net.gini.android.vision.internal.camera.photo.PhotoFactory;
 import net.gini.android.vision.internal.util.ActivityHelper;
 import net.gini.android.vision.internal.util.DeviceHelper;
 import net.gini.android.vision.internal.util.FileImportValidator;
 import net.gini.android.vision.internal.util.MimeType;
-import net.gini.android.vision.network.GiniVisionNetworkService;
 import net.gini.android.vision.review.ReviewActivity;
 import net.gini.android.vision.review.multipage.MultiPageReviewActivity;
+import net.gini.android.vision.util.CancellationToken;
 import net.gini.android.vision.util.IntentHelper;
 import net.gini.android.vision.util.UriHelper;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -49,14 +51,7 @@ public final class GiniVisionFileImport {
      * @throws ImportedFileValidationException if the file didn't pass validation
      * @throws IllegalArgumentException        if the Intent's data is not valid or the mime type is not
      *                                         supported
-     *
-     * @deprecated Use {@link GiniVisionFileImport#createIntentForImportedFile(Intent, Context)} instead
-     * when a {@link GiniVision} instance is available. The document
-     * is analyzed internally by using the configured {@link GiniVisionNetworkService}
-     * implementation. The extractions will be returned in the extra called
-     * {@link CameraActivity#EXTRA_OUT_EXTRACTIONS} of the {@link CameraActivity}'s result Intent.
      */
-    @Deprecated
     @NonNull
     public static Intent createIntentForImportedFile(@NonNull final Intent intent,
             @NonNull final Context context,
@@ -65,17 +60,7 @@ public final class GiniVisionFileImport {
             throws ImportedFileValidationException {
         final Document document = createDocumentForImportedFile(intent, context);
         final Intent giniVisionIntent;
-        if (document.getType() == Document.Type.IMAGE_MULTI_PAGE) {
-            final ImageMultiPageDocument multiPageDocument = (ImageMultiPageDocument) document;
-            final List<ImageDocument> imageDocuments = multiPageDocument.getDocuments();
-            if (imageDocuments.size() > 1) {
-                giniVisionIntent = MultiPageReviewActivity.createIntent(context);
-            } else {
-                final ImageDocument imageDocument = imageDocuments.get(0);
-                giniVisionIntent = createReviewActivityIntent(context, ReviewActivity.class,
-                        AnalysisActivity.class, imageDocument);
-            }
-        } else if (document.isReviewable()) {
+        if (document.isReviewable()) {
             giniVisionIntent = createReviewActivityIntent(context, reviewActivityClass,
                     analysisActivityClass, document);
         } else {
@@ -99,51 +84,6 @@ public final class GiniVisionFileImport {
     }
 
     /**
-     * <b>Screen API</b>
-     * <p>
-     * When your application receives a file from another application you can use this method to
-     * create an Intent for launching the Gini Vision Library.
-     * <p>
-     *     Start the Intent with {@link android.app.Activity#startActivityForResult(Intent,
-     *     int)} to receive the extractions or a {@link GiniVisionError} in case there was an error.
-     * </p>
-     *
-     * @param intent                the Intent your app received
-     * @param context               Android context subclass
-     * @return an Intent for launching the Gini Vision Library
-     * @throws ImportedFileValidationException if the file didn't pass validation
-     * @throws IllegalArgumentException        if the Intent's data is not valid or the mime type is not
-     *                                         supported
-     */
-    @NonNull
-    public static Intent createIntentForImportedFile(@NonNull final Intent intent,
-            @NonNull final Context context)
-            throws ImportedFileValidationException {
-        final Document document = createDocumentForImportedFile(intent, context);
-        final Intent giniVisionIntent;
-        if (document.getType() == Document.Type.IMAGE_MULTI_PAGE) {
-            final ImageMultiPageDocument multiPageDocument = (ImageMultiPageDocument) document;
-            final List<ImageDocument> imageDocuments = multiPageDocument.getDocuments();
-            if (imageDocuments.size() > 1) {
-                giniVisionIntent = MultiPageReviewActivity.createIntent(context);
-            } else {
-                final ImageDocument imageDocument = imageDocuments.get(0);
-                giniVisionIntent = createReviewActivityIntent(context, ReviewActivity.class,
-                        AnalysisActivity.class, imageDocument);
-            }
-        } else {
-            if (document.isReviewable()) {
-                giniVisionIntent = createReviewActivityIntent(context, ReviewActivity.class,
-                        AnalysisActivity.class, document);
-            } else {
-                giniVisionIntent = new Intent(context, AnalysisActivity.class);
-                giniVisionIntent.putExtra(AnalysisActivity.EXTRA_IN_DOCUMENT, document);
-            }
-        }
-        return giniVisionIntent;
-    }
-
-    /**
      * <b>Component API</b>
      * <p>
      * When your application receives a file from another application you can use this method to
@@ -163,15 +103,10 @@ public final class GiniVisionFileImport {
      * @return a Document for launching one of the Gini Vision Library's Review Fragments or
      * Analysis Fragments
      * @throws ImportedFileValidationException if the file didn't pass validation
-     * @throws IllegalArgumentException        if the Intent's data is null or the mime type is not
-     *                                         supported
      */
     @NonNull
     public static Document createDocumentForImportedFile(@NonNull final Intent intent,
             @NonNull final Context context) throws ImportedFileValidationException {
-        if (isMultiPageEnabled() && IntentHelper.hasMultipleUris(intent)) {
-            return createDocumentForImportedFiles(intent, context);
-        }
         final Uri uri = IntentHelper.getUri(intent);
         if (uri == null) {
             throw new ImportedFileValidationException("Intent data did not contain a Uri");
@@ -190,45 +125,248 @@ public final class GiniVisionFileImport {
         }
     }
 
+    /**
+     * <b>Screen API</b>
+     * <p>
+     * When your application receives a file from another application you can use this method to
+     * create an Intent for launching the Gini Vision Library.
+     * <p>
+     *     Start the Intent with {@link android.app.Activity#startActivityForResult(Intent,
+     *     int)} to receive the extractions or a {@link GiniVisionError} in case there was an error.
+     * </p>
+     *
+     * @param intent                the Intent your app received
+     * @param context               Android context subclass
+     * @throws ImportedFileValidationException if the file didn't pass validation
+     */
+    public static CancellationToken createIntentForImportedFiles(@NonNull final Intent intent,
+            @NonNull final Context context,
+            @NonNull final Callback<Intent> callback) {
+        final CancellationToken cancellationToken =
+                createDocumentForImportedFiles(intent, context, new Callback<Document>() {
+                    @Override
+                    public void onDone(@NonNull final Document result) {
+                        final Intent giniVisionIntent = createIntent(result, context);
+                        callback.onDone(giniVisionIntent);
+                    }
+
+                    @Override
+                    public void onFailed(
+                            @NonNull final ImportedFileValidationException exception) {
+                        callback.onFailed(exception);
+                    }
+
+                    @Override
+                    public void onCancelled() {
+                        callback.onCancelled();
+                    }
+                });
+        return new CancellationToken() {
+            @Override
+            public void cancel() {
+                cancellationToken.cancel();
+            }
+        };
+    }
+
     @NonNull
-    private static Document createDocumentForImportedFiles(@NonNull final Intent intent,
-            @NonNull final Context context) throws ImportedFileValidationException {
+    private static Intent createIntent(final @NonNull Document result,
+            final @NonNull Context context) {
+        final Intent giniVisionIntent;
+        if (result.getType() == Document.Type.IMAGE_MULTI_PAGE) {
+            final ImageMultiPageDocument multiPageDocument = (ImageMultiPageDocument) result;
+            final List<ImageDocument> imageDocuments = multiPageDocument.getDocuments();
+            if (imageDocuments.size() > 1) {
+                giniVisionIntent = MultiPageReviewActivity.createIntent(context);
+            } else {
+                final ImageDocument imageDocument = imageDocuments.get(0);
+                giniVisionIntent = createReviewActivityIntent(context, ReviewActivity.class,
+                        AnalysisActivity.class, imageDocument);
+            }
+        } else {
+            if (result.isReviewable()) {
+                giniVisionIntent = createReviewActivityIntent(context, ReviewActivity.class,
+                        AnalysisActivity.class, result);
+            } else {
+                giniVisionIntent = new Intent(context, AnalysisActivity.class);
+                giniVisionIntent.putExtra(AnalysisActivity.EXTRA_IN_DOCUMENT, result);
+            }
+        }
+        return giniVisionIntent;
+    }
+
+    public static CancellationToken createDocumentForImportedFiles(@NonNull final Intent intent,
+            @NonNull final Context context, @NonNull final Callback<Document> callback) {
         if (!GiniVision.hasInstance()) {
-            throw new IllegalStateException(
-                    "Cannot import files. GiniVision instance not available. Create it with GiniVision.newInstance().");
+            callback.onFailed(new ImportedFileValidationException(
+                    "Cannot import files. GiniVision instance not available. Create it with GiniVision.newInstance()."));
+            return new CancellationToken() {
+                @Override
+                public void cancel() {
+                }
+            };
         }
         final List<Uri> uris = IntentHelper.getUris(intent);
         if (uris == null) {
-            throw new ImportedFileValidationException("Intent data did not contain Uris");
-        }
-        final ImageMultiPageDocument multiPageDocument = new ImageMultiPageDocument(
-                Document.Source.newExternalSource(), Document.ImportMethod.OPEN_WITH);
-        for (final Uri uri : uris) {
-            if (!UriHelper.isUriInputStreamAvailable(uri, context)) {
-                throw new ImportedFileValidationException(
-                        "InputStream not available for one of the Intent's data Uris");
-            }
-            final FileImportValidator fileImportValidator = new FileImportValidator(context);
-            if (fileImportValidator.matchesCriteria(uri)) {
-                if (IntentHelper.hasMimeTypeWithPrefix(uri, context,
-                        MimeType.IMAGE_PREFIX.asString())) {
-                    final ImageDocument document = DocumentFactory.newImageDocumentFromUri(uri,
-                            intent, context, DeviceHelper.getDeviceOrientation(context),
-                            DeviceHelper.getDeviceType(context), Document.ImportMethod.OPEN_WITH);
-                    multiPageDocument.addDocument(document);
+            callback.onFailed(
+                    new ImportedFileValidationException("Intent data did not contain Uris"));
+            return new CancellationToken() {
+                @Override
+                public void cancel() {
                 }
-            } else {
-                throw new ImportedFileValidationException(fileImportValidator.getError());
+            };
+        }
+        final ImportFilesAsyncTask asyncTask = new ImportFilesAsyncTask(context, intent,
+                new Callback<ImageMultiPageDocument>() {
+                    @Override
+                    public void onDone(@NonNull final ImageMultiPageDocument result) {
+                        if (!GiniVision.hasInstance()) {
+                            callback.onFailed(new ImportedFileValidationException(
+                                    "Cannot import files. GiniVision instance not available. Create it with GiniVision.newInstance()."));
+                            return;
+                        }
+                        GiniVision.getInstance().internal().getImageMultiPageDocumentMemoryStore()
+                                .setMultiPageDocument(result);
+                        callback.onDone(result);
+                    }
+
+                    @Override
+                    public void onFailed(@NonNull final ImportedFileValidationException exception) {
+                        callback.onFailed(exception);
+                    }
+
+                    @Override
+                    public void onCancelled() {
+                        callback.onCancelled();
+                    }
+                });
+        asyncTask.execute(uris.toArray(new Uri[uris.size()]));
+        return new CancellationToken() {
+            @Override
+            public void cancel() {
+                asyncTask.cancel(false);
             }
-        }
-        if (multiPageDocument.getDocuments().isEmpty()) {
-            throw new ImportedFileValidationException("Intent did not contain images");
-        }
-        GiniVision.getInstance().internal().getImageMultiPageDocumentMemoryStore()
-                .setMultiPageDocument(multiPageDocument);
-        return multiPageDocument;
+        };
     }
 
     private GiniVisionFileImport() {
+    }
+
+    public interface Callback<T> {
+
+        void onDone(@NonNull final T result);
+
+        void onFailed(@NonNull final ImportedFileValidationException exception);
+
+        void onCancelled();
+    }
+
+    private static class ImportFilesAsyncTask extends AsyncTask<Uri, Void, ImageMultiPageDocument> {
+
+        @SuppressLint("StaticFieldLeak")
+        private final Context mContext;
+        private final Intent mIntent;
+        private final Callback<ImageMultiPageDocument> mCallback;
+        private ImportedFileValidationException mException;
+
+        private ImportFilesAsyncTask(@NonNull final Context context,
+                @NonNull final Intent intent,
+                @NonNull final Callback<ImageMultiPageDocument> callback) {
+            mContext = context;
+            mIntent = intent;
+            mCallback = callback;
+        }
+
+        @Override
+        protected ImageMultiPageDocument doInBackground(final Uri... uris) {
+            final ImageMultiPageDocument multiPageDocument = new ImageMultiPageDocument(
+                    Document.Source.newExternalSource(), Document.ImportMethod.OPEN_WITH);
+            for (final Uri uri : uris) {
+                if (isCancelled()) {
+                    return null;
+                }
+                if (!UriHelper.isUriInputStreamAvailable(uri, mContext)) {
+                    mException = new ImportedFileValidationException(
+                            "InputStream not available for one of the Intent's data Uris");
+                    return null;
+                }
+                final FileImportValidator fileImportValidator = new FileImportValidator(mContext);
+                if (fileImportValidator.matchesCriteria(uri)) {
+                    if (isCancelled()) {
+                        return null;
+                    }
+                    if (IntentHelper.hasMimeTypeWithPrefix(uri, mContext,
+                            MimeType.IMAGE_PREFIX.asString())) {
+                        final String deviceOrientation = DeviceHelper.getDeviceOrientation(
+                                mContext);
+                        final String deviceType = DeviceHelper.getDeviceType(mContext);
+                        // Create Document
+                        final ImageDocument document = DocumentFactory.newImageDocumentFromUri(uri,
+                                mIntent, mContext, deviceOrientation,
+                                deviceType, Document.ImportMethod.OPEN_WITH);
+                        try {
+                            // Load uri into memory
+                            final byte[] bytesFromUri = UriHelper.getBytesFromUri(uri, mContext);
+                            document.setData(bytesFromUri);
+                        } catch (final IOException e) {
+                            mException = new ImportedFileValidationException(
+                                    "Failed to read file into memory");
+                            return null;
+                        }
+                        if (isCancelled()) {
+                            return null;
+                        }
+                        // Create Photo
+                        final Photo photo = PhotoFactory.newPhotoFromDocument(document);
+                        if (isCancelled()) {
+                            return null;
+                        }
+                        // Compress Photo
+                        photo.edit().compressByDefault().apply();
+                        if (isCancelled()) {
+                            return null;
+                        }
+                        // Save to local storage
+                        final Uri localUri = GiniVision.getInstance().internal().getImageDiskStore()
+                                .save(mContext, photo.getData());
+                        if (localUri == null) {
+                            mException = new ImportedFileValidationException(
+                                    "Failed to copy to app storage");
+                            return null;
+                        }
+                        if (isCancelled()) {
+                            return null;
+                        }
+                        // Create compressed Document
+                        final ImageDocument compressedDocument =
+                                DocumentFactory.newImageDocumentFromPhoto(photo, localUri);
+                        multiPageDocument.addDocument(compressedDocument);
+                    }
+                } else {
+                    mException = new ImportedFileValidationException(
+                            fileImportValidator.getError());
+                    return null;
+                }
+            }
+            if (multiPageDocument.getDocuments().isEmpty()) {
+                mException = new ImportedFileValidationException("Intent did not contain images");
+                return null;
+            }
+            if (isCancelled()) {
+                return null;
+            }
+            return multiPageDocument;
+        }
+
+        @Override
+        protected void onPostExecute(final ImageMultiPageDocument multiPageDocument) {
+            if (multiPageDocument != null) {
+                mCallback.onDone(multiPageDocument);
+            } else if (mException != null) {
+                mCallback.onFailed(mException);
+            } else {
+                mCallback.onCancelled();
+            }
+        }
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
@@ -21,6 +21,7 @@ import net.gini.android.vision.review.ReviewActivity;
 import net.gini.android.vision.review.multipage.MultiPageReviewActivity;
 import net.gini.android.vision.util.CancellationToken;
 import net.gini.android.vision.util.IntentHelper;
+import net.gini.android.vision.util.NoOpCancellationToken;
 import net.gini.android.vision.util.UriHelper;
 
 import java.io.IOException;
@@ -143,10 +144,11 @@ public final class GiniVisionFileImport {
             @NonNull final Context context,
             @NonNull final Callback<Intent> callback) {
         final CancellationToken cancellationToken =
-                createDocumentForImportedFiles(intent, context, new Callback<Document>() {
+                createDocumentForImportedFiles(intent, context, new Callback<ImageMultiPageDocument>() {
                     @Override
-                    public void onDone(@NonNull final Document result) {
-                        final Intent giniVisionIntent = createIntent(result, context);
+                    public void onDone(@NonNull final ImageMultiPageDocument result) {
+                        // The new ImageMultiPageDocument was already added to the memory store
+                        final Intent giniVisionIntent = MultiPageReviewActivity.createIntent(context);
                         callback.onDone(giniVisionIntent);
                     }
 
@@ -169,60 +171,24 @@ public final class GiniVisionFileImport {
         };
     }
 
-    @NonNull
-    private static Intent createIntent(final @NonNull Document result,
-            final @NonNull Context context) {
-        final Intent giniVisionIntent;
-        if (result.getType() == Document.Type.IMAGE_MULTI_PAGE) {
-            final ImageMultiPageDocument multiPageDocument = (ImageMultiPageDocument) result;
-            final List<ImageDocument> imageDocuments = multiPageDocument.getDocuments();
-            if (imageDocuments.size() > 1) {
-                giniVisionIntent = MultiPageReviewActivity.createIntent(context);
-            } else {
-                final ImageDocument imageDocument = imageDocuments.get(0);
-                giniVisionIntent = createReviewActivityIntent(context, ReviewActivity.class,
-                        AnalysisActivity.class, imageDocument);
-            }
-        } else {
-            if (result.isReviewable()) {
-                giniVisionIntent = createReviewActivityIntent(context, ReviewActivity.class,
-                        AnalysisActivity.class, result);
-            } else {
-                giniVisionIntent = new Intent(context, AnalysisActivity.class);
-                giniVisionIntent.putExtra(AnalysisActivity.EXTRA_IN_DOCUMENT, result);
-            }
-        }
-        return giniVisionIntent;
-    }
-
     public static CancellationToken createDocumentForImportedFiles(@NonNull final Intent intent,
-            @NonNull final Context context, @NonNull final Callback<Document> callback) {
+            @NonNull final Context context, @NonNull final Callback<ImageMultiPageDocument> callback) {
         if (!GiniVision.hasInstance()) {
-            callback.onFailed(new ImportedFileValidationException(
-                    "Cannot import files. GiniVision instance not available. Create it with GiniVision.newInstance()."));
-            return new CancellationToken() {
-                @Override
-                public void cancel() {
-                }
-            };
+            callback.onFailed(createNoGiniVisionFileValidationException());
+            return new NoOpCancellationToken();
         }
         final List<Uri> uris = IntentHelper.getUris(intent);
         if (uris == null) {
             callback.onFailed(
                     new ImportedFileValidationException("Intent data did not contain Uris"));
-            return new CancellationToken() {
-                @Override
-                public void cancel() {
-                }
-            };
+            return new NoOpCancellationToken();
         }
         final ImportFilesAsyncTask asyncTask = new ImportFilesAsyncTask(context, intent,
                 new Callback<ImageMultiPageDocument>() {
                     @Override
                     public void onDone(@NonNull final ImageMultiPageDocument result) {
                         if (!GiniVision.hasInstance()) {
-                            callback.onFailed(new ImportedFileValidationException(
-                                    "Cannot import files. GiniVision instance not available. Create it with GiniVision.newInstance()."));
+                            callback.onFailed(createNoGiniVisionFileValidationException());
                             return;
                         }
                         GiniVision.getInstance().internal().getImageMultiPageDocumentMemoryStore()
@@ -247,6 +213,12 @@ public final class GiniVisionFileImport {
                 asyncTask.cancel(false);
             }
         };
+    }
+
+    @NonNull
+    private static ImportedFileValidationException createNoGiniVisionFileValidationException() {
+        return new ImportedFileValidationException(
+                "Cannot import files. GiniVision instance not available. Create it with GiniVision.newInstance().");
     }
 
     private GiniVisionFileImport() {

--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
@@ -196,7 +196,7 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
         forcePortraitOrientationOnPhones(activity);
         final GiniVisionDocument documentToRender = getFirstDocument();
         if (documentToRender != null) {
-            mDocumentRenderer = DocumentRendererFactory.fromDocument(documentToRender, activity);
+            mDocumentRenderer = DocumentRendererFactory.fromDocument(documentToRender);
         }
         mHints = generateRandomHintsList();
     }
@@ -559,9 +559,13 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
     }
 
     private void showDocument() {
+        final Activity activity = mFragment.getActivity();
+        if (activity == null) {
+            return;
+        }
         LOG.debug("Rendering the document");
         final Size previewSize = new Size(mImageDocument.getWidth(), mImageDocument.getHeight());
-        mDocumentRenderer.toBitmap(previewSize, new DocumentRenderer.Callback() {
+        mDocumentRenderer.toBitmap(activity, previewSize, new DocumentRenderer.Callback() {
             @Override
             public void onBitmapReady(@Nullable final Bitmap bitmap, final int rotationForDisplay) {
                 LOG.debug("Document rendered");
@@ -594,7 +598,7 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
             mPdfPageCountTextView.setVisibility(View.VISIBLE);
             mPdfPageCountTextView.setText("");
 
-            mDocumentRenderer.getPageCount(new AsyncCallback<Integer>() {
+            mDocumentRenderer.getPageCount(activity, new AsyncCallback<Integer>() {
                 @Override
                 public void onSuccess(final Integer result) {
                     if (result > 0) {

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -68,6 +68,7 @@ import net.gini.android.vision.internal.camera.api.CameraException;
 import net.gini.android.vision.internal.camera.api.CameraInterface;
 import net.gini.android.vision.internal.camera.api.UIExecutor;
 import net.gini.android.vision.internal.camera.photo.Photo;
+import net.gini.android.vision.internal.camera.photo.PhotoEdit;
 import net.gini.android.vision.internal.camera.view.CameraPreviewSurface;
 import net.gini.android.vision.internal.fileimport.FileChooserActivity;
 import net.gini.android.vision.internal.network.AnalysisNetworkRequestResult;
@@ -1150,7 +1151,6 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                 new AsyncCallback<ImageMultiPageDocument>() {
                     @Override
                     public void onSuccess(final ImageMultiPageDocument multiPageDocument) {
-                        hideActivityIndicatorAndEnableInteraction();
                         if (mMultiPageDocument == null) {
                             mInMultiPageState = true;
                             mMultiPageDocument = multiPageDocument;
@@ -1167,6 +1167,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                         LOG.info("Document imported: {}", mMultiPageDocument);
                         updateImageStack();
                         requestClientDocumentCheck(mMultiPageDocument);
+                        hideActivityIndicatorAndEnableInteraction();
                     }
 
                     @Override
@@ -1215,7 +1216,6 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     private void updateImageStack() {
         final List<ImageDocument> documents = mMultiPageDocument.getDocuments();
         if (!documents.isEmpty()) {
-            showActivityIndicatorAndDisableInteraction();
             mImageStack.removeImages();
         }
         final int size = documents.size();
@@ -1274,7 +1274,6 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                             imagesLoadedCounter.incrementAndGet();
                             if (imagesToLoadCount == imagesLoadedCounter.get()) {
                                 mImageStack.setImageCount(mMultiPageDocument.getDocuments().size());
-                                hideActivityIndicatorAndEnableInteraction();
                             }
                         }
 
@@ -1284,7 +1283,6 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                             imagesLoadedCounter.incrementAndGet();
                             if (imagesToLoadCount == imagesLoadedCounter.get()) {
                                 mImageStack.setImageCount(mMultiPageDocument.getDocuments().size());
-                                hideActivityIndicatorAndEnableInteraction();
                             }
                         }
                     });
@@ -1355,57 +1353,83 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         } else {
             if (photo != null) {
                 LOG.info("Picture taken");
-                if (mInMultiPageState) {
-                    final ImageDocument document = (ImageDocument) createSavedDocument(photo);
-                    if (document == null) {
-                        handleError(GiniVisionError.ErrorCode.CAMERA_SHOT_FAILED,
-                                "Failed to take picture: could not save picture to disk", null);
-                        mCameraController.startPreview();
-                        mIsTakingPicture = false;
-                        return;
-                    }
-                    mMultiPageDocument.addDocument(document);
-                    mImageStack.addImage(new ImageStack.StackBitmap(photo.getBitmapPreview(),
-                            document.getRotationForDisplay()), new TransitionListenerAdapter() {
-                        @Override
-                        public void onTransitionEnd(@NonNull final Transition transition) {
-                            mIsTakingPicture = false;
-                        }
-                    });
-                    mCameraController.startPreview();
-                } else {
-                    if (isMultiPageEnabled()) {
-                        final ImageDocument document = createSavedDocument(photo);
-                        if (document == null) {
-                            handleError(GiniVisionError.ErrorCode.CAMERA_SHOT_FAILED,
-                                    "Failed to take picture: could not save picture to disk", null);
+                showActivityIndicatorAndDisableInteraction();
+                photo.edit().compressByDefault().applyAsync(new PhotoEdit.PhotoEditCallback() {
+                    @Override
+                    public void onDone(@NonNull final Photo result) {
+                        hideActivityIndicatorAndEnableInteraction();
+                        if (mInMultiPageState) {
+                            final ImageDocument document = createSavedDocument(result);
+                            if (document == null) {
+                                handleError(GiniVisionError.ErrorCode.CAMERA_SHOT_FAILED,
+                                        "Failed to take picture: could not save picture to disk",
+                                        null);
+                                mCameraController.startPreview();
+                                mIsTakingPicture = false;
+                                return;
+                            }
+                            mMultiPageDocument.addDocument(document);
+                            mImageStack.addImage(
+                                    new ImageStack.StackBitmap(result.getBitmapPreview(),
+                                            document.getRotationForDisplay()),
+                                    new TransitionListenerAdapter() {
+                                        @Override
+                                        public void onTransitionEnd(
+                                                @NonNull final Transition transition) {
+                                            mIsTakingPicture = false;
+                                        }
+                                    });
                             mCameraController.startPreview();
-                            mIsTakingPicture = false;
-                            return;
-                        }
-                        mInMultiPageState = true;
-                        mMultiPageDocument = new ImageMultiPageDocument(
-                                Document.Source.newCameraSource(), ImportMethod.NONE);
-                        GiniVision.getInstance().internal()
-                                .getImageMultiPageDocumentMemoryStore().setMultiPageDocument(
-                                mMultiPageDocument);
-                        mMultiPageDocument.addDocument(document);
-                        mImageStack.addImage(new ImageStack.StackBitmap(photo.getBitmapPreview(),
-                                document.getRotationForDisplay()), new TransitionListenerAdapter() {
-                            @Override
-                            public void onTransitionEnd(@NonNull final Transition transition) {
-                                mListener.onProceedToMultiPageReviewScreen(mMultiPageDocument);
+                        } else {
+                            if (isMultiPageEnabled()) {
+                                final ImageDocument document = createSavedDocument(result);
+                                if (document == null) {
+                                    handleError(GiniVisionError.ErrorCode.CAMERA_SHOT_FAILED,
+                                            "Failed to take picture: could not save picture to disk",
+                                            null);
+                                    mCameraController.startPreview();
+                                    mIsTakingPicture = false;
+                                    return;
+                                }
+                                mInMultiPageState = true;
+                                mMultiPageDocument = new ImageMultiPageDocument(
+                                        Document.Source.newCameraSource(), ImportMethod.NONE);
+                                GiniVision.getInstance().internal()
+                                        .getImageMultiPageDocumentMemoryStore().setMultiPageDocument(
+                                        mMultiPageDocument);
+                                mMultiPageDocument.addDocument(document);
+                                mImageStack.addImage(
+                                        new ImageStack.StackBitmap(result.getBitmapPreview(),
+                                                document.getRotationForDisplay()),
+                                        new TransitionListenerAdapter() {
+                                            @Override
+                                            public void onTransitionEnd(
+                                                    @NonNull final Transition transition) {
+                                                mListener.onProceedToMultiPageReviewScreen(
+                                                        mMultiPageDocument);
+                                                mIsTakingPicture = false;
+                                            }
+                                        });
+                            } else {
+                                final ImageDocument document =
+                                        DocumentFactory.newImageDocumentFromPhoto(
+                                                result);
+                                mListener.onDocumentAvailable(document);
                                 mIsTakingPicture = false;
                             }
-                        });
-                    } else {
-                        final ImageDocument document = DocumentFactory.newImageDocumentFromPhoto(
-                                photo);
-                        mListener.onDocumentAvailable(document);
+                            mCameraController.startPreview();
+                        }
+                    }
+
+                    @Override
+                    public void onFailed() {
+                        hideActivityIndicatorAndEnableInteraction();
+                        handleError(GiniVisionError.ErrorCode.CAMERA_SHOT_FAILED,
+                                "Failed to take picture: picture compression failed", null);
+                        mCameraController.startPreview();
                         mIsTakingPicture = false;
                     }
-                    mCameraController.startPreview();
-                }
+                });
             } else {
                 handleError(GiniVisionError.ErrorCode.CAMERA_SHOT_FAILED,
                         "Failed to take picture: no picture from the camera", null);

--- a/ginivision/src/main/java/net/gini/android/vision/camera/ImportUrisAsyncTask.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/ImportUrisAsyncTask.java
@@ -7,12 +7,15 @@ import android.os.AsyncTask;
 import android.support.annotation.NonNull;
 
 import net.gini.android.vision.Document;
+import net.gini.android.vision.GiniVision;
 import net.gini.android.vision.R;
 import net.gini.android.vision.document.DocumentFactory;
 import net.gini.android.vision.document.GiniVisionDocumentError;
 import net.gini.android.vision.document.ImageDocument;
 import net.gini.android.vision.document.ImageMultiPageDocument;
 import net.gini.android.vision.internal.AsyncCallback;
+import net.gini.android.vision.internal.camera.photo.Photo;
+import net.gini.android.vision.internal.camera.photo.PhotoFactory;
 import net.gini.android.vision.internal.storage.ImageDiskStore;
 import net.gini.android.vision.internal.util.DeviceHelper;
 import net.gini.android.vision.internal.util.FileImportValidator;
@@ -23,6 +26,7 @@ import net.gini.android.vision.util.UriHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -71,30 +75,64 @@ class ImportUrisAsyncTask extends AsyncTask<List<Uri>, Void, ImageMultiPageDocum
                         R.string.gv_document_import_invalid_document), multiPageDocument);
                 break;
             }
+
             final FileImportValidator fileImportValidator = new FileImportValidator(mContext);
             if (fileImportValidator.matchesCriteria(uri)) {
+                if (isCancelled()) {
+                    return null;
+                }
                 if (IntentHelper.hasMimeTypeWithPrefix(uri, mContext,
                         MimeType.IMAGE_PREFIX.asString())) {
+                    final String deviceOrientation = DeviceHelper.getDeviceOrientation(
+                            mContext);
+                    final String deviceType = DeviceHelper.getDeviceType(mContext);
+                    // Create Document
+                    final ImageDocument document = DocumentFactory.newImageDocumentFromUri(uri,
+                            mIntent, mContext, deviceOrientation,
+                            deviceType, Document.ImportMethod.PICKER);
                     try {
-                        final Uri localUri = mImageDiskStore.save(mContext, uri);
-                        if (localUri == null) {
-                            LOG.error("Failed to import selected document: "
-                                    + "could not copy to app storage");
-                            addMultiPageDocumentError(mContext.getString(
-                                    R.string.gv_document_import_invalid_document),
-                                    multiPageDocument);
-                            break;
-                        }
-                        final ImageDocument document = DocumentFactory.newImageDocumentFromUri(
-                                localUri,
-                                mIntent, mContext, DeviceHelper.getDeviceOrientation(mContext),
-                                DeviceHelper.getDeviceType(mContext), mImportMethod);
-                        multiPageDocument.addDocument(document);
-                    } catch (final IllegalArgumentException e) {
-                        LOG.error("Failed to import selected document", e);
+                        // Load uri into memory
+                        final byte[] bytesFromUri = UriHelper.getBytesFromUri(uri, mContext);
+                        document.setData(bytesFromUri);
+                    } catch (final IOException e) {
+                        LOG.error("Failed to import selected document: "
+                                + "could not read file into memory");
                         addMultiPageDocumentError(mContext.getString(
-                                R.string.gv_document_import_invalid_document), multiPageDocument);
+                                R.string.gv_document_import_invalid_document),
+                                multiPageDocument);
+                        break;
                     }
+                    if (isCancelled()) {
+                        return null;
+                    }
+                    // Create Photo
+                    final Photo photo = PhotoFactory.newPhotoFromDocument(document);
+                    if (isCancelled()) {
+                        return null;
+                    }
+                    // Compress Photo
+                    photo.edit().compressByDefault().apply();
+                    if (isCancelled()) {
+                        return null;
+                    }
+                    // Save to local storage
+                    final Uri localUri = GiniVision.getInstance().internal().getImageDiskStore()
+                            .save(mContext, photo.getData());
+                    if (localUri == null) {
+                        LOG.error("Failed to import selected document: "
+                                + "could not copy to app storage");
+                        addMultiPageDocumentError(mContext.getString(
+                                R.string.gv_document_import_invalid_document),
+                                multiPageDocument);
+                        break;
+                    }
+                    if (isCancelled()) {
+                        return null;
+                    }
+                    // Create compressed Document
+                    final ImageDocument compressedDocument =
+                            DocumentFactory.newImageDocumentFromPhoto(photo, localUri);
+                    multiPageDocument.addDocument(compressedDocument);
                 }
             } else {
                 String errorMessage = mContext.getString(

--- a/ginivision/src/main/java/net/gini/android/vision/camera/ImportUrisAsyncTask.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/ImportUrisAsyncTask.java
@@ -7,7 +7,6 @@ import android.os.AsyncTask;
 import android.support.annotation.NonNull;
 
 import net.gini.android.vision.Document;
-import net.gini.android.vision.GiniVision;
 import net.gini.android.vision.R;
 import net.gini.android.vision.document.DocumentFactory;
 import net.gini.android.vision.document.GiniVisionDocumentError;
@@ -116,8 +115,7 @@ class ImportUrisAsyncTask extends AsyncTask<List<Uri>, Void, ImageMultiPageDocum
                         return null;
                     }
                     // Save to local storage
-                    final Uri localUri = GiniVision.getInstance().internal().getImageDiskStore()
-                            .save(mContext, photo.getData());
+                    final Uri localUri = mImageDiskStore.save(mContext, photo.getData());
                     if (localUri == null) {
                         LOG.error("Failed to import selected document: "
                                 + "could not copy to app storage");

--- a/ginivision/src/main/java/net/gini/android/vision/document/GiniVisionDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/GiniVisionDocument.java
@@ -167,7 +167,7 @@ public class GiniVisionDocument implements Document {
         return mData;
     }
 
-    private synchronized void setData(final byte[] data) {
+    public synchronized void setData(final byte[] data) {
         mData = data;
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/document/ImageDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/ImageDocument.java
@@ -131,12 +131,7 @@ public final class ImageDocument extends GiniVisionDocument {
             throw new IllegalArgumentException("Intent must have a mime type of image/*");
         }
         final Source source = getDocumentSource(intent, context);
-        final Uri localUri = GiniVision.getInstance().internal().getImageDiskStore()
-                .save(context, uri);
-        if (localUri == null) {
-            throw new IllegalArgumentException("Failed to copy to app storage");
-        }
-        return new ImageDocument(localUri, ImageFormat.fromMimeType(mimeType), deviceOrientation,
+        return new ImageDocument(uri, ImageFormat.fromMimeType(mimeType), deviceOrientation,
                 deviceType, source, importMethod);
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoEdit.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/PhotoEdit.java
@@ -13,6 +13,8 @@ import java.util.List;
  */
 public class PhotoEdit {
 
+    private static final int DEFAULT_JPEG_COMPRESSION_QUALITY = 50;
+
     private final Photo mPhoto;
     @VisibleForTesting
     List<PhotoModifier> mPhotoModifiers;
@@ -43,6 +45,16 @@ public class PhotoEdit {
     public PhotoEdit compressBy(final int quality) {
         removeCompressionModifier();
         final PhotoCompressionModifier compressionModifier = new PhotoCompressionModifier(quality,
+                mPhoto);
+        getPhotoModifiers().add(compressionModifier);
+        return this;
+    }
+
+    @NonNull
+    public PhotoEdit compressByDefault() {
+        removeCompressionModifier();
+        final PhotoCompressionModifier compressionModifier = new PhotoCompressionModifier(
+                DEFAULT_JPEG_COMPRESSION_QUALITY,
                 mPhoto);
         getPhotoModifiers().add(compressionModifier);
         return this;
@@ -128,6 +140,7 @@ public class PhotoEdit {
      * @exclude
      */
     public interface PhotoEditCallback {
+
         void onDone(@NonNull Photo photo);
 
         void onFailed();

--- a/ginivision/src/main/java/net/gini/android/vision/internal/document/DocumentRenderer.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/document/DocumentRenderer.java
@@ -1,5 +1,6 @@
 package net.gini.android.vision.internal.document;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -12,9 +13,9 @@ import net.gini.android.vision.internal.util.Size;
  */
 public interface DocumentRenderer {
 
-    void toBitmap(@NonNull final Size targetSize, @NonNull final Callback callback);
+    void toBitmap(@NonNull final Context context, @NonNull final Size targetSize, @NonNull final Callback callback);
 
-    void getPageCount(@NonNull final AsyncCallback<Integer> asyncCallback);
+    void getPageCount(@NonNull final Context context, @NonNull final AsyncCallback<Integer> asyncCallback);
 
     /**
      * @exclude

--- a/ginivision/src/main/java/net/gini/android/vision/internal/document/DocumentRendererFactory.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/document/DocumentRendererFactory.java
@@ -1,6 +1,5 @@
 package net.gini.android.vision.internal.document;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 
 import net.gini.android.vision.Document;
@@ -13,13 +12,12 @@ import net.gini.android.vision.document.PdfDocument;
 
 public final class DocumentRendererFactory {
 
-    public static DocumentRenderer fromDocument(@NonNull final Document document,
-            @NonNull final Context context) {
+    public static DocumentRenderer fromDocument(@NonNull final Document document) {
         switch (document.getType()) {
             case IMAGE:
                 return new ImageDocumentRenderer((ImageDocument) document);
             case PDF:
-                return new PdfDocumentRenderer((PdfDocument) document, context);
+                return new PdfDocumentRenderer((PdfDocument) document);
             default:
                 throw new IllegalArgumentException("Unknown document type");
         }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/document/ImageDocumentRenderer.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/document/ImageDocumentRenderer.java
@@ -1,9 +1,12 @@
 package net.gini.android.vision.internal.document;
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 
+import net.gini.android.vision.GiniVision;
 import net.gini.android.vision.document.ImageDocument;
 import net.gini.android.vision.internal.AsyncCallback;
+import net.gini.android.vision.internal.cache.PhotoMemoryCache;
 import net.gini.android.vision.internal.camera.photo.Photo;
 import net.gini.android.vision.internal.camera.photo.PhotoFactoryDocumentAsyncTask;
 import net.gini.android.vision.internal.util.Size;
@@ -22,31 +25,56 @@ class ImageDocumentRenderer implements DocumentRenderer {
     }
 
     @Override
-    public void toBitmap(@NonNull final Size targetSize,
+    public void toBitmap(@NonNull final Context context, @NonNull final Size targetSize,
             @NonNull final Callback callback) {
-        if (mPhoto == null) {
-            final PhotoFactoryDocumentAsyncTask asyncTask = new PhotoFactoryDocumentAsyncTask(
-                    new AsyncCallback<Photo>() {
-                        @Override
-                        public void onSuccess(final Photo result) {
-                            mPhoto = result;
-                            callback.onBitmapReady(mPhoto.getBitmapPreview(),
-                                    mImageDocument.getRotationForDisplay());
-                        }
-
-                        @Override
-                        public void onError(final Exception exception) {
-                            callback.onBitmapReady(null, 0);
-                        }
-                    });
-            asyncTask.execute(mImageDocument);
+        if (GiniVision.hasInstance()) {
+            getFromCache(context, callback);
+        } else if (mPhoto == null)  {
+            createWithAsyncTask(callback);
         } else {
-            callback.onBitmapReady(mPhoto.getBitmapPreview(), mImageDocument.getRotationForDisplay());
+            callback.onBitmapReady(mPhoto.getBitmapPreview(),
+                    mImageDocument.getRotationForDisplay());
         }
     }
 
+    private void createWithAsyncTask(final @NonNull Callback callback) {
+        final PhotoFactoryDocumentAsyncTask asyncTask = new PhotoFactoryDocumentAsyncTask(
+                new AsyncCallback<Photo>() {
+                    @Override
+                    public void onSuccess(final Photo result) {
+                        mPhoto = result;
+                        callback.onBitmapReady(mPhoto.getBitmapPreview(),
+                                mImageDocument.getRotationForDisplay());
+                    }
+
+                    @Override
+                    public void onError(final Exception exception) {
+                        callback.onBitmapReady(null, 0);
+                    }
+                });
+        asyncTask.execute(mImageDocument);
+    }
+
+    private void getFromCache(@NonNull final Context context,
+            @NonNull final Callback callback) {
+        final PhotoMemoryCache photoMemoryCache =
+                GiniVision.getInstance().internal().getPhotoMemoryCache();
+        photoMemoryCache.get(context, mImageDocument, new AsyncCallback<Photo>() {
+            @Override
+            public void onSuccess(final Photo result) {
+                callback.onBitmapReady(result.getBitmapPreview(),
+                        mImageDocument.getRotationForDisplay());
+            }
+
+            @Override
+            public void onError(final Exception exception) {
+                callback.onBitmapReady(null, 0);
+            }
+        });
+    }
+
     @Override
-    public void getPageCount(@NonNull final AsyncCallback<Integer> asyncCallback) {
+    public void getPageCount(@NonNull final Context context, @NonNull final AsyncCallback<Integer> asyncCallback) {
         asyncCallback.onSuccess(1);
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/document/PdfDocumentRenderer.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/document/PdfDocumentRenderer.java
@@ -15,23 +15,20 @@ import net.gini.android.vision.internal.util.Size;
 class PdfDocumentRenderer implements DocumentRenderer {
 
     private final PdfDocument mPdfDocument;
-    private final Context mContext;
     private Pdf mPdf;
     private Bitmap mBitmap;
     private int mPageCount = -1;
 
-    PdfDocumentRenderer(@NonNull final PdfDocument document,
-            @NonNull final Context context) {
+    PdfDocumentRenderer(@NonNull final PdfDocument document) {
         mPdfDocument = document;
-        mContext = context;
     }
 
     @Override
-    public void toBitmap(@NonNull final Size targetSize,
+    public void toBitmap(@NonNull final Context context, @NonNull final Size targetSize,
             @NonNull final Callback callback) {
         final Pdf pdf = getPdf();
         if (mBitmap == null) {
-            pdf.toBitmap(targetSize, mContext, new AsyncCallback<Bitmap>() {
+            pdf.toBitmap(targetSize, context, new AsyncCallback<Bitmap>() {
                 @Override
                 public void onSuccess(final Bitmap result) {
                     mBitmap = result;
@@ -57,10 +54,10 @@ class PdfDocumentRenderer implements DocumentRenderer {
     }
 
     @Override
-    public void getPageCount(@NonNull final AsyncCallback<Integer> asyncCallback) {
+    public void getPageCount(@NonNull final Context context, @NonNull final AsyncCallback<Integer> asyncCallback) {
         final Pdf pdf = getPdf();
         if (mPageCount == -1) {
-            pdf.getPageCount(mContext, new AsyncCallback<Integer>() {
+            pdf.getPageCount(context, new AsyncCallback<Integer>() {
                 @Override
                 public void onSuccess(final Integer result) {
                     mPageCount = result;

--- a/ginivision/src/main/java/net/gini/android/vision/internal/network/NetworkRequestsManager.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/network/NetworkRequestsManager.java
@@ -10,17 +10,18 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import net.gini.android.vision.GiniVisionDebug;
 import net.gini.android.vision.document.GiniVisionDocument;
 import net.gini.android.vision.document.GiniVisionMultiPageDocument;
 import net.gini.android.vision.document.ImageDocument;
 import net.gini.android.vision.internal.AsyncCallback;
 import net.gini.android.vision.internal.cache.DocumentDataMemoryCache;
 import net.gini.android.vision.network.AnalysisResult;
-import net.gini.android.vision.network.CancellationToken;
 import net.gini.android.vision.network.Error;
 import net.gini.android.vision.network.GiniVisionNetworkCallback;
 import net.gini.android.vision.network.GiniVisionNetworkService;
 import net.gini.android.vision.network.Result;
+import net.gini.android.vision.util.CancellationToken;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,6 +91,7 @@ public class NetworkRequestsManager {
             @Override
             public void onSuccess(final byte[] result) {
                 LOG.debug("Document data loaded for {}", document.getId());
+                GiniVisionDebug.writeDocumentToFile(context, document, "-upload");
                 final CancellationToken cancellationToken =
                         mGiniVisionNetworkService.upload(document,
                                 new GiniVisionNetworkCallback<Result, Error>() {

--- a/ginivision/src/main/java/net/gini/android/vision/network/GiniVisionNetworkService.java
+++ b/ginivision/src/main/java/net/gini/android/vision/network/GiniVisionNetworkService.java
@@ -3,6 +3,7 @@ package net.gini.android.vision.network;
 import android.support.annotation.NonNull;
 
 import net.gini.android.vision.Document;
+import net.gini.android.vision.util.CancellationToken;
 
 import java.util.LinkedHashMap;
 

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
@@ -316,7 +316,6 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
                 .applyAsync(callback);
     }
 
-
     private void photoCreationFailed() {
         if (mNextClicked || mStopped) {
             return;

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
@@ -30,6 +30,7 @@ import net.gini.android.vision.document.DocumentFactory;
 import net.gini.android.vision.document.GiniVisionDocument;
 import net.gini.android.vision.document.ImageDocument;
 import net.gini.android.vision.internal.AsyncCallback;
+import net.gini.android.vision.internal.cache.PhotoMemoryCache;
 import net.gini.android.vision.internal.camera.photo.Photo;
 import net.gini.android.vision.internal.camera.photo.PhotoEdit;
 import net.gini.android.vision.internal.camera.photo.PhotoFactoryDocumentAsyncTask;
@@ -50,8 +51,6 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
     private static final String PHOTO_KEY = "PHOTO_KEY";
     private static final String DOCUMENT_KEY = "DOCUMENT_KEY";
     private static final Logger LOG = LoggerFactory.getLogger(ReviewFragmentImpl.class);
-
-    private static final int JPEG_COMPRESSION_QUALITY_FOR_UPLOAD = 50;
 
     private static final ReviewFragmentListener NO_OP_LISTENER = new ReviewFragmentListener() {
         @Override
@@ -179,7 +178,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
                     if (mNextClicked || mStopped) {
                         return;
                     }
-                    createAndCompressPhoto();
+                    createPhoto();
                 }
 
                 @Override
@@ -205,7 +204,8 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         if (activity == null) {
             return;
         }
-        final GiniVisionDocument document = DocumentFactory.newImageDocumentFromPhotoAndDocument(mPhoto,
+        final GiniVisionDocument document = DocumentFactory.newImageDocumentFromPhotoAndDocument(
+                mPhoto,
                 mDocument);
         if (GiniVision.hasInstance()) {
             final NetworkRequestsManager networkRequestsManager = GiniVision.getInstance()
@@ -233,55 +233,106 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         }
     }
 
-    private void createAndCompressPhoto() {
-        LOG.debug("Instantiating a Photo from the Document");
-        final PhotoFactoryDocumentAsyncTask asyncTask = new PhotoFactoryDocumentAsyncTask(
-                new AsyncCallback<Photo>() {
-                    @Override
-                    public void onSuccess(final Photo result) {
-                        LOG.debug("Photo instantiated");
-                        if (mNextClicked || mStopped) {
-                            return;
-                        }
-                        mPhoto = result;
-                        mCurrentRotation = mDocument.getRotationForDisplay();
-                        applyCompressionToPhoto(new PhotoEdit.PhotoEditCallback() {
-                            @Override
-                            public void onDone(@NonNull final Photo photo) {
-                                LOG.debug("Photo compressed");
-                                if (mNextClicked || mStopped) {
-                                    return;
-                                }
-                                hideActivityIndicatorAndEnableButtons();
-                                observeViewTree();
-                                LOG.info("Should analyze document");
-                                shouldAnalyzeDocument();
-                            }
+    private void createPhoto() {
+        final Activity activity = mFragment.getActivity();
+        if (activity == null) {
+            return;
+        }
+        if (GiniVision.hasInstance()) {
+            LOG.debug("Loading Photo from memory cache");
+            final PhotoMemoryCache photoMemoryCache =
+                    GiniVision.getInstance().internal().getPhotoMemoryCache();
+            photoMemoryCache.get(activity, mDocument, new AsyncCallback<Photo>() {
+                @Override
+                public void onSuccess(final Photo result) {
+                    LOG.debug("Photo loaded");
+                    photoCreated(result);
+                }
 
-                            @Override
-                            public void onFailed() {
-                                LOG.error("Failed to compress the Photo");
-                                if (mNextClicked || mStopped) {
-                                    return;
-                                }
-                                mListener.onError(
-                                        new GiniVisionError(GiniVisionError.ErrorCode.REVIEW,
-                                                "An error occurred while compressing the jpeg."));
-                            }
-                        });
-                    }
-
-                    @Override
-                    public void onError(final Exception exception) {
-                        LOG.error("Failed to instantiate a Photo from the ImageDocument");
-                        if (mNextClicked || mStopped) {
-                            return;
+                @Override
+                public void onError(final Exception exception) {
+                    LOG.error("Failed to load a Photo for the ImageDocument");
+                    photoCreationFailed();
+                }
+            });
+        } else {
+            LOG.debug("Instantiating a Photo from the Document");
+            final PhotoFactoryDocumentAsyncTask asyncTask = new PhotoFactoryDocumentAsyncTask(
+                    new AsyncCallback<Photo>() {
+                        @Override
+                        public void onSuccess(final Photo result) {
+                            LOG.debug("Photo instantiated");
+                            photoCreated(result);
                         }
-                        mListener.onError(new GiniVisionError(GiniVisionError.ErrorCode.REVIEW,
-                                "An error occurred while instantiating a Photo from the ImageDocument."));
+
+                        @Override
+                        public void onError(final Exception exception) {
+                            LOG.error("Failed to instantiate a Photo from the ImageDocument");
+                            photoCreationFailed();
+                        }
+                    });
+            asyncTask.execute(mDocument);
+        }
+    }
+
+    private void photoCreated(final Photo result) {
+        if (mNextClicked || mStopped) {
+            return;
+        }
+        mPhoto = result;
+        mCurrentRotation = mDocument.getRotationForDisplay();
+        if (!mDocument.getSource().equals(Document.Source.newCameraSource())) {
+            LOG.debug("Compressing Photo");
+            applyCompressionToPhoto(new PhotoEdit.PhotoEditCallback() {
+                @Override
+                public void onDone(@NonNull final Photo photo) {
+                    LOG.debug("Photo compressed");
+                    photoReady();
+                }
+
+                @Override
+                public void onFailed() {
+                    LOG.error("Failed to compress the Photo");
+                    if (mNextClicked || mStopped) {
+                        return;
                     }
-                });
-        asyncTask.execute(mDocument);
+                    mListener.onError(
+                            new GiniVisionError(GiniVisionError.ErrorCode.REVIEW,
+                                    "An error occurred while compressing the jpeg."));
+                }
+            });
+        } else {
+            photoReady();
+        }
+    }
+
+    private void applyCompressionToPhoto(@NonNull final PhotoEdit.PhotoEditCallback callback) {
+        if (mPhoto == null) {
+            return;
+        }
+        LOG.debug("Compressing the Photo");
+        mPhoto.edit()
+                .compressByDefault()
+                .applyAsync(callback);
+    }
+
+
+    private void photoCreationFailed() {
+        if (mNextClicked || mStopped) {
+            return;
+        }
+        mListener.onError(new GiniVisionError(GiniVisionError.ErrorCode.REVIEW,
+                "An error occurred while instantiating a Photo from the ImageDocument."));
+    }
+
+    private void photoReady() {
+        if (mNextClicked || mStopped) {
+            return;
+        }
+        hideActivityIndicatorAndEnableButtons();
+        observeViewTree();
+        LOG.info("Should analyze document");
+        shouldAnalyzeDocument();
     }
 
     private void showActivityIndicatorAndDisableButtons() {
@@ -426,7 +477,8 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         final int oldRotation = mCurrentRotation;
         mCurrentRotation += 90;
         rotateImageView(mCurrentRotation, true);
-        if (GiniVision.hasInstance() && GiniVision.getInstance().internal().getNetworkRequestsManager() != null) {
+        if (GiniVision.hasInstance()
+                && GiniVision.getInstance().internal().getNetworkRequestsManager() != null) {
             LOG.debug("Only the preview was rotated");
             mDocument.setRotationForDisplay(mCurrentRotation);
             mDocument.updateRotationDeltaBy(90);
@@ -443,8 +495,9 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
                 }
                 mDocument.setRotationForDisplay(mCurrentRotation);
                 mDocument.updateRotationDeltaBy(90);
-                final GiniVisionDocument document = DocumentFactory.newImageDocumentFromPhotoAndDocument(
-                        photo, mDocument);
+                final GiniVisionDocument document =
+                        DocumentFactory.newImageDocumentFromPhotoAndDocument(
+                                photo, mDocument);
                 mListener.onDocumentWasRotated(
                         document,
                         oldRotation, mCurrentRotation);
@@ -520,7 +573,8 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         if (activity == null) {
             return;
         }
-        final GiniVisionDocument document = DocumentFactory.newImageDocumentFromPhotoAndDocument(mPhoto,
+        final GiniVisionDocument document = DocumentFactory.newImageDocumentFromPhotoAndDocument(
+                mPhoto,
                 mDocument);
         if (GiniVision.hasInstance()) {
             final NetworkRequestsManager networkRequestsManager =
@@ -537,7 +591,8 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
 
     private void proceedToAnalysisScreen() {
         LOG.info("Proceed to Analysis Screen");
-        final GiniVisionDocument document = DocumentFactory.newImageDocumentFromPhotoAndDocument(mPhoto,
+        final GiniVisionDocument document = DocumentFactory.newImageDocumentFromPhotoAndDocument(
+                mPhoto,
                 mDocument);
         if (GiniVision.hasInstance()) {
             mListener.onProceedToAnalysisScreen(document, mDocumentAnalysisErrorMessage);
@@ -553,16 +608,6 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         LOG.debug("Rotating the Photo {} degrees", mCurrentRotation);
         mPhoto.edit()
                 .rotateTo(mCurrentRotation)
-                .applyAsync(callback);
-    }
-
-    private void applyCompressionToPhoto(@NonNull final PhotoEdit.PhotoEditCallback callback) {
-        if (mPhoto == null) {
-            return;
-        }
-        LOG.debug("Compressing the Photo to quality {}", JPEG_COMPRESSION_QUALITY_FOR_UPLOAD);
-        mPhoto.edit()
-                .compressBy(JPEG_COMPRESSION_QUALITY_FOR_UPLOAD)
                 .applyAsync(callback);
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/util/CancellationToken.java
+++ b/ginivision/src/main/java/net/gini/android/vision/util/CancellationToken.java
@@ -1,4 +1,4 @@
-package net.gini.android.vision.network;
+package net.gini.android.vision.util;
 
 /**
  * Created by Alpar Szotyori on 26.04.2018.

--- a/ginivision/src/main/java/net/gini/android/vision/util/NoOpCancellationToken.java
+++ b/ginivision/src/main/java/net/gini/android/vision/util/NoOpCancellationToken.java
@@ -1,0 +1,17 @@
+package net.gini.android.vision.util;
+
+/**
+ * Created by Alpar Szotyori on 24.05.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+
+/**
+ * @exclude
+ */
+public class NoOpCancellationToken implements CancellationToken {
+
+    @Override
+    public void cancel() {
+    }
+}


### PR DESCRIPTION
JPEG compression and EXIF handling was not done for all multi-page cases.

* Camera Screen
  * Taken pictures are compressed and their EXIF is updated before proceeding
  * If multi-page is enabled then imported JPEGs are compressed and their EXIF is updated before proceeding
* Review Screen (used only if multi-page is not enabled)
  * Only imported JPEG is compressed and its EXIF updated
* "Open with" JPEGs
  * Only multi-page import JPEGs are compressed and their EXIF updated

### How to test
Run one of the example apps and check the EXIF of the JPEGs saved in the example app's external storage.
