### PR TITLE
Camera picture accessible from the accounting networking plugin

### DIFF
--- a/screenapiexample/src/main/AndroidManifest.xml
+++ b/screenapiexample/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="net.gini.android.vision.screen">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -28,14 +29,18 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter android:label="@string/app_name">
+            <intent-filter
+                android:label="@string/app_name"
+                tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.SEND" />
                 <action android:name="android.intent.action.SEND_MULTIPLE" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />
             </intent-filter>
-            <intent-filter android:label="@string/app_name">
+            <intent-filter
+                android:label="@string/app_name"
+                tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -58,6 +63,17 @@
         <activity
             android:name="net.gini.android.vision.screen.NoExtractionsActivity"
             android:label="@string/title_no_extractions"/>
+
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="net.gini.android.vision.screen.fileprovider"
+            android:grantUriPermissions="true"
+            android:exported="false">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/screenapiexample/src/main/res/menu/menu_extractions.xml
+++ b/screenapiexample/src/main/res/menu/menu_extractions.xml
@@ -5,4 +5,8 @@
         android:id="@+id/feedback"
         android:title="@string/menu_item_feedback"
         app:showAsAction="always" />
+    <item
+        android:id="@+id/view_picture"
+        android:title="@string/menu_item_view_picture"
+        app:showAsAction="ifRoom" />
 </menu>

--- a/screenapiexample/src/main/res/values/strings.xml
+++ b/screenapiexample/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="start_gini_vision_library">Start Gini Vision Library</string>
 
     <string name="menu_item_feedback">Send Feedback</string>
+    <string name="menu_item_view_picture">View Picture</string>
     <string name="document_size_too_large">Diese Datei ist leider größer als 5MB.</string>
     <string name="unsupported_document_type">Nur Dateien vom Format jpg oder pdf können analysiert werden.</string>
 

--- a/screenapiexample/src/main/res/xml/filepaths.xml
+++ b/screenapiexample/src/main/res/xml/filepaths.xml
@@ -1,0 +1,3 @@
+<paths>
+    <external-files-path path="camera-pictures/" name="analyzed_camera_pictures" />
+</paths>


### PR DESCRIPTION
After successful analysis the picture taken by the camera can be accessed when using the accounting networking plugin.

Updated the screen api example app to allow viewing the picture when using the accounting api.

### How to test
Run the screen api example app, select accounting as the api type, analyze a document and on the extractions screen tap 'View Picture'. This should allow you to view the picture in another app (you have to select in which app you want to view it).

### Ticket 
https://gini-aha.atlassian.net/secure/RapidBoard.jspa?rapidView=5&projectKey=PIA&modal=detail&selectedIssue=PIA-130
