### PR TITLE
Fixed removing the click listener for the first image stack item

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/camera/ImageStack.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/ImageStack.java
@@ -196,9 +196,9 @@ public class ImageStack extends RelativeLayout {
 
     private void removeClickListener(
             @NonNull final View view) {
+        view.setOnClickListener(null);
         view.setClickable(false);
         view.setFocusable(false);
-        view.setOnClickListener(null);
     }
 
     public void setImages(@Nullable final List<StackBitmap> bitmaps) {


### PR DESCRIPTION
The image stack items were still clickable (but without click listeners) after removing the click listeners due to the `setOnClickListener(null)` call which even though receiving a `null` listener sets clickable to `true`. I moved it before setting clickable to `false` to fix the bug.

### How to test
Run one of the example apps and tap on the area where the image stack is shown. You shouldn't see a ripple effect and the camera should focus and show the focus position indicator.