### PR TITLE
Bugfix memory leak

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
@@ -237,8 +237,8 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
     }
 
     private void clearParcelableMemoryCache() {
-        // Remove data from memory cache which was added when the document in the arguments
-        // was automatically parcelled when the activity has been stopped
+        // Remove data from the memory cache. The data had been added when the document in the
+        // arguments was automatically parcelled when the activity was stopped
         ParcelableMemoryCache.getInstance().removeEntriesWithTag(PARCELABLE_MEMORY_CACHE_TAG);
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
@@ -126,7 +126,10 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
         mFragment = fragment;
         mMultiPageDocument = asMultiPageDocument(document);
         // Tag the documents to be able to clean up the automatically parcelled data
-        ((GiniVisionDocument) document).setParcelableMemoryCacheTag(PARCELABLE_MEMORY_CACHE_TAG);
+        if (document instanceof GiniVisionDocument) {
+            ((GiniVisionDocument) document).setParcelableMemoryCacheTag(
+                    PARCELABLE_MEMORY_CACHE_TAG);
+        }
         mMultiPageDocument.setParcelableMemoryCacheTag(PARCELABLE_MEMORY_CACHE_TAG);
         mDocumentAnalysisErrorMessage = documentAnalysisErrorMessage;
     }
@@ -229,10 +232,14 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
         }
         final Activity activity = mFragment.getActivity();
         if (activity != null && activity.isFinishing()) {
-            // Remove data from memory cache which was added when the document in the arguments
-            // was automatically parcelled when the activity has been stopped
-            ParcelableMemoryCache.getInstance().removeEntriesWithTag(PARCELABLE_MEMORY_CACHE_TAG);
+            clearParcelableMemoryCache();
         }
+    }
+
+    private void clearParcelableMemoryCache() {
+        // Remove data from memory cache which was added when the document in the arguments
+        // was automatically parcelled when the activity has been stopped
+        ParcelableMemoryCache.getInstance().removeEntriesWithTag(PARCELABLE_MEMORY_CACHE_TAG);
     }
 
     private void deleteUploadedDocuments() {
@@ -276,9 +283,7 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
         if (activity == null) {
             return;
         }
-        // Remove data from memory cache which was added when the document in the arguments
-        // was automatically parcelled when the activity has been stopped
-        ParcelableMemoryCache.getInstance().removeEntriesWithTag(PARCELABLE_MEMORY_CACHE_TAG);
+        clearParcelableMemoryCache();
 
         startScanAnimation();
         LOG.debug("Loading document data");

--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
@@ -108,6 +108,7 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
     private RelativeLayout mLayoutRoot;
     private AnalysisFragmentListener mListener = NO_OP_LISTENER;
     private ProgressBar mProgressActivity;
+    private Runnable mHintStartRunnable;
     private Runnable mHintCycleRunnable;
     private LinearLayout mPdfOverlayLayout;
     private TextView mPdfTitleTextView;
@@ -119,7 +120,6 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
     private static final int HINT_CYCLE_INTERVAL = 4000;
     private boolean mStopped;
     private boolean mAnalysisCompleted;
-
 
     AnalysisFragmentImpl(final FragmentImplCallback fragment, @NonNull final Document document,
             final String documentAnalysisErrorMessage) {
@@ -321,7 +321,7 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
                 mHintAnimation.start();
             }
         };
