### PR TITLE
Supported Formats help screen can be disabled

### DIFF
--- a/componentapiexample/src/main/java/net/gini/android/vision/component/MainActivity.java
+++ b/componentapiexample/src/main/java/net/gini/android/vision/component/MainActivity.java
@@ -95,7 +95,9 @@ public class MainActivity extends AppCompatActivity {
                     .setMultiPageEnabled(true);
         }
         // Uncomment to add an extra page to the Onboarding pages
-//      builder.setCustomOnboardingPages(getOnboardingPages());
+//        builder.setCustomOnboardingPages(getOnboardingPages());
+        // Uncomment to remove the Supported Formats help screen
+//        builder.setSupportedFormatsHelpScreenEnabled(false);
         builder.build();
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVision.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVision.java
@@ -63,6 +63,7 @@ public class GiniVision {
     private final boolean mShouldShowOnboardingAtFirstRun;
     private final boolean mMultiPageEnabled;
     private boolean mShouldShowOnboarding;
+    private final boolean mIsSupportedFormatsHelpScreenEnabled;
 
     /**
      * Retrieve the current instance.
@@ -145,6 +146,7 @@ public class GiniVision {
         mGiniVisionFileImport = new GiniVisionFileImport(this);
         mInternal = new Internal(this);
         mMultiPageEnabled = builder.isMultiPageEnabled();
+        mIsSupportedFormatsHelpScreenEnabled = builder.isSupportedFormatsHelpScreenEnabled();
     }
 
     /**
@@ -259,6 +261,17 @@ public class GiniVision {
      */
     public void setShouldShowOnboarding(final boolean shouldShowOnboarding) {
         mShouldShowOnboarding = shouldShowOnboarding;
+    }
+
+    /**
+     * Find out whether the Supported Formats help screen has been enabled.
+     *
+     * <p> Enabled by default.
+     *
+     * @return {@code true} if the Supported Formats help screen was enabled
+     */
+    public boolean isSupportedFormatsHelpScreenEnabled() {
+        return mIsSupportedFormatsHelpScreenEnabled;
     }
 
     /**
@@ -424,6 +437,7 @@ public class GiniVision {
         private boolean mShouldShowOnboardingAtFirstRun = true;
         private boolean mShouldShowOnboarding;
         private boolean mMultiPageEnabled;
+        private boolean mIsSupportedFormatsHelpScreenEnabled = true;
 
         /**
          * Create a new {@link GiniVision} instance.
@@ -629,6 +643,24 @@ public class GiniVision {
 
         boolean shouldShowOnboarding() {
             return mShouldShowOnboarding;
+        }
+
+        /**
+         * Enable/disable the Supported Formats help screen.
+         *
+         * <p> Enabled by default.
+         *
+         * @param enabled {@code true} to show the Supported Formats help screen
+         *
+         * @return the {@link Builder} instance
+         */
+        public Builder setSupportedFormatsHelpScreenEnabled(final boolean enabled) {
+            mIsSupportedFormatsHelpScreenEnabled = enabled;
+            return this;
+        }
+
+        boolean isSupportedFormatsHelpScreenEnabled() {
+            return mIsSupportedFormatsHelpScreenEnabled;
         }
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/help/HelpActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/help/HelpActivity.java
@@ -102,6 +102,7 @@ public class HelpActivity extends AppCompatActivity {
     private static final Logger LOG = LoggerFactory.getLogger(HelpActivity.class);
     private static final int PHOTO_TIPS_REQUEST = 1;
     private GiniVisionFeatureConfiguration mGiniVisionFeatureConfiguration;
+    private RecyclerView mRecyclerView;
 
     @Override
     protected void onActivityResult(final int requestCode, final int resultCode,
@@ -120,6 +121,10 @@ public class HelpActivity extends AppCompatActivity {
         readExtras();
         setUpHelpItems();
         forcePortraitOrientationOnPhones(this);
+        if (hasOnlyOneHelpItem()) {
+            launchHelpScreen(((HelpItemsAdapter) mRecyclerView.getAdapter()).getItems().get(0));
+            finish();
+        }
     }
 
     private void readExtras() {
@@ -135,15 +140,19 @@ public class HelpActivity extends AppCompatActivity {
     }
 
     private void setUpHelpItems() {
-        final RecyclerView recyclerView = findViewById(R.id.gv_help_items);
-        recyclerView.setLayoutManager(new LinearLayoutManager(this));
-        recyclerView.setAdapter(new HelpItemsAdapter(mGiniVisionFeatureConfiguration,
+        mRecyclerView = findViewById(R.id.gv_help_items);
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        mRecyclerView.setAdapter(new HelpItemsAdapter(mGiniVisionFeatureConfiguration,
                 new HelpItemsAdapter.HelpItemSelectedListener() {
                     @Override
                     public void onItemSelected(@NonNull final HelpItem helpItem) {
                         launchHelpScreen(helpItem);
                     }
                 }));
+    }
+
+    private boolean hasOnlyOneHelpItem() {
+        return mRecyclerView.getAdapter().getItemCount() == 1;
     }
 
     private void launchHelpScreen(final HelpItem helpItem) {

--- a/ginivision/src/main/java/net/gini/android/vision/help/HelpItemsAdapter.java
+++ b/ginivision/src/main/java/net/gini/android/vision/help/HelpItemsAdapter.java
@@ -10,6 +10,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import net.gini.android.vision.GiniVision;
 import net.gini.android.vision.GiniVisionFeatureConfiguration;
 import net.gini.android.vision.R;
 
@@ -39,8 +40,16 @@ class HelpItemsAdapter extends Adapter<HelpItemsAdapter.HelpItemsViewHolder> {
         if (isFileImportEnabled(giniVisionFeatureConfiguration)) {
             items.add(HelpItem.FILE_IMPORT_GUIDE);
         }
-        items.add(HelpItem.SUPPORTED_FORMATS);
+        if (GiniVision.hasInstance()
+                && GiniVision.getInstance().isSupportedFormatsHelpScreenEnabled()) {
+            items.add(HelpItem.SUPPORTED_FORMATS);
+        }
         return items;
+    }
+
+    @NonNull
+    List<HelpItem> getItems() {
+        return mItems;
     }
 
     @Override

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
@@ -325,6 +325,8 @@ public class MainActivity extends AppCompatActivity {
 //                builder.setShouldShowOnboardingAtFirstRun(false);
         // Uncomment to show the OnboardingActivity every time the CameraActivity starts
 //                builder.setShouldShowOnboarding(true);
+        // Uncomment to remove the Supported Formats help screen
+//                builder.setSupportedFormatsHelpScreenEnabled(false);
         builder.build();
     }
 


### PR DESCRIPTION
With `GiniVision.newInstance().setSupportedFormatsHelpScreenEnabled(false)` the Supported Formats help screen can be disabled.

If file import is also disabled, then the Photo Tips screen is shown directly. The selection screen is skipped since it has only one item in this case.

### How to test
Disable the screen in one of the example app's `MainActivity.java` and verify that it's not shown. Also disable file import and verify that the Photo Tips screen is shown directly.