### PR TITLE
MultiPageReviewFragment doesn't finish its hosting Activity directly anymore

### DIFF
--- a/componentapiexample/src/main/java/net/gini/android/vision/component/review/multipage/MultiPageReviewExampleActivity.java
+++ b/componentapiexample/src/main/java/net/gini/android/vision/component/review/multipage/MultiPageReviewExampleActivity.java
@@ -37,6 +37,16 @@ public class MultiPageReviewExampleActivity extends AppCompatActivity implements
     }
 
     @Override
+    public void onReturnToCameraScreen() {
+        finish();
+    }
+
+    @Override
+    public void onImportedDocumentReviewCancelled() {
+        finish();
+    }
+
+    @Override
     protected void onActivityResult(final int requestCode, final int resultCode,
             final Intent data) {
         super.onActivityResult(requestCode, resultCode, data);

--- a/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewActivity.java
@@ -274,6 +274,16 @@ public class MultiPageReviewActivity extends AppCompatActivity implements
     }
 
     @Override
+    public void onReturnToCameraScreen() {
+        finish();
+    }
+
+    @Override
+    public void onImportedDocumentReviewCancelled() {
+        finish();
+    }
+
+    @Override
     protected void onActivityResult(final int requestCode, final int resultCode,
             final Intent data) {
         if (requestCode == ANALYSE_DOCUMENT_REQUEST) {

--- a/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewFragment.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewFragment.java
@@ -244,7 +244,7 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
 
                     @Override
                     public void onPlusButtonClicked() {
-                        activity.finish();
+                        mListener.onReturnToCameraScreen();
                     }
                 };
 
@@ -327,7 +327,7 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
                                     @Override
                                     public void onClick(final DialogInterface dialog,
                                             final int which) {
-                                        activity.finish();
+                                        mListener.onImportedDocumentReviewCancelled();
                                     }
                                 })
                         .setNegativeButton(
@@ -336,7 +336,7 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
                         .create().show();
             } else {
                 doDeleteDocumentAndUpdateUI(document);
-                activity.finish();
+                mListener.onReturnToCameraScreen();
             }
         } else {
             doDeleteDocumentAndUpdateUI(document);

--- a/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewFragmentListener.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewFragmentListener.java
@@ -1,11 +1,17 @@
 package net.gini.android.vision.review.multipage;
 
+import android.content.Context;
+import android.content.Intent;
 import android.support.annotation.NonNull;
 
+import net.gini.android.vision.AsyncCallback;
 import net.gini.android.vision.Document;
+import net.gini.android.vision.GiniVision;
 import net.gini.android.vision.analysis.AnalysisActivity;
 import net.gini.android.vision.analysis.AnalysisFragmentCompat;
 import net.gini.android.vision.analysis.AnalysisFragmentStandard;
+import net.gini.android.vision.camera.CameraFragmentCompat;
+import net.gini.android.vision.camera.CameraFragmentStandard;
 import net.gini.android.vision.document.GiniVisionMultiPageDocument;
 
 /**
@@ -34,4 +40,27 @@ public interface MultiPageReviewFragmentListener {
      * @param document contains the reviewed image (can be the original one or a modified image)
      */
     void onProceedToAnalysisScreen(@NonNull GiniVisionMultiPageDocument document);
+
+    /**
+     * Called when the user wants to add a picture of another page. Also called when the user has
+     * deleted every page and the document consisted of images taken with the Camera Screen or
+     * imported using the Camera Screen.
+     *
+     * <p> If you host the {@link MultiPageReviewFragment} in its own Activity, then you should
+     * simply finish the Activity.
+     *
+     * <p> If you use one Activity to host all the GVL fragments, then you should display the
+     * {@link CameraFragmentCompat} (or the {@link CameraFragmentStandard}) again.
+     */
+    void onReturnToCameraScreen();
+
+    /**
+     * Called when the user deleted all the pages of a document received from another app.
+     * This means the {@link MultiPageReviewFragment} was launched after a document had been created
+     * using {@link GiniVision#createDocumentForImportedFiles(Intent, Context, AsyncCallback)}.
+     *
+     * <p> At this point you should finish GVL by closing the {@link MultiPageReviewFragment} and
+     * cleaning up using {@link GiniVision#cleanup(Context)}.
+     */
+    void onImportedDocumentReviewCancelled();
 }


### PR DESCRIPTION
Using a single activity to host all the Component API fragments revealed an oversight in the `MultiPageReviewFragment`. It was finishing its host activity directly when the user tapped on the add more pages button or deleted the last page. This prevented the client app from being able to go back to the camera fragment in the same activity.

### How to test
Run our example apps.