-        mHandler.postDelayed(new Runnable() {
+        mHintStartRunnable = new Runnable() {
             @Override
             public void run() {
                 if (TextUtils.isEmpty(mHintHeadlineTextView.getText())) {
@@ -330,7 +330,8 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
                 }
                 mHandler.post(mHintCycleRunnable);
             }
-        }, HINT_START_DELAY);
+        };
+        mHandler.postDelayed(mHintStartRunnable, HINT_START_DELAY);
     }
 
     private ViewPropertyAnimatorCompat getHintHeadlineSlideDownAnimation() {
@@ -409,6 +410,7 @@ class AnalysisFragmentImpl implements AnalysisFragmentInterface {
 
     void onStop() {
         mStopped = true;
+        mHandler.removeCallbacks(mHintStartRunnable);
         mHandler.removeCallbacks(mHintCycleRunnable);
         if (mHintAnimation != null) {
             mHintAnimation.cancel();

--- a/ginivision/src/main/java/net/gini/android/vision/document/GiniVisionDocument.java
+++ b/ginivision/src/main/java/net/gini/android/vision/document/GiniVisionDocument.java
@@ -44,6 +44,7 @@ public class GiniVisionDocument implements Document {
     private final ImportMethod mImportMethod;
     private final String mMimeType;
     private byte[] mData;
+    private String mParcelableMemoryCacheTag;
 
     GiniVisionDocument(@NonNull final Type type,
             @NonNull final Source source,
@@ -98,6 +99,7 @@ public class GiniVisionDocument implements Document {
         mIntent = in.readParcelable(Intent.class.getClassLoader());
         mUri = in.readParcelable(Uri.class.getClassLoader());
         mIsReviewable = in.readInt() == 1;
+        mParcelableMemoryCacheTag = in.readString();
     }
 
     @Override
@@ -120,10 +122,16 @@ public class GiniVisionDocument implements Document {
     @Override
     public void writeToParcel(final Parcel dest, final int flags) {
         dest.writeString(mUniqueId);
+
+        final ParcelableMemoryCache cache = ParcelableMemoryCache.getInstance();
         synchronized (this) {
             if (mData != null) {
-                final ParcelableMemoryCache cache = ParcelableMemoryCache.getInstance();
-                final ParcelableMemoryCache.Token token = cache.storeByteArray(mData);
+                final ParcelableMemoryCache.Token token;
+                if (mParcelableMemoryCacheTag != null) {
+                    token = cache.storeByteArray(mData, mParcelableMemoryCacheTag);
+                } else {
+                    token = cache.storeByteArray(mData);
+                }
                 dest.writeParcelable(token, flags);
             } else {
                 dest.writeParcelable(null, flags);
@@ -136,6 +144,7 @@ public class GiniVisionDocument implements Document {
         dest.writeParcelable(mIntent, flags);
         dest.writeParcelable(mUri, flags);
         dest.writeInt(mIsReviewable ? 1 : 0);
+        dest.writeString(mParcelableMemoryCacheTag);
     }
 
     @Deprecated
@@ -204,6 +213,15 @@ public class GiniVisionDocument implements Document {
     @Override
     public boolean isReviewable() {
         return mIsReviewable;
+    }
+
+    public void setParcelableMemoryCacheTag(@NonNull final String tag) {
+        mParcelableMemoryCacheTag = tag;
+    }
+
+    @Nullable
+    public String getParcelableMemoryCacheTag() {
+        return mParcelableMemoryCacheTag;
     }
 
     @Override

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ParcelableMemoryCache.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ParcelableMemoryCache.java
@@ -85,15 +85,15 @@ public enum ParcelableMemoryCache {
         }
 
         @Override
-        public boolean equals(final Object o) {
-            if (this == o) {
+        public boolean equals(final Object other) {
+            if (this == other) {
                 return true;
             }
-            if (o == null || getClass() != o.getClass()) {
+            if (other == null || getClass() != other.getClass()) {
                 return false;
             }
 
-            final Token token = (Token) o;
+            final Token token = (Token) other;
 
             if (tokenId != token.tokenId) {
                 return false;

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ParcelableMemoryCache.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ParcelableMemoryCache.java
@@ -6,22 +6,29 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * This singleton cache keeps references to byte arrays and Bitmaps to be preserved between
  * parceling and unparceling.
- * <p>
- * This solution is needed because it is not possible to pass large byte arrays and Bitmaps via
- * Intents.
+ *
+ * <p> This solution is needed because it is not possible to pass large
+ * byte arrays and Bitmaps via Intents.
  *
  * @exclude
  */
 public enum ParcelableMemoryCache {
 
     INSTANCE;
+
+    private static final Logger LOG = LoggerFactory.getLogger(ParcelableMemoryCache.class);
 
     /**
      * Opaque tokenId type to identify a document.
@@ -33,7 +40,8 @@ public enum ParcelableMemoryCache {
             @Override
             public Token createFromParcel(final Parcel source) {
                 final int token = source.readInt();
-                return new Token(token);
+                final String tag = source.readString();
+                return new Token(token, tag);
             }
 
             @Override
@@ -43,14 +51,26 @@ public enum ParcelableMemoryCache {
         };
 
         private final int tokenId;
+        final String tag;
 
         private Token(final int tokenId) {
             this.tokenId = tokenId;
+            tag = "";
+        }
+
+        private Token(final int tokenId, @NonNull final String tag) {
+            this.tokenId = tokenId;
+            this.tag = tag;
         }
 
         @NonNull
         static Token next() {
             return new Token(COUNTER.getAndIncrement());
+        }
+
+        @NonNull
+        static Token next(@NonNull final String tag) {
+            return new Token(COUNTER.getAndIncrement(), tag);
         }
 
         @Override
@@ -61,21 +81,39 @@ public enum ParcelableMemoryCache {
         @Override
         public void writeToParcel(final Parcel dest, final int flags) {
             dest.writeInt(tokenId);
+            dest.writeString(tag);
         }
 
         @Override
-        public boolean equals(final Object other) {
-            if (this == other) {
+        public boolean equals(final Object o) {
+            if (this == o) {
                 return true;
-            } else if (other instanceof Token) {
-                return tokenId == ((Token) other).tokenId;
             }
-            return false;
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            final Token token = (Token) o;
+
+            if (tokenId != token.tokenId) {
+                return false;
+            }
+            return tag.equals(token.tag);
         }
 
         @Override
         public int hashCode() {
-            return tokenId;
+            int result = tokenId;
+            result = 31 * result + tag.hashCode();
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Token{" +
+                    "tokenId=" + tokenId +
+                    ", tag='" + tag + '\'' +
+                    '}';
         }
     }
 
@@ -83,21 +121,68 @@ public enum ParcelableMemoryCache {
     private final Map<Token, Bitmap> mBitmapCache = new ConcurrentHashMap<>();
 
     public byte[] getByteArray(@NonNull final Token token) {
+        LOG.debug("Get byte array for token {}", token);
+        logCacheSizes();
         return mByteArrayCache.get(token);
+    }
+
+    private void logCacheSizes() {
+        LOG.debug("Cached byte arrays: {}; Cached bitmaps: {}", mByteArrayCache.size(),
+                mBitmapCache.size());
     }
 
     public Token storeByteArray(@NonNull final byte[] documentJpeg) {
         final Token token = Token.next();
         mByteArrayCache.put(token, documentJpeg);
+        LOG.debug("Store byte array for token {}", token);
+        logCacheSizes();
+        return token;
+    }
+
+    public Token storeByteArray(@NonNull final byte[] documentJpeg, @NonNull final String tag) {
+        final Token token = Token.next(tag);
+        mByteArrayCache.put(token, documentJpeg);
+        LOG.debug("Store byte array for token {} with tag {}", token, tag);
+        logCacheSizes();
         return token;
     }
 
     public void removeByteArray(@NonNull final Token token) {
         mByteArrayCache.remove(token);
+        LOG.debug("Remove byte array for token {}", token);
+        logCacheSizes();
+    }
+
+    public void removeEntriesWithTag(@NonNull final String tag) {
+        removeByteArraysWithTag(tag);
+        removeBitmapsWithTag(tag);
+        LOG.debug("Remove entries for tag {}", tag);
+        logCacheSizes();
+    }
+
+    private void removeByteArraysWithTag(final @NonNull String tag) {
+        removeTokensWithTag(mByteArrayCache.keySet(), tag);
+    }
+
+    private void removeBitmapsWithTag(final @NonNull String tag) {
+        removeTokensWithTag(mBitmapCache.keySet(), tag);
+    }
+
+    private void removeTokensWithTag(final Set<Token> tokens,
+            final @NonNull String tag) {
+        final Iterator<Token> iterator = tokens.iterator();
+        while (iterator.hasNext()) {
+            final Token token = iterator.next();
+            if (token.tag.equals(tag)) {
+                iterator.remove();
+            }
+        }
     }
 
     @Nullable
     public Bitmap getBitmap(@NonNull final Token token) {
+        LOG.debug("Get bitmap for token {}", token);
+        logCacheSizes();
         return mBitmapCache.get(token);
     }
 
@@ -107,15 +192,31 @@ public enum ParcelableMemoryCache {
         if (documentBitmap != null) {
             mBitmapCache.put(token, documentBitmap);
         }
+        LOG.debug("Store bitmap for token {}", token);
+        logCacheSizes();
+        return token;
+    }
+
+    @NonNull
+    public Token storeBitmap(@Nullable final Bitmap documentBitmap, @NonNull final String tag) {
+        final Token token = Token.next(tag);
+        if (documentBitmap != null) {
+            mBitmapCache.put(token, documentBitmap);
+        }
+        LOG.debug("Store bitmap for token {} with tag {}", token, tag);
+        logCacheSizes();
         return token;
     }
 
     public void removeBitmap(@NonNull final Token token) {
         mBitmapCache.remove(token);
+        LOG.debug("Remove bitmap for token {}", token);
+        logCacheSizes();
     }
 
     @NonNull
     public static ParcelableMemoryCache getInstance() {
         return INSTANCE;
     }
+
 }

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ParcelableMemoryCache.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/ParcelableMemoryCache.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.NOPLogger;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -28,7 +29,15 @@ public enum ParcelableMemoryCache {
 
     INSTANCE;
 
-    private static final Logger LOG = LoggerFactory.getLogger(ParcelableMemoryCache.class);
+    private static final boolean DEBUG = false;
+    private static final Logger LOG;
+    static {
+        if (DEBUG) {
+            LOG = LoggerFactory.getLogger(ParcelableMemoryCache.class);
+        } else {
+            LOG = NOPLogger.NOP_LOGGER;
+        }
+    }
 
     /**
      * Opaque tokenId type to identify a document.

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/photo/Photo.java
@@ -2,6 +2,8 @@ package net.gini.android.vision.internal.camera.photo;
 
 import android.graphics.Bitmap;
 import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import net.gini.android.vision.Document;
 import net.gini.android.vision.document.ImageDocument;
@@ -46,4 +48,9 @@ public interface Photo extends Parcelable {
     void updateRotationDeltaBy(int i);
 
     void saveToFile(File file);
+
+    void setParcelableMemoryCacheTag(@NonNull final String tag);
+    
+    @Nullable
+    String getParcelableMemoryCacheTag();
 }

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
@@ -439,7 +439,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         }
         final Activity activity = mFragment.getActivity();
         if (activity != null && activity.isFinishing()) {
-            // Remove data from the memory cache wich was added in onSaveInstanceState() and also
+            // Remove data from the memory cache. The data was added in onSaveInstanceState() and also
             // when the document in the arguments was automatically parcelled when the activity
             // has been stopped
             ParcelableMemoryCache.getInstance().removeEntriesWithTag(PARCELABLE_MEMORY_CACHE_TAG);

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
@@ -30,6 +30,7 @@ import net.gini.android.vision.document.DocumentFactory;
 import net.gini.android.vision.document.GiniVisionDocument;
 import net.gini.android.vision.document.ImageDocument;
 import net.gini.android.vision.internal.cache.PhotoMemoryCache;
+import net.gini.android.vision.internal.camera.photo.ParcelableMemoryCache;
 import net.gini.android.vision.internal.camera.photo.Photo;
 import net.gini.android.vision.internal.camera.photo.PhotoEdit;
 import net.gini.android.vision.internal.camera.photo.PhotoFactoryDocumentAsyncTask;
@@ -52,6 +53,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
 
     private static final String PHOTO_KEY = "PHOTO_KEY";
     private static final String DOCUMENT_KEY = "DOCUMENT_KEY";
+    private static final String PARCELABLE_MEMORY_CACHE_TAG = "REVIEW_FRAGMENT";
     private static final Logger LOG = LoggerFactory.getLogger(ReviewFragmentImpl.class);
 
     private static final ReviewFragmentListener NO_OP_LISTENER = new ReviewFragmentListener() {
@@ -126,6 +128,8 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
             throw new IllegalArgumentException("Only Documents with type IMAGE allowed");
         }
         mDocument = (ImageDocument) document;
+        // Tag the documents to be able to clean up the parcelled data
+        mDocument.setParcelableMemoryCacheTag(PARCELABLE_MEMORY_CACHE_TAG);
     }
 
     @VisibleForTesting
@@ -306,6 +310,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
             return;
         }
         mPhoto = result;
+        mPhoto.setParcelableMemoryCacheTag(PARCELABLE_MEMORY_CACHE_TAG);
         mCurrentRotation = mDocument.getRotationForDisplay();
         if (!mDocument.getSource().equals(Document.Source.newCameraSource())) {
             LOG.debug("Compressing Photo");
@@ -422,6 +427,8 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
     }
 
     void onSaveInstanceState(final Bundle outState) {
+        // Remove previously saved data from the memory cache
+        ParcelableMemoryCache.getInstance().removeEntriesWithTag(PARCELABLE_MEMORY_CACHE_TAG);
         outState.putParcelable(PHOTO_KEY, mPhoto);
         outState.putParcelable(DOCUMENT_KEY, mDocument);
     }
@@ -429,6 +436,13 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
     public void onDestroy() {
         if (!mNextClicked) {
             deleteUploadedDocument();
+        }
+        final Activity activity = mFragment.getActivity();
+        if (activity != null && activity.isFinishing()) {
+            // Remove data from the memory cache wich was added in onSaveInstanceState() and also
+            // when the document in the arguments was automatically parcelled when the activity
+            // has been stopped
+            ParcelableMemoryCache.getInstance().removeEntriesWithTag(PARCELABLE_MEMORY_CACHE_TAG);
         }
         mPhoto = null; // NOPMD
         mDocument = null; // NOPMD

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
@@ -427,10 +427,15 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
     }
 
     void onSaveInstanceState(final Bundle outState) {
-        // Remove previously saved data from the memory cache
-        ParcelableMemoryCache.getInstance().removeEntriesWithTag(PARCELABLE_MEMORY_CACHE_TAG);
+        // Remove previously saved data from the memory cache to keep only the data saved in the
+        // current invocation
+        clearParcelableMemoryCache();
         outState.putParcelable(PHOTO_KEY, mPhoto);
         outState.putParcelable(DOCUMENT_KEY, mDocument);
+    }
+
+    private void clearParcelableMemoryCache() {
+        ParcelableMemoryCache.getInstance().removeEntriesWithTag(PARCELABLE_MEMORY_CACHE_TAG);
     }
 
     public void onDestroy() {
@@ -439,10 +444,10 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         }
         final Activity activity = mFragment.getActivity();
         if (activity != null && activity.isFinishing()) {
-            // Remove data from the memory cache. The data was added in onSaveInstanceState() and also
-            // when the document in the arguments was automatically parcelled when the activity
-            // has been stopped
-            ParcelableMemoryCache.getInstance().removeEntriesWithTag(PARCELABLE_MEMORY_CACHE_TAG);
+            // Remove data from the memory cache. The data had been added in onSaveInstanceState()
+            // and also when the document in the arguments was automatically parcelled when the
+            // activity was stopped
+            clearParcelableMemoryCache();
         }
         mPhoto = null; // NOPMD
         mDocument = null; // NOPMD

--- a/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewFragment.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewFragment.java
@@ -12,7 +12,6 @@ import android.content.DialogInterface;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.view.PagerAdapter;
@@ -103,7 +102,7 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
         PreviewFragmentListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(MultiPageReviewFragment.class);
-    private static final String MP_DOCUMENT_KEY = "MP_DOCUMENT_KEY";
+
     private final Map<String, Boolean> mDocumentUploadResults = new HashMap<>();
     private ImageMultiPageDocument mMultiPageDocument;
     private MultiPageReviewFragmentListener mListener;
@@ -133,9 +132,6 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
         forcePortraitOrientationOnPhones(getActivity());
         initMultiPageDocument();
         initListener();
-        if (savedInstanceState != null) {
-            restoreSavedState(savedInstanceState);
-        }
     }
 
     private void initMultiPageDocument() {
@@ -153,18 +149,6 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
     private void initUploadResults() {
         for (final ImageDocument imageDocument : mMultiPageDocument.getDocuments()) {
             mDocumentUploadResults.put(imageDocument.getId(), false);
-        }
-    }
-
-    private void restoreSavedState(@Nullable final Bundle savedInstanceState) {
-        if (savedInstanceState == null) {
-            return;
-        }
-        LOG.debug("Restoring saved state");
-        mMultiPageDocument = savedInstanceState.getParcelable(MP_DOCUMENT_KEY);
-        if (mMultiPageDocument == null) {
-            throw new IllegalStateException(
-                    "Missing required instances for restoring saved instance state.");
         }
     }
 
@@ -621,11 +605,6 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
         mPreviewsPager.setCurrentItem(0);
         updatePageIndicator(0);
         highlightThumbnail(0);
-    }
-
-    @Override
-    public void onSaveInstanceState(final Bundle outState) {
-        outState.putParcelable(MP_DOCUMENT_KEY, mMultiPageDocument);
     }
 
     @Override

--- a/ginivision/src/main/java/net/gini/android/vision/review/multipage/previews/PreviewFragment.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/multipage/previews/PreviewFragment.java
@@ -94,9 +94,7 @@ public class PreviewFragment extends Fragment {
         if (context == null) {
             return;
         }
-        // Remove data from memory cache which was added when the document in the arguments
-        // was automatically parcelled when the activity has been stopped
-        ParcelableMemoryCache.getInstance().removeEntriesWithTag(PARCELABLE_MEMORY_CACHE_TAG);
+        clearParcelableMemoryCache();
         if (shouldShowPreviewImage()) {
             LOG.debug("Loading preview bitmap ({})", this);
             showActivityIndicator();
@@ -221,8 +219,12 @@ public class PreviewFragment extends Fragment {
     @Override
     public void onDestroy() {
         super.onDestroy();
-        // Remove data from memory cache which was added when the document in the arguments
-        // was automatically parcelled when the activity has been stopped
+        clearParcelableMemoryCache();
+    }
+
+    private void clearParcelableMemoryCache() {
+        // Remove data from the memory cache. The data had been added when the document in the
+        // arguments was automatically parcelled when the activity was stopped
         ParcelableMemoryCache.getInstance().removeEntriesWithTag(PARCELABLE_MEMORY_CACHE_TAG);
     }
 


### PR DESCRIPTION
To keep the state between activity restarts we saved the `Document` and `Photo` in `onSaveInstanceState()`. This was causing memory leaks for the following reasons:

* `onSaveInstanceState()` is called as soon as there is a chance the activity will be destroyed, meaning that it can be called multiple times without `onCreate()` or `onRestoreInstanceState()` being called afterwards.
* Data size that may be parceled is limited. To circumvent this we use the `ParcelableMemoryCache` which is a singleton and keeps references to byte arrays and bitmaps for `Documents` and `Photos` when they are parceled. During unparceling the byte arrays and bitmaps are fetched and removed from the cache.
* Due to the above leaks occurred when parceling and unparceling `Documents` and `Photos` was not balanced. In this particular case parceling happened every time the `ReviewFragmentImpl` and `AnalysisFragmentImpl` were stopped. Only rotation caused restarts were always parceling and unparceling the objects.

#### The fix:
Allow tagging of `ParcelableMemoryCache` entries. With the help of the tags clear the cache of the desired tagged entries as soon as it is safe to presume that unparceling will never happen and the cached data won't be used.

### How to test
Run one of the example apps and use the Android Profiler in AS to observe memory usage. Take pictures, send the app to the background and resume, enter and exit the review and analysis screens multiple times, etc. The memory usage should NOT show a build up of allocations.

### Ticket 
https://trello.com/c/oSvhvofV/245-crash-in-netginiandroidvision
