### PR TITLE
Stores images in a subfolder to only affect own files

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/internal/storage/ImageDiskStore.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/storage/ImageDiskStore.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +32,8 @@ public class ImageDiskStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(ImageDiskStore.class);
 
-    private static final String STORE_DIR = "gv-images";
+    @VisibleForTesting
+    static final String STORE_DIR = "gv-images";
 
     @Nullable
     public Uri save(@NonNull final Context context, @NonNull final byte[] bytes) {
@@ -104,7 +106,8 @@ public class ImageDiskStore {
         return file;
     }
 
-    private void writeToFile(@NonNull final File file, @NonNull final byte[] bytes)
+    @VisibleForTesting
+    void writeToFile(@NonNull final File file, @NonNull final byte[] bytes)
             throws IOException {
         OutputStream outputStream = null;
         try {

--- a/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisScreenPresenterTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisScreenPresenterTest.java
@@ -296,8 +296,8 @@ public class AnalysisScreenPresenterTest {
     public void should_clearImagesFromDisk_onDocumentAnalyzed() throws Exception {
         // Given
         final AnalysisScreenPresenter presenter = spy(createPresenterWithEmptyImageDocument());
-        final File filesDir = mock(File.class);
-        when(filesDir.getAbsolutePath()).thenReturn("");
+        final File filesDir = spy(new File("file:///gv-images/12343.jpg"));
+        when(filesDir.exists()).thenReturn(true);
         when(mApp.getFilesDir()).thenReturn(filesDir);
 
         // When

--- a/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisScreenPresenterTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisScreenPresenterTest.java
@@ -216,8 +216,6 @@ public class AnalysisScreenPresenterTest {
         final int nrOfComparisons = presenters.size() - 1;
         final int nrOfPairwiseComparisons = (int) ((nrOfComparisons / 2.0) * (nrOfComparisons + 1));
         final int samePositionCountIfSameOrder = nrOfPairwiseComparisons * hints1.size();
-        System.out.println(samePositionCountIfSameOrder);
-        System.out.println(countSamePosition);
         assertThat(countSamePosition).isLessThan(samePositionCountIfSameOrder);
     }
 

--- a/ginivision/src/test/java/net/gini/android/vision/internal/storage/ImageDiskStoreTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/internal/storage/ImageDiskStoreTest.java
@@ -1,0 +1,286 @@
+package net.gini.android.vision.internal.storage;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import static net.gini.android.vision.test.Helpers.copyAssetToStorage;
+import static net.gini.android.vision.test.Helpers.getTestJpeg;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.robolectric.Shadows.shadowOf;
+
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+
+import android.app.Application;
+import android.content.ContentResolver;
+import android.net.Uri;
+import android.webkit.MimeTypeMap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowContentResolver;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Calendar;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+/**
+ * Created by Alpar Szotyori on 04.07.2019.
+ *
+ * Copyright (c) 2019 Gini GmbH.
+ */
+@RunWith(AndroidJUnit4.class)
+@Config(shadows = {
+        ImageDiskStoreTest.ContentResolverShadow.class,
+        ImageDiskStoreTest.MimeTypeMapShadow.class
+})
+public class ImageDiskStoreTest {
+
+    @Test
+    public void should_saveByteArray_toOwnFolder_inAppFilesDir() throws Exception {
+        // Given
+        final ImageDiskStore imageDiskStore = new ImageDiskStore();
+        final Application appContext = getApplicationContext();
+
+        // When
+        imageDiskStore.save(appContext, getTestJpeg());
+
+        // Then
+        final File storeDir = new File(appContext.getFilesDir(), ImageDiskStore.STORE_DIR);
+        assertThat(storeDir.listFiles()).hasLength(1);
+    }
+
+    @Test
+    public void should_returnUri_toFile_ofSavedByteArray() throws Exception {
+        // Given
+        final ImageDiskStore imageDiskStore = new ImageDiskStore();
+        final Application appContext = getApplicationContext();
+
+        // When
+        final Uri uri = imageDiskStore.save(appContext, getTestJpeg());
+
+        // Then
+        final File storeDir = new File(appContext.getFilesDir(), ImageDiskStore.STORE_DIR);
+        assertThat(storeDir.listFiles()[0].getAbsolutePath()).isEqualTo(uri.getPath());
+    }
+
+    @Test
+    public void should_notUseExtension_whenSavingByteArray() throws Exception {
+        // Given
+        final ImageDiskStore imageDiskStore = new ImageDiskStore();
+        final Application appContext = getApplicationContext();
+
+        // When
+        imageDiskStore.save(appContext, getTestJpeg());
+
+        // Then
+        final File storeDir = new File(appContext.getFilesDir(), ImageDiskStore.STORE_DIR);
+        assertThat(storeDir.listFiles()[0].getName()).doesNotContainMatch("^.+\\..+$");
+    }
+
+    @Test
+    public void should_saveUri_toOwnFolder_inAppFilesDir() throws Exception {
+        // Given
+        final ImageDiskStore imageDiskStore = new ImageDiskStore();
+
+        final Application appContext = getApplicationContext();
+        final Uri uri = getUriAndRegisterInputStream(appContext);
+
+        // When
+        imageDiskStore.save(appContext, uri);
+
+        // Then
+        final File storeDir = new File(appContext.getFilesDir(), ImageDiskStore.STORE_DIR);
+        assertThat(storeDir.listFiles()).hasLength(1);
+    }
+
+    private Uri getUriAndRegisterInputStream(final Application appContext) throws IOException {
+        final File filesDir = appContext.getFilesDir();
+        copyAssetToStorage("invoice.jpg", filesDir.getPath());
+
+        final File file = new File(filesDir, "invoice.jpg");
+        final Uri uri = Uri.fromFile(file);
+
+        final ShadowContentResolver contentResolver = shadowOf(appContext.getContentResolver());
+        contentResolver.registerInputStream(uri, new FileInputStream(file));
+        return uri;
+    }
+
+    @Test
+    public void should_preserveExtension_whenSavingUri() throws Exception {
+        // Given
+        final ImageDiskStore imageDiskStore = new ImageDiskStore();
+
+        final Application appContext = getApplicationContext();
+        final Uri uri = getUriAndRegisterInputStream(appContext);
+
+        // When
+        imageDiskStore.save(appContext, uri);
+
+        // Then
+        final File storeDir = new File(appContext.getFilesDir(), ImageDiskStore.STORE_DIR);
+        assertThat(storeDir.listFiles()[0].getName()).endsWith(".jpg");
+    }
+
+    @Test
+    public void should_returnUri_toFile_ofSavedUri() throws Exception {
+        // Given
+        final ImageDiskStore imageDiskStore = new ImageDiskStore();
+
+        final Application appContext = getApplicationContext();
+        final Uri uri = getUriAndRegisterInputStream(appContext);
+
+        // When
+        final Uri resultUri = imageDiskStore.save(appContext, uri);
+
+        // Then
+        final File storeDir = new File(appContext.getFilesDir(), ImageDiskStore.STORE_DIR);
+        assertThat(storeDir.listFiles()[0].getAbsolutePath()).isEqualTo(resultUri.getPath());
+    }
+
+    @Test
+    public void should_generateFilenames_basedOnTheCurrentTime_inMilliseconds() throws Exception {
+        // Given
+        final ImageDiskStore imageDiskStore = new ImageDiskStore();
+        final Application appContext = getApplicationContext();
+
+        // When
+        imageDiskStore.save(appContext, getTestJpeg());
+
+        // Then
+        final File storeDir = new File(appContext.getFilesDir(), ImageDiskStore.STORE_DIR);
+        final String fileName = storeDir.listFiles()[0].getName();
+
+        final Calendar calendarFileNameDate = Calendar.getInstance();
+        calendarFileNameDate.setTimeInMillis(Long.parseLong(fileName));
+
+        final Calendar calendarNow = Calendar.getInstance();
+        calendarNow.get(Calendar.YEAR);
+
+        assertThat(calendarFileNameDate.get(Calendar.YEAR)).isEqualTo(
+                calendarNow.get(Calendar.YEAR));
+        assertThat(calendarFileNameDate.get(Calendar.MONTH)).isEqualTo(
+                calendarNow.get(Calendar.MONTH));
+        assertThat(calendarFileNameDate.get(Calendar.DAY_OF_MONTH)).isEqualTo(
+                calendarNow.get(Calendar.DAY_OF_MONTH));
+        assertThat(calendarFileNameDate.get(Calendar.HOUR)).isEqualTo(
+                calendarNow.get(Calendar.HOUR));
+        assertThat(calendarFileNameDate.get(Calendar.MINUTE)).isEqualTo(
+                calendarNow.get(Calendar.MINUTE));
+    }
+
+    @Test
+    public void should_updateByteArray() throws Exception {
+        // Given
+        final ImageDiskStore imageDiskStore = new ImageDiskStore();
+        final Application appContext = getApplicationContext();
+        final byte[] bytes = new byte[]{10, 20, 1, 34, 42};
+
+        // When
+        final Uri uri = imageDiskStore.save(appContext, getTestJpeg());
+        final boolean result = imageDiskStore.update(uri, bytes);
+
+        // Then
+        assertThat(result).isTrue();
+        final File storeDir = new File(appContext.getFilesDir(), ImageDiskStore.STORE_DIR);
+        assertThat(storeDir.listFiles()[0].length()).isEqualTo(bytes.length);
+    }
+
+    @Test
+    public void should_failUpdate_ifUriIsInvalid() throws Exception {
+        // Given
+        final ImageDiskStore imageDiskStore = new ImageDiskStore();
+        final Application appContext = getApplicationContext();
+        final byte[] bytes = new byte[]{10, 20, 1, 34, 42};
+
+        // When
+        imageDiskStore.save(appContext, getTestJpeg());
+        final boolean result = imageDiskStore.update(Uri.EMPTY, bytes);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    public void should_failUpdate_ifErrorWritingFile_atUri() throws Exception {
+        // Given
+        final ImageDiskStore imageDiskStore = spy(new ImageDiskStore());
+        final Application appContext = getApplicationContext();
+        final byte[] bytes = new byte[]{10, 20, 1, 34, 42};
+
+        // When
+        imageDiskStore.save(appContext, getTestJpeg());
+        Mockito.doThrow(new IOException()).when(imageDiskStore).writeToFile(any(File.class),
+                any(byte[].class));
+        final boolean result = imageDiskStore.update(Uri.EMPTY, bytes);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    public void should_deleteUri() throws Exception {
+        // Given
+        final ImageDiskStore imageDiskStore = new ImageDiskStore();
+        final Application appContext = getApplicationContext();
+        copyAssetToStorage("invoice.jpg", appContext.getFilesDir().getPath());
+
+        // When
+        final Uri uri = imageDiskStore.save(appContext, getTestJpeg());
+        imageDiskStore.save(appContext, getTestJpeg());
+        imageDiskStore.delete(uri);
+
+        // Then
+        final File storeDir = new File(appContext.getFilesDir(), ImageDiskStore.STORE_DIR);
+        assertThat(storeDir.listFiles()).hasLength(1);
+    }
+
+    @Test
+    public void should_clearStore_byRemovingOnlyOwnFiles() throws Exception {
+        // Given
+        final ImageDiskStore imageDiskStore = new ImageDiskStore();
+        final Application appContext = getApplicationContext();
+        copyAssetToStorage("invoice.jpg", appContext.getFilesDir().getPath());
+
+        // When
+        imageDiskStore.save(appContext, getTestJpeg());
+        imageDiskStore.save(appContext, getTestJpeg());
+        imageDiskStore.save(appContext, getTestJpeg());
+        imageDiskStore.save(appContext, getTestJpeg());
+        ImageDiskStore.clear(appContext);
+
+        // Then
+        final File storeDir = new File(appContext.getFilesDir(), ImageDiskStore.STORE_DIR);
+        assertThat(storeDir.exists()).isFalse();
+
+        final File nonStoreFile = new File(appContext.getFilesDir(), "invoice.jpg");
+        assertThat(nonStoreFile.exists()).isTrue();
+    }
+
+    @Implements(ContentResolver.class)
+    public static class ContentResolverShadow extends ShadowContentResolver {
+
+        @Override
+        @Implementation
+        protected String getType(final Uri uri) {
+            final String name = uri.getLastPathSegment();
+            return name.substring(name.lastIndexOf(".") + 1);
+        }
+    }
+
+    @Implements(MimeTypeMap.class)
+    public static class MimeTypeMapShadow {
+
+        @Implementation
+        public String getExtensionFromMimeType(final String mimeType) {
+            return mimeType;
+        }
+    }
+}

--- a/ginivision/src/test/java/net/gini/android/vision/test/Helpers.java
+++ b/ginivision/src/test/java/net/gini/android/vision/test/Helpers.java
@@ -1,12 +1,17 @@
 package net.gini.android.vision.test;
 
+import static androidx.test.InstrumentationRegistry.getTargetContext;
+
 import android.content.res.AssetManager;
+import android.net.Uri;
+import android.support.annotation.NonNull;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-
-import androidx.test.InstrumentationRegistry;
+import java.io.OutputStream;
 
 /**
  * Created by Alpar Szotyori on 15.05.2019.
@@ -23,7 +28,7 @@ public final class Helpers {
     }
 
     public static byte[] loadAsset(final String filename) throws IOException {
-        final AssetManager assetManager = InstrumentationRegistry.getTargetContext().getAssets();
+        final AssetManager assetManager = getTargetContext().getAssets();
         InputStream inputStream = null;
         try {
             inputStream = assetManager.open(filename);
@@ -49,5 +54,39 @@ public final class Helpers {
             outputStream.close();
         }
         return bytes;
+    }
+
+    public static void copyAssetToStorage(@NonNull final String assetFilePath,
+            @NonNull final String storageDirPath) throws IOException {
+        final AssetManager assetManager = getTargetContext().getAssets();
+        InputStream inputStream = null;
+        OutputStream outputStream = null;
+        try {
+            inputStream = assetManager.open(assetFilePath);
+            final File file = new File(storageDirPath,
+                    Uri.parse(assetFilePath).getLastPathSegment());
+            if (file.exists() || file.createNewFile()) {
+                outputStream = new FileOutputStream(file);
+                copyFile(inputStream, outputStream);
+            } else {
+                throw new IOException("Could not create file: " + file.getAbsolutePath());
+            }
+        } finally {
+            if (inputStream != null) {
+                inputStream.close();
+            }
+            if (outputStream != null) {
+                outputStream.close();
+            }
+        }
+    }
+
+    private static void copyFile(final InputStream inputStream, final OutputStream outputStream)
+            throws IOException {
+        final byte[] buffer = new byte[8192];
+        int read;
+        while ((read = inputStream.read(buffer)) != -1) {
+            outputStream.write(buffer, 0, read);
+        }
     }
 }


### PR DESCRIPTION
We omitted putting GVL images into a subfolder and only working with that to not affect host app's files. This PR remedies that by storing GVL images in the `gv-images` subfolder.

### How to test
Run one of the example apps using Android Studio. Navigate using the Device File Explorer to the apps private files in `data/data/net.gini.android.vision.*apiexample/files`. Upload a file there and verify that after analysing documents the `gv-images` folder is removed, but all other files remain.

### Ticket 
[PIA-298](https://ginis.atlassian.net/browse/PIA-298)
