### PR TITLE
Expose user credentials deletion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath('com.dicedmelon.gradle:jacoco-android:0.1.3') {
             exclude group: 'org.codehaus.groovy', module: 'groovy-all'
         }

--- a/ginivision-accounting-network/src/main/java/net/gini/android/vision/accounting/network/GiniVisionAccountingNetworkApi.java
+++ b/ginivision-accounting-network/src/main/java/net/gini/android/vision/accounting/network/GiniVisionAccountingNetworkApi.java
@@ -77,8 +77,7 @@ public class GiniVisionAccountingNetworkApi implements GiniVisionNetworkApi {
                         .continueWith(new Continuation<net.gini.android.models.Document, Object>() {
                             @Override
                             public Object then(
-                                    @NonNull final Task<net.gini.android.models.Document> task)
-                                    throws Exception {
+                                    @NonNull final Task<net.gini.android.models.Document> task) {
                                 mUIExecutor.runOnUiThread(new Runnable() {
                                     @Override
                                     public void run() {
@@ -110,6 +109,12 @@ public class GiniVisionAccountingNetworkApi implements GiniVisionNetworkApi {
             callback.failure(new Error("Feedback not set: no Gini Api Document available"));
         }
     }
+
+    @Override
+    public void deleteGiniUserCredentials() {
+        mAccountingNetworkService.getGiniApi().getCredentialsStore().deleteUserCredentials();
+    }
+
     /**
      * Builder for configuring a new instance of the {@link GiniVisionAccountingNetworkApi}.
      */

--- a/ginivision-network/src/main/java/net/gini/android/vision/network/GiniVisionDefaultNetworkApi.java
+++ b/ginivision-network/src/main/java/net/gini/android/vision/network/GiniVisionDefaultNetworkApi.java
@@ -74,8 +74,7 @@ public class GiniVisionDefaultNetworkApi implements GiniVisionNetworkApi {
                         .continueWith(new Continuation<net.gini.android.models.Document, Object>() {
                             @Override
                             public Object then(
-                                    @NonNull final Task<net.gini.android.models.Document> task)
-                                    throws Exception {
+                                    @NonNull final Task<net.gini.android.models.Document> task) {
                                 mUIExecutor.runOnUiThread(new Runnable() {
                                     @Override
                                     public void run() {
@@ -106,6 +105,11 @@ public class GiniVisionDefaultNetworkApi implements GiniVisionNetworkApi {
             LOG.error("Send feedback failed: no Gini Api Document available");
             callback.failure(new Error("Feedback not set: no Gini Api Document available"));
         }
+    }
+
+    @Override
+    public void deleteGiniUserCredentials() {
+        mDefaultNetworkService.getGiniApi().getCredentialsStore().deleteUserCredentials();
     }
 
     /**

--- a/ginivision/src/doc/requirements.txt
+++ b/ginivision/src/doc/requirements.txt
@@ -1,4 +1,4 @@
-Jinja2==2.7.3
+Jinja2==2.8.1
 MarkupSafe==0.23
 Pygments==2.0.1
 Sphinx==1.2.3

--- a/ginivision/src/main/java/net/gini/android/vision/network/GiniVisionNetworkApi.java
+++ b/ginivision/src/main/java/net/gini/android/vision/network/GiniVisionNetworkApi.java
@@ -33,4 +33,12 @@ public interface GiniVisionNetworkApi {
      */
     void sendFeedback(@NonNull final Map<String, GiniVisionSpecificExtraction> extractions,
             @NonNull final GiniVisionNetworkCallback<Void, Error> callback);
+
+    /**
+     * Delete the anonymous gini user credentials. These were automatically generated when the first
+     * document was uploaded.
+     * <p>
+     * By deleting the credentials, new ones will be generated at the next upload.
+     */
+    void deleteGiniUserCredentials();
 }


### PR DESCRIPTION
Added a method to the `GiniVisionNetworkApi` to delete the anonymous gini credentials.

### How to test
Run one of the example apps and scan a document. Using Android Studio's Device File Explorer navigate to `data/data/net.gini.android.vision.screenapiexample/shared_prefs` and open `Gini.xml` and note down the credentials (works on Nexus and Pixel devices or in the emulator when the app is running - this folder is accessible only from the app's process). Alter the example app to call the `GiniVisionNetworkApi#deleteGiniUserCredentials()` and scan a document again. Open the `Gini.xml` file again (close the other one first and refresh the folder in the Device File Explorer) and compare the credentials to the previous ones. They should be different.