### PR TITLE
Feature document metadata

### DIFF
--- a/componentapiexample/src/main/java/net/gini/android/vision/component/MainActivity.java
+++ b/componentapiexample/src/main/java/net/gini/android/vision/component/MainActivity.java
@@ -76,7 +76,7 @@ public class MainActivity extends AppCompatActivity {
         // Configure the Gini Vision Library
         GiniVision.cleanup(this);
         GiniVision.newInstance()
-                .setGiniVisionNetworkService(app.getGiniVisionNetworkService())
+                .setGiniVisionNetworkService(app.getGiniVisionNetworkService("ComponentAPI"))
                 .setGiniVisionNetworkApi(app.getGiniVisionNetworkApi())
                 .setDocumentImportEnabledFileTypes(DocumentImportEnabledFileTypes.PDF_AND_IMAGES)
                 .setFileImportEnabled(true)

--- a/exampleShared/java/net/gini/android/vision/example/BaseExampleApp.java
+++ b/exampleShared/java/net/gini/android/vision/example/BaseExampleApp.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 import android.support.multidex.MultiDexApplication;
 import android.text.TextUtils;
 
+import net.gini.android.DocumentMetadata;
 import net.gini.android.Gini;
 import net.gini.android.SdkBuilder;
 import net.gini.android.vision.network.GiniVisionDefaultNetworkApi;
@@ -72,7 +73,7 @@ public abstract class BaseExampleApp extends MultiDexApplication {
     }
 
     @NonNull
-    public GiniVisionNetworkService getGiniVisionNetworkService() {
+    public GiniVisionNetworkService getGiniVisionNetworkService(@NonNull final String appFlowApiType) {
         final String clientId = getClientId();
         final String clientSecret = getClientSecret();
         if (TextUtils.isEmpty(clientId) || TextUtils.isEmpty(clientSecret)) {
@@ -82,8 +83,12 @@ public abstract class BaseExampleApp extends MultiDexApplication {
                             + "parameters with -PclientId and -PclientSecret.");
         }
         if (mGiniVisionNetworkService == null) {
+            final DocumentMetadata documentMetadata = new DocumentMetadata();
+            documentMetadata.setBranchId("GVLExampleAndroid");
+            documentMetadata.add("AppFlow", appFlowApiType);
             mGiniVisionNetworkService = GiniVisionDefaultNetworkService.builder(this)
                     .setClientCredentials(clientId, clientSecret, "example.com")
+                    .setDocumentMetadata(documentMetadata)
                     .build();
         }
         return mGiniVisionNetworkService;

--- a/ginivision-network/build.gradle
+++ b/ginivision-network/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation deps.supportAnnotations
     implementation project(path: ':ginivision')
-    implementation('net.gini:gini-android-sdk:2.1.0@aar') {
+    api('net.gini:gini-android-sdk:2.2.0-beta@aar') {
         transitive = true
     }
 

--- a/ginivision-network/src/main/java/net/gini/android/vision/network/GiniVisionDefaultNetworkService.java
+++ b/ginivision-network/src/main/java/net/gini/android/vision/network/GiniVisionDefaultNetworkService.java
@@ -106,15 +106,15 @@ public class GiniVisionDefaultNetworkService implements GiniVisionNetworkService
             return new NoOpCancellationToken();
         }
         final DocumentTaskManager documentTaskManager = mGiniApi.getDocumentTaskManager();
-        final Task<net.gini.android.models.Document> uploadTask;
+        final Task<net.gini.android.models.Document> createDocumentTask;
         if (mDocumentMetadata != null) {
-            uploadTask = documentTaskManager.createPartialDocument(document.getData(),
+            createDocumentTask = documentTaskManager.createPartialDocument(document.getData(),
                     document.getMimeType(), null, null, mDocumentMetadata);
         } else {
-            uploadTask = documentTaskManager.createPartialDocument(document.getData(),
+            createDocumentTask = documentTaskManager.createPartialDocument(document.getData(),
                     document.getMimeType(), null, null);
         }
-        uploadTask.continueWith(new Continuation<net.gini.android.models.Document, Void>() {
+        createDocumentTask.continueWith(new Continuation<net.gini.android.models.Document, Void>() {
                     @Override
                     public Void then(final Task<net.gini.android.models.Document> task)
                             throws Exception {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
@@ -225,6 +225,10 @@ public class FileChooserActivity extends AppCompatActivity implements AlertDialo
 
     @Override
     public void onBackPressed() {
+        final boolean isShown = (boolean) mFileProvidersView.getTag();
+        if (!isShown) {
+            return;
+        }
         overridePendingTransition(0, 0);
         hideFileProviders(new TransitionListenerAdapter() {
             @Override

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
@@ -284,7 +284,7 @@ public class MainActivity extends AppCompatActivity {
         final BaseExampleApp app = (BaseExampleApp) getApplication();
         GiniVision.cleanup(this);
         GiniVision.newInstance()
-                .setGiniVisionNetworkService(app.getGiniVisionNetworkService())
+                .setGiniVisionNetworkService(app.getGiniVisionNetworkService("ScreenAPI"))
                 .setGiniVisionNetworkApi(app.getGiniVisionNetworkApi())
                 .setDocumentImportEnabledFileTypes(DocumentImportEnabledFileTypes.PDF_AND_IMAGES)
                 .setFileImportEnabled(true)


### PR DESCRIPTION
Using the Gini API SDK 2.2.0-beta a `DocumentMetadata` can be set when building the `GiniVisionDefaultNetworkService`. This metadata will be passed to all document uploads.

Also fixed a bug which has been reported to us. Dismissing the file chooser bottom sheet will not crash the app, if the back button is pressed rapidly multiple times.

### How to test
Run the example apps.