### PR TITLE
Set flash default status

### DIFF
--- a/componentapiexample/src/main/java/net/gini/android/vision/component/MainActivity.java
+++ b/componentapiexample/src/main/java/net/gini/android/vision/component/MainActivity.java
@@ -87,14 +87,16 @@ public class MainActivity extends AppCompatActivity {
                 .setGiniVisionNetworkService(
                         app.getGiniVisionNetworkService("ComponentAPI",
                                 mGiniApiType)
-                ).setGiniVisionNetworkApi(app.getGiniVisionNetworkApi())
-                .setFlashButtonEnabled(true);
+                ).setGiniVisionNetworkApi(app.getGiniVisionNetworkApi());
         if (mGiniApiType == GiniApiType.DEFAULT) {
             builder.setDocumentImportEnabledFileTypes(DocumentImportEnabledFileTypes.PDF_AND_IMAGES)
                     .setFileImportEnabled(true)
                     .setQRCodeScanningEnabled(true)
                     .setMultiPageEnabled(true);
         }
+        builder.setFlashButtonEnabled(true);
+        // Uncomment to turn off the camera flash by default
+//        builder.setFlashOnByDefault(false);
         // Uncomment to add an extra page to the Onboarding pages
 //        builder.setCustomOnboardingPages(getOnboardingPages());
         // Uncomment to remove the Supported Formats help screen

--- a/ginivision/build.gradle
+++ b/ginivision/build.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'com.android.library'
 apply plugin: 'jacoco-android'
 
