### PR TITLE
Using DialogFragment in FileChooserActivity and also persisting state

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
@@ -303,14 +303,12 @@ public class FileChooserActivity extends AppCompatActivity implements AlertDialo
         final PermissionRequestListener listener = new PermissionRequestListener() {
             @Override
             public void permissionGranted() {
-                LOG.info("Read storage permission granted");
-                launchApp(mSelectedAppItem);
+                storagePermissionGranted();
             }
 
             @Override
             public void permissionDenied() {
-                LOG.info("Read storage permission denied");
-                showStoragePermissionDeniedDialog();
+                storagePermisionDenied();
             }
 
             @Override
@@ -331,6 +329,18 @@ public class FileChooserActivity extends AppCompatActivity implements AlertDialo
         } else {
             listener.permissionGranted();
         }
+    }
+
+    private void storagePermissionGranted() {
+        LOG.info("Read storage permission granted");
+        if (mSelectedAppItem != null) {
+            launchApp(mSelectedAppItem);
+        }
+    }
+
+    private void storagePermisionDenied() {
+        LOG.info("Read storage permission denied");
+        showStoragePermissionDeniedDialog();
     }
 
     private void launchApp(final @NonNull ProvidersAppItem item) {
@@ -389,22 +399,24 @@ public class FileChooserActivity extends AppCompatActivity implements AlertDialo
             @NonNull final String[] permissions, @NonNull final int[] grantResults) {
         final boolean handled = mRuntimePermissions.onRequestPermissionsResult(requestCode,
                 permissions, grantResults);
-        // On activity restart mRuntimePermissions is cleared and handled is false
-        // so we need to check the permission request result here
-        if (!handled && permissions.length == 1
-                && permissions[0].equals(Manifest.permission.READ_EXTERNAL_STORAGE)) {
-            if (grantResults.length == 1 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                LOG.info("Read storage permission granted");
-                if (mSelectedAppItem != null) {
-                    launchApp(mSelectedAppItem);
-                }
+        if (!handled && isReadExternalStoragePermission(permissions)) {
+            if (isPermissionGranted(grantResults)) {
+                storagePermissionGranted();
             } else {
-                LOG.info("Read storage permission denied");
-                showStoragePermissionDeniedDialog();
+                storagePermisionDenied();
             }
         } else {
             super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         }
+    }
+
+    private boolean isReadExternalStoragePermission(final @NonNull String[] permissions) {
+        return permissions.length == 1
+                && permissions[0].equals(Manifest.permission.READ_EXTERNAL_STORAGE);
+    }
+
+    private boolean isPermissionGranted(final @NonNull int[] grantResults) {
+        return grantResults.length == 1 && grantResults[0] == PackageManager.PERMISSION_GRANTED;
     }
 
     private boolean shouldShowImageProviders() {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
@@ -335,11 +335,17 @@ public class FileChooserActivity extends AppCompatActivity implements AlertDialo
     }
 
     private void showStoragePermissionDeniedDialog() {
-        final AlertDialogFragment dialogFragment = AlertDialogFragment.createInstance(0,
-                R.string.gv_storage_permission_denied,
-                R.string.gv_storage_permission_denied_positive_button,
-                R.string.gv_storage_permission_denied_negative_button, PERMISSION_DENIED_DIALOG);
+        final AlertDialogFragment dialogFragment = new AlertDialogFragment.Builder()
+                .setMessage(R.string.gv_storage_permission_denied)
+                .setPositiveButton(R.string.gv_storage_permission_denied_positive_button)
+                .setNegativeButton(R.string.gv_storage_permission_denied_negative_button)
+                .setDialogId(PERMISSION_DENIED_DIALOG)
+                .disableCancelOnTouchOutside()
+                .create();
+        showPermissionDialog(dialogFragment);
+    }
 
+    private void showPermissionDialog(final AlertDialogFragment dialogFragment) {
         final FragmentTransaction transaction =
                 getSupportFragmentManager().beginTransaction();
         final Fragment previous = getSupportFragmentManager().findFragmentByTag(PERMISSION_DIALOG);
@@ -351,20 +357,14 @@ public class FileChooserActivity extends AppCompatActivity implements AlertDialo
     }
 
     private void showStoragePermissionRationale() {
-        final AlertDialogFragment dialogFragment = AlertDialogFragment.createInstance(0,
-                R.string.gv_storage_permission_rationale,
-                R.string.gv_storage_permission_rationale_positive_button,
-                R.string.gv_storage_permission_rationale_negative_button,
-                PERMISSION_RATIONALE_DIALOG);
-
-        final FragmentTransaction transaction =
-                getSupportFragmentManager().beginTransaction();
-        final Fragment previous = getSupportFragmentManager().findFragmentByTag(PERMISSION_DIALOG);
-        if (previous != null) {
-            transaction.remove(previous);
-        }
-        transaction.addToBackStack(null);
-        dialogFragment.show(transaction, PERMISSION_DIALOG);
+        final AlertDialogFragment dialogFragment = new AlertDialogFragment.Builder()
+                .setMessage(R.string.gv_storage_permission_rationale)
+                .setPositiveButton(R.string.gv_storage_permission_rationale_positive_button)
+                .setNegativeButton(R.string.gv_storage_permission_rationale_negative_button)
+                .setDialogId(PERMISSION_RATIONALE_DIALOG)
+                .disableCancelOnTouchOutside()
+                .create();
+        showPermissionDialog(dialogFragment);
     }
 
     private void showAppDetailsSettingsScreen() {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
@@ -89,6 +89,9 @@ public class FileChooserActivity extends AppCompatActivity implements AlertDialo
     private final RuntimePermissions mRuntimePermissions = new RuntimePermissions();
     private ProvidersAppItem mSelectedAppItem;
 
+    // Used to prevent fragment transactions after instance state has been save
+    private boolean mInstanceStateSaved = false;
+
     public static boolean canChooseFiles(@NonNull final Context context) {
         final List<ResolveInfo> imagePickerResolveInfos = queryImagePickers(context);
         final List<ResolveInfo> imageProviderResolveInfos = queryImageProviders(context);
@@ -117,6 +120,7 @@ public class FileChooserActivity extends AppCompatActivity implements AlertDialo
     @Override
     protected void onSaveInstanceState(final Bundle outState) {
         super.onSaveInstanceState(outState);
+        mInstanceStateSaved = true;
         outState.putParcelable(SELECTED_APP_ITEM_KEY, mSelectedAppItem);
     }
 
@@ -195,6 +199,9 @@ public class FileChooserActivity extends AppCompatActivity implements AlertDialo
         super.onResume();
         populateFileProviders();
         showFileProviders();
+        // Sometimes onRestoreInstanceState() is not called after onSaveInstanceState() - seen on
+        // a Galaxy S5 Neo with Android 6.0.1
+        mInstanceStateSaved = false;
     }
 
     private void showFileProviders() {
@@ -346,6 +353,9 @@ public class FileChooserActivity extends AppCompatActivity implements AlertDialo
     }
 
     private void showPermissionDialog(final AlertDialogFragment dialogFragment) {
+        if (mInstanceStateSaved) {
+            return;
+        }
         final FragmentTransaction transaction =
                 getSupportFragmentManager().beginTransaction();
         final Fragment previous = getSupportFragmentManager().findFragmentByTag(PERMISSION_DIALOG);

--- a/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/providerchooser/ProvidersAppItem.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/providerchooser/ProvidersAppItem.java
@@ -2,6 +2,7 @@ package net.gini.android.vision.internal.fileimport.providerchooser;
 
 import android.content.Intent;
 import android.content.pm.ResolveInfo;
+import android.os.Parcel;
 import android.support.annotation.NonNull;
 
 /**
@@ -9,13 +10,44 @@ import android.support.annotation.NonNull;
  */
 public class ProvidersAppItem extends ProvidersItem {
 
+    public static final Creator<ProvidersAppItem> CREATOR =
+            new Creator<ProvidersAppItem>() {
+                @Override
+                public ProvidersAppItem createFromParcel(final Parcel in) {
+                    return new ProvidersAppItem(in);
+                }
+
+                @Override
+                public ProvidersAppItem[] newArray(final int size) {
+                    return new ProvidersAppItem[size];
+                }
+            };
+
     private final Intent mIntent;
     private final ResolveInfo mResolveInfo;
+
+    protected ProvidersAppItem(final Parcel in) {
+        super(in);
+        mIntent = in.readParcelable(getClass().getClassLoader());
+        mResolveInfo = in.readParcelable(getClass().getClassLoader());
+    }
 
     public ProvidersAppItem(@NonNull final Intent intent, @NonNull final ResolveInfo resolveInfo) {
         super(FileProviderItemType.APP);
         mIntent = intent;
         mResolveInfo = resolveInfo;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull final Parcel dest, final int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeParcelable(mIntent, flags);
+        dest.writeParcelable(mResolveInfo, flags);
     }
 
     public Intent getIntent() {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/providerchooser/ProvidersItem.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/providerchooser/ProvidersItem.java
@@ -1,11 +1,51 @@
 package net.gini.android.vision.internal.fileimport.providerchooser;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
 /**
  * @exclude
  */
-public class ProvidersItem {
+public class ProvidersItem implements Parcelable {
+
+    public static final Parcelable.Creator<ProvidersItem> CREATOR =
+            new Parcelable.Creator<ProvidersItem>() {
+                @Override
+                public ProvidersItem createFromParcel(final Parcel in) {
+                    return new ProvidersItem(in);
+                }
+
+                @Override
+                public ProvidersItem[] newArray(final int size) {
+                    return new ProvidersItem[size];
+                }
+            };
+
+    private final FileProviderItemType mType;
+
+    ProvidersItem(final Parcel in) {
+        mType = (FileProviderItemType) in.readSerializable();
+    }
+
+    ProvidersItem(@NonNull final FileProviderItemType type) {
+        mType = type;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull final Parcel dest, final int flags) {
+        dest.writeSerializable(mType);
+    }
+
+    @NonNull
+    FileProviderItemType getType() {
+        return mType;
+    }
 
     enum FileProviderItemType {
         SECTION,
@@ -20,16 +60,5 @@ public class ProvidersItem {
             }
             return values()[ordinal];
         }
-    }
-
-    private final FileProviderItemType mType;
-
-    ProvidersItem(@NonNull final FileProviderItemType type) {
-        mType = type;
-    }
-
-    @NonNull
-    FileProviderItemType getType() {
-        return mType;
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/permission/AbstractPermissionRequest.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/permission/AbstractPermissionRequest.java
@@ -58,6 +58,20 @@ abstract class AbstractPermissionRequest<T> implements PermissionRequest<T> {
         }
     }
 
+    @Override
+    public void requestPermissionWithoutRationale(@NonNull final T context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            mListener.permissionGranted();
+            return;
+        }
+        if (checkSelfPermission(context)) {
+            mListener.permissionGranted();
+            return;
+        }
+
+        doRequestPermission(context);
+    }
+
     protected abstract boolean checkSelfPermission(@NonNull final T context);
 
     protected abstract boolean shouldShowRequestRationale(@NonNull final T context);

--- a/ginivision/src/main/java/net/gini/android/vision/internal/permission/AbstractPermissionRequest.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/permission/AbstractPermissionRequest.java
@@ -13,8 +13,8 @@ abstract class AbstractPermissionRequest<T> implements PermissionRequest<T> {
     private final int mReqCode;
     private final PermissionRequestListener mListener;
 
-    AbstractPermissionRequest(String permission, int reqCode,
-            final PermissionRequestListener listener) {
+    AbstractPermissionRequest(@NonNull final String permission, final int reqCode,
+            @NonNull final PermissionRequestListener listener) {
         mPermission = permission;
         mReqCode = reqCode;
         mListener = listener;
@@ -34,6 +34,7 @@ abstract class AbstractPermissionRequest<T> implements PermissionRequest<T> {
         return mListener;
     }
 
+    @Override
     public void requestPermission(@NonNull final T context) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             mListener.permissionGranted();
@@ -57,12 +58,13 @@ abstract class AbstractPermissionRequest<T> implements PermissionRequest<T> {
         }
     }
 
-    protected abstract Boolean checkSelfPermission(@NonNull final T context);
+    protected abstract boolean checkSelfPermission(@NonNull final T context);
 
     protected abstract boolean shouldShowRequestRationale(@NonNull final T context);
 
     protected abstract void doRequestPermission(@NonNull final T context);
 
+    @Override
     public void onRequestPermissionsResult(@NonNull final String[] permissions,
             @NonNull final int[] grantResults) {
         if (grantResults.length == 1 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/permission/PermissionRequest.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/permission/PermissionRequest.java
@@ -9,6 +9,8 @@ interface PermissionRequest<T> {
 
     void requestPermission(@NonNull final T context);
 
+    void requestPermissionWithoutRationale(@NonNull final T context);
+
     void onRequestPermissionsResult(@NonNull final String[] permissions,
             @NonNull final int[] grantResults);
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/permission/PermissionRequestActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/permission/PermissionRequestActivity.java
@@ -18,7 +18,7 @@ class PermissionRequestActivity extends AbstractPermissionRequest<Activity> {
     }
 
     @Override
-    protected Boolean checkSelfPermission(@NonNull final Activity activity) {
+    protected boolean checkSelfPermission(@NonNull final Activity activity) {
         return ContextCompat.checkSelfPermission(activity, getPermission())
                 == PackageManager.PERMISSION_GRANTED;
     }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/permission/RuntimePermissions.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/permission/RuntimePermissions.java
@@ -29,6 +29,19 @@ public class RuntimePermissions {
         }
     }
 
+    public void requestPermissionWithoutRationale(@NonNull final Activity activity,
+            @NonNull final String permission, @NonNull final PermissionRequestListener listener) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            final int requestCode = getNextRequestCode();
+            final PermissionRequestActivity request = new PermissionRequestActivity(permission,
+                    requestCode, listener);
+            mPermissionRequests.put(requestCode, request);
+            request.requestPermissionWithoutRationale(activity);
+        } else {
+            listener.permissionGranted();
+        }
+    }
+
     public boolean onRequestPermissionsResult(final int requestCode,
             @NonNull final String[] permissions,
             @NonNull final int[] grantResults) {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/ui/AlertDialogFragment.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/ui/AlertDialogFragment.java
@@ -1,0 +1,107 @@
+package net.gini.android.vision.internal.ui;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v7.app.AlertDialog;
+
+/**
+ * Created by Alpar Szotyori on 05.06.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+
+/**
+ * @exclude
+ */
+public class AlertDialogFragment extends DialogFragment {
+
+    private static final String ARG_TITLE = "ARG_TITLE";
+    private static final String ARG_MESSAGE = "ARG_MESSAGE";
+    private static final String ARG_POSITIVE_BUTTON_TITLE = "ARG_POSITIVE_BUTTON_TITLE";
+    private static final String ARG_NEGATIVE_BUTTON_TITLE = "ARG_NEGATIVE_BUTTON_TITLE";
+    private static final String ARG_DIALOG_ID = "ARG_DIALOG_ID";
+
+    @StringRes
+    private int mTitle;
+    private int mMessage;
+    private int mPositiveButtonTitle;
+    private int mNegativeButtonTitle;
+    private int mDialogId;
+
+    public static AlertDialogFragment createInstance(@StringRes final int title,
+            @StringRes final int message, @StringRes final int positiveButtonTitle,
+            @StringRes final int negativeButtonTitle, @StringRes final int dialogId) {
+        final Bundle args = new Bundle();
+        args.putInt(ARG_TITLE, title);
+        args.putInt(ARG_MESSAGE, message);
+        args.putInt(ARG_POSITIVE_BUTTON_TITLE, positiveButtonTitle);
+        args.putInt(ARG_NEGATIVE_BUTTON_TITLE, negativeButtonTitle);
+        args.putInt(ARG_DIALOG_ID, dialogId);
+        final AlertDialogFragment fragment = new AlertDialogFragment();
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        readArguments();
+    }
+
+    private void readArguments() {
+        final Bundle arguments = getArguments();
+        if (arguments == null) {
+            return;
+        }
+        mTitle = arguments.getInt(ARG_TITLE);
+        mMessage = arguments.getInt(ARG_MESSAGE);
+        mPositiveButtonTitle = arguments.getInt(ARG_POSITIVE_BUTTON_TITLE);
+        mNegativeButtonTitle = arguments.getInt(ARG_NEGATIVE_BUTTON_TITLE);
+        mDialogId = arguments.getInt(ARG_DIALOG_ID);
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(final Bundle savedInstanceState) {
+        final AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        if (mTitle > 0) {
+            builder.setTitle(mTitle);
+        }
+        if (mMessage > 0) {
+            builder.setMessage(mMessage);
+        }
+        if (mPositiveButtonTitle > 0) {
+            builder.setPositiveButton(mPositiveButtonTitle, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(final DialogInterface dialog, final int which) {
+                    final FragmentActivity activity = getActivity();
+                    if (activity instanceof AlertDialogFragmentListener) {
+                        ((AlertDialogFragmentListener) activity).onPositiveButtonClicked(
+                                dialog, mDialogId);
+                    }
+                }
+            });
+        }
+        if (mNegativeButtonTitle > 0) {
+            builder.setNegativeButton(mNegativeButtonTitle, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(final DialogInterface dialog, final int which) {
+                    final FragmentActivity activity = getActivity();
+                    if (activity instanceof AlertDialogFragmentListener) {
+                        ((AlertDialogFragmentListener) activity).onNegativeButtonClicked(dialog,
+                                mDialogId);
+                    }
+                }
+            });
+        }
+        final AlertDialog alertDialog = builder.create();
+        alertDialog.setCanceledOnTouchOutside(false);
+        return alertDialog;
+    }
+}

--- a/ginivision/src/main/java/net/gini/android/vision/internal/ui/AlertDialogFragment.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/ui/AlertDialogFragment.java
@@ -30,8 +30,11 @@ public class AlertDialogFragment extends DialogFragment {
 
     @StringRes
     private int mTitle;
+    @StringRes
     private int mMessage;
+    @StringRes
     private int mPositiveButtonTitle;
+    @StringRes
     private int mNegativeButtonTitle;
     private int mDialogId;
     private boolean mDisableCancelOnTouchOutside;

--- a/ginivision/src/main/java/net/gini/android/vision/internal/ui/AlertDialogFragment.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/ui/AlertDialogFragment.java
@@ -26,6 +26,7 @@ public class AlertDialogFragment extends DialogFragment {
     private static final String ARG_POSITIVE_BUTTON_TITLE = "ARG_POSITIVE_BUTTON_TITLE";
     private static final String ARG_NEGATIVE_BUTTON_TITLE = "ARG_NEGATIVE_BUTTON_TITLE";
     private static final String ARG_DIALOG_ID = "ARG_DIALOG_ID";
+    private static final String ARG_DISABLE_CANCEL_ON_TOUCH_OUTSIDE = "ARG_CANCELED_ON_TOUCH_OUTSIDE";
 
     @StringRes
     private int mTitle;
@@ -33,20 +34,7 @@ public class AlertDialogFragment extends DialogFragment {
     private int mPositiveButtonTitle;
     private int mNegativeButtonTitle;
     private int mDialogId;
-
-    public static AlertDialogFragment createInstance(@StringRes final int title,
-            @StringRes final int message, @StringRes final int positiveButtonTitle,
-            @StringRes final int negativeButtonTitle, @StringRes final int dialogId) {
-        final Bundle args = new Bundle();
-        args.putInt(ARG_TITLE, title);
-        args.putInt(ARG_MESSAGE, message);
-        args.putInt(ARG_POSITIVE_BUTTON_TITLE, positiveButtonTitle);
-        args.putInt(ARG_NEGATIVE_BUTTON_TITLE, negativeButtonTitle);
-        args.putInt(ARG_DIALOG_ID, dialogId);
-        final AlertDialogFragment fragment = new AlertDialogFragment();
-        fragment.setArguments(args);
-        return fragment;
-    }
+    private boolean mDisableCancelOnTouchOutside;
 
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
@@ -55,15 +43,16 @@ public class AlertDialogFragment extends DialogFragment {
     }
 
     private void readArguments() {
-        final Bundle arguments = getArguments();
-        if (arguments == null) {
+        final Bundle args = getArguments();
+        if (args == null) {
             return;
         }
-        mTitle = arguments.getInt(ARG_TITLE);
-        mMessage = arguments.getInt(ARG_MESSAGE);
-        mPositiveButtonTitle = arguments.getInt(ARG_POSITIVE_BUTTON_TITLE);
-        mNegativeButtonTitle = arguments.getInt(ARG_NEGATIVE_BUTTON_TITLE);
-        mDialogId = arguments.getInt(ARG_DIALOG_ID);
+        mTitle = args.getInt(ARG_TITLE);
+        mMessage = args.getInt(ARG_MESSAGE);
+        mPositiveButtonTitle = args.getInt(ARG_POSITIVE_BUTTON_TITLE);
+        mNegativeButtonTitle = args.getInt(ARG_NEGATIVE_BUTTON_TITLE);
+        mDialogId = args.getInt(ARG_DIALOG_ID);
+        mDisableCancelOnTouchOutside = args.getBoolean(ARG_DISABLE_CANCEL_ON_TOUCH_OUTSIDE);
     }
 
     @NonNull
@@ -101,7 +90,50 @@ public class AlertDialogFragment extends DialogFragment {
             });
         }
         final AlertDialog alertDialog = builder.create();
-        alertDialog.setCanceledOnTouchOutside(false);
+        if (mDisableCancelOnTouchOutside) {
+            alertDialog.setCanceledOnTouchOutside(false);
+        }
         return alertDialog;
+    }
+
+    public static class Builder {
+
+        private final Bundle args = new Bundle();
+
+        public Builder setTitle(@StringRes final int title) {
+            args.putInt(ARG_TITLE, title);
+            return this;
+        }
+
+        public Builder setMessage(@StringRes final int message) {
+            args.putInt(ARG_MESSAGE, message);
+            return this;
+        }
+
+        public Builder setPositiveButton(@StringRes final int positiveButtonTitle) {
+            args.putInt(ARG_POSITIVE_BUTTON_TITLE, positiveButtonTitle);
+            return this;
+        }
+
+        public Builder setNegativeButton(@StringRes final int negativeButtonTitle) {
+            args.putInt(ARG_NEGATIVE_BUTTON_TITLE, negativeButtonTitle);
+            return this;
+        }
+
+        public Builder setDialogId(final int dialogId) {
+            args.putInt(ARG_DIALOG_ID, dialogId);
+            return this;
+        }
+
+        public Builder disableCancelOnTouchOutside() {
+            args.putBoolean(ARG_DISABLE_CANCEL_ON_TOUCH_OUTSIDE, true);
+            return this;
+        }
+
+        public AlertDialogFragment create() {
+            final AlertDialogFragment fragment = new AlertDialogFragment();
+            fragment.setArguments(args);
+            return fragment;
+        }
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/ui/AlertDialogFragmentListener.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/ui/AlertDialogFragmentListener.java
@@ -1,0 +1,21 @@
+package net.gini.android.vision.internal.ui;
+
+import android.content.DialogInterface;
+import android.support.annotation.NonNull;
+
+/**
+ * Created by Alpar Szotyori on 05.06.2018.
+ *
+ * Copyright (c) 2018 Gini GmbH.
+ */
+
+/**
+ * @exclude
+ */
+public interface AlertDialogFragmentListener {
+
+    void onPositiveButtonClicked(@NonNull final DialogInterface dialog, final int dialogId);
+
+    void onNegativeButtonClicked(@NonNull final DialogInterface dialog, final int dialogId);
+
+}


### PR DESCRIPTION
I thought these changes will show up in PR #216, but it didn't so here's a new one. Added a DialogFragment subclass for showing permission alerts and since these are persisted across Activity restarts updated the FileChooserActivity to persist the selected app. Granting permission after Activity restarts will launch the originally selected app.

### How to test
Disable portrait lock in ActivityHelper and play around with the document import from the Camera Screen while changing device orientation between dialog interactions.

### Ticket 
Issue #181