+jacoco {
+    toolVersion = "0.8.3"
+}
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
@@ -116,8 +120,8 @@ def unifyTestCoverage(coverageFilesPath) {
     tasks.withType(JacocoReport) { task ->
         File execDataDir = file(coverageFilesPath)
         if (execDataDir.exists() && execDataDir.isDirectory() && execDataDir.listFiles().length > 0) {
-            File[] execDataDirContents = execDataDir.listFiles();
-            task.executionData = task.executionData.plus(files { execDataDirContents })
+            File[] execDataDirContents = execDataDir.listFiles()
+            task.executionData.from(files { execDataDirContents })
         }
     }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/camera/CameraScreenTest.java
@@ -811,4 +811,31 @@ public class CameraScreenTest {
         // Then
         assertThat(activity.hasDocument()).isTrue();
     }
+
+    @Test
+    public void should_turnOffFlashByDefault_whenRequested() {
+        // Given
+        GiniVision.newInstance()
+                .setFlashOnByDefault(false)
+                .build();
+        // When
+        final CameraActivityFake cameraActivityFake = startCameraActivityFakeWithoutOnboarding(
+                null);
+
+        // Then
+        assertThat(cameraActivityFake.getCameraControllerFake().isFlashEnabled()).isFalse();
+    }
+
+    @Test
+    public void should_turnOnFlashByDefault_ifNotChanged() {
+        // Given
+        GiniVision.newInstance().build();
+
+        // When
+        final CameraActivityFake cameraActivityFake = startCameraActivityFakeWithoutOnboarding(
+                null);
+
+        // Then
+        assertThat(cameraActivityFake.getCameraControllerFake().isFlashEnabled()).isTrue();
+    }
 }

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/api/CameraControllerFake.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/api/CameraControllerFake.java
@@ -30,6 +30,7 @@ public class CameraControllerFake implements CameraInterface {
     private Camera.PreviewCallback mPreviewCallback;
     private Size mPreviewSize = DEFAULT_PREVIEW_SIZE;
     private SurfaceHolder mSurfaceHolder;
+    private boolean mFlashEnabled;
 
     @NonNull
     @Override
@@ -123,17 +124,17 @@ public class CameraControllerFake implements CameraInterface {
 
     @Override
     public boolean isFlashAvailable() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isFlashEnabled() {
-        return false;
+        return mFlashEnabled;
     }
 
     @Override
     public void setFlashEnabled(final boolean enabled) {
-
+        mFlashEnabled = enabled;
     }
 
     public void showImageAsPreview(@NonNull final byte[] image, @Nullable final byte[] imageNV21) {

--- a/ginivision/src/doc/requirements.txt
+++ b/ginivision/src/doc/requirements.txt
@@ -1,4 +1,4 @@
-Jinja2==2.8.1
+Jinja2==2.10.1
 MarkupSafe==0.23
 Pygments==2.0.1
 Sphinx==1.2.3

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVision.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVision.java
@@ -66,6 +66,7 @@ public class GiniVision {
     private final boolean mIsSupportedFormatsHelpScreenEnabled;
     private final boolean mFlashButtonEnabled;
     private final boolean mBackButtonsEnabled;
+    private final boolean mIsFlashOnByDefault;
 
     /**
      * Retrieve the current instance.
@@ -151,6 +152,7 @@ public class GiniVision {
         mIsSupportedFormatsHelpScreenEnabled = builder.isSupportedFormatsHelpScreenEnabled();
         mFlashButtonEnabled = builder.isFlashButtonEnabled();
         mBackButtonsEnabled = builder.areBackButtonsEnabled();
+        mIsFlashOnByDefault = builder.isFlashOnByDefault();
     }
 
     /**
@@ -302,6 +304,17 @@ public class GiniVision {
      */
     public boolean areBackButtonsEnabled() {
         return mBackButtonsEnabled;
+    }
+
+    /**
+     * Find out whether the camera flash is on or off by default.
+     *
+     * <p> If not changed, then flash is on by default.
+     *
+     * @return {@code true} if the flash is on by default
+     */
+    public boolean isFlashOnByDefault() {
+        return mIsFlashOnByDefault;
     }
 
     /**
@@ -470,6 +483,7 @@ public class GiniVision {
         private boolean mIsSupportedFormatsHelpScreenEnabled = true;
         private boolean mFlashButtonEnabled;
         private boolean mBackButtonsEnabled = true;
+        private boolean mIsFlashOnByDefault = true;
 
         /**
          * Create a new {@link GiniVision} instance.
@@ -732,6 +746,24 @@ public class GiniVision {
 
         boolean areBackButtonsEnabled() {
             return mBackButtonsEnabled;
+        }
+
+        /**
+         * Set whether the camera flash is on or off by default.
+         *
+         * <p> If not changed, then flash is on by default.
+         *
+         * @param flashOn {@code true} to turn the flash on
+         *
+         * @return the {@link Builder} instance
+         */
+        public Builder setFlashOnByDefault(final boolean flashOn) {
+            mIsFlashOnByDefault = flashOn;
+            return this;
+        }
+
+        boolean isFlashOnByDefault() {
+            return mIsFlashOnByDefault;
         }
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -327,8 +327,15 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
             return;
         }
         forcePortraitOrientationOnPhones(activity);
+        initFlashState();
         if (savedInstanceState != null) {
             restoreSavedState(savedInstanceState);
+        }
+    }
+
+    private void initFlashState() {
+        if (GiniVision.hasInstance()) {
+            mIsFlashEnabled = GiniVision.getInstance().isFlashOnByDefault();
         }
     }
 
@@ -400,11 +407,13 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         if (activity == null) {
             return;
         }
-        if (mCameraController.isFlashAvailable()
-                && (GiniVision.hasInstance() && GiniVision.getInstance().isFlashButtonEnabled())) {
-            mButtonCameraFlash.setVisibility(View.VISIBLE);
+        if (mCameraController.isFlashAvailable()) {
+            if (GiniVision.hasInstance() && GiniVision.getInstance().isFlashButtonEnabled()) {
+                mButtonCameraFlash.setVisibility(View.VISIBLE);
+            }
             updateCameraFlashState();
         }
+
     }
 
     public void onResume() {

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
@@ -318,6 +318,8 @@ public class MainActivity extends AppCompatActivity {
                     .setMultiPageEnabled(true);
         }
         builder.setFlashButtonEnabled(true);
+        // Uncomment to turn off the camera flash by default
+//        builder.setFlashOnByDefault(false);
         // Uncomment to disable back buttons (except in the review and analysis screens)
 //        builder.setBackButtonsEnabled(false);
         // Uncomment to add an extra page to the Onboarding pages


### PR DESCRIPTION
You can now set the default flash state with `GiniVision.Builder#setFlashOnByDefault()`. If not changed, then the flash is on by default.

### How to test
Uncomment [this](https://github.com/gini/gini-vision-lib-android/commit/92f4f806f1b3ee1d249339f833aa7e65f50d8b8e#diff-2cc00d5e1fa7b257dcbfd235f1598060R322) or [this](https://github.com/gini/gini-vision-lib-android/commit/92f4f806f1b3ee1d249339f833aa7e65f50d8b8e#diff-2cc00d5e1fa7b257dcbfd235f1598060R322) to set flash off by default and run the example app.