### PR TITLE
ClassNotFoundException error fix

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVisionFileImport.java
@@ -78,6 +78,7 @@ public final class GiniVisionFileImport {
         } else {
             giniVisionIntent = new Intent(context, analysisActivityClass);
             giniVisionIntent.putExtra(AnalysisActivity.EXTRA_IN_DOCUMENT, document);
+            giniVisionIntent.setExtrasClassLoader(GiniVisionFileImport.class.getClassLoader());
         }
         return giniVisionIntent;
     }
@@ -90,6 +91,7 @@ public final class GiniVisionFileImport {
         final Intent giniVisionIntent;
         giniVisionIntent = new Intent(context, getReviewActivityClass(reviewActivityClass));
         giniVisionIntent.putExtra(ReviewActivity.EXTRA_IN_DOCUMENT, document);
+        giniVisionIntent.setExtrasClassLoader(GiniVisionFileImport.class.getClassLoader());
         ActivityHelper.setActivityExtra(giniVisionIntent,
                 ReviewActivity.EXTRA_IN_ANALYSIS_ACTIVITY, context,
                 getAnalysisActivityClass(analysisActivityClass));

--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisActivity.java
@@ -256,6 +256,7 @@ public class AnalysisActivity extends AppCompatActivity implements
         if (GiniVisionCoordinator.shouldShowGiniVisionNoResultsScreen(mDocument)) {
             final Intent noResultsActivity = new Intent(this, NoResultsActivity.class);
             noResultsActivity.putExtra(NoResultsActivity.EXTRA_IN_DOCUMENT, mDocument);
+            noResultsActivity.setExtrasClassLoader(AnalysisActivity.class.getClassLoader());
             startActivity(noResultsActivity);
             setResult(RESULT_NO_EXTRACTIONS);
         } else {
@@ -466,6 +467,7 @@ public class AnalysisActivity extends AppCompatActivity implements
         if (GiniVisionCoordinator.shouldShowGiniVisionNoResultsScreen(mDocument)) {
             final Intent noResultsActivity = new Intent(this, NoResultsActivity.class);
             noResultsActivity.putExtra(NoResultsActivity.EXTRA_IN_DOCUMENT, mDocument);
+            noResultsActivity.setExtrasClassLoader(AnalysisActivity.class.getClassLoader());
             startActivity(noResultsActivity);
             setResult(RESULT_NO_EXTRACTIONS);
         } else {

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
@@ -720,12 +720,14 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
         reviewIntent.putExtra(
                 ReviewActivity.EXTRA_IN_BACK_BUTTON_SHOULD_CLOSE_LIBRARY,
                 mBackButtonShouldCloseLibrary);
+        reviewIntent.setExtrasClassLoader(CameraActivity.class.getClassLoader());
         startActivityForResult(reviewIntent, REVIEW_DOCUMENT_REQUEST);
     }
 
     private void startAnalysisActivity(@NonNull final Document document) {
         final Intent analysisIntent = new Intent(mAnalyzeDocumentActivityIntent);
         analysisIntent.putExtra(AnalysisActivity.EXTRA_IN_DOCUMENT, document);
+        analysisIntent.setExtrasClassLoader(CameraActivity.class.getClassLoader());
         startActivityForResult(analysisIntent, ANALYSE_DOCUMENT_REQUEST);
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -1067,6 +1067,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         }
         fileChooserIntent.putExtra(FileChooserActivity.EXTRA_IN_DOCUMENT_IMPORT_FILE_TYPES,
                 enabledFileTypes);
+        fileChooserIntent.setExtrasClassLoader(CameraFragmentImpl.class.getClassLoader());
         mFragment.startActivityForResult(fileChooserIntent, REQ_CODE_CHOOSE_FILE);
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
@@ -334,6 +334,7 @@ public class ReviewActivity extends AppCompatActivity implements ReviewFragmentL
             if (GiniVisionCoordinator.shouldShowGiniVisionNoResultsScreen(document)) {
                 final Intent noResultsActivity = new Intent(this, NoResultsActivity.class);
                 noResultsActivity.putExtra(NoResultsActivity.EXTRA_IN_DOCUMENT, mDocument);
+                noResultsActivity.setExtrasClassLoader(ReviewActivity.class.getClassLoader());
                 startActivity(noResultsActivity);
                 setResult(RESULT_NO_EXTRACTIONS);
             } else {
@@ -348,6 +349,8 @@ public class ReviewActivity extends AppCompatActivity implements ReviewFragmentL
                         AnalysisActivity.EXTRA_IN_DOCUMENT_ANALYSIS_ERROR_MESSAGE,
                         errorMessage);
             }
+            mAnalyzeDocumentActivityIntent.setExtrasClassLoader(
+                    ReviewActivity.class.getClassLoader());
             startActivityForResult(mAnalyzeDocumentActivityIntent, ANALYSE_DOCUMENT_REQUEST);
         }
     }
@@ -492,6 +495,7 @@ public class ReviewActivity extends AppCompatActivity implements ReviewFragmentL
         if (GiniVisionCoordinator.shouldShowGiniVisionNoResultsScreen(document)) {
             final Intent noResultsActivity = new Intent(this, NoResultsActivity.class);
             noResultsActivity.putExtra(NoResultsActivity.EXTRA_IN_DOCUMENT, mDocument);
+            noResultsActivity.setExtrasClassLoader(ReviewActivity.class.getClassLoader());
             startActivity(noResultsActivity);
             setResult(RESULT_NO_EXTRACTIONS);
         } else {

--- a/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewActivity.java
@@ -270,6 +270,7 @@ public class MultiPageReviewActivity extends AppCompatActivity implements
         }
         final Intent intent = new Intent(this, AnalysisActivity.class);
         intent.putExtra(AnalysisActivity.EXTRA_IN_DOCUMENT, multiPageDocument);
+        intent.setExtrasClassLoader(MultiPageReviewActivity.class.getClassLoader());
         startActivityForResult(intent, ANALYSE_DOCUMENT_REQUEST);
     }
 


### PR DESCRIPTION
On some Samsung devices setting parcelable extras on intents causes ClassNotFoundExceptions when unmarshalling. The [fix](https://stackoverflow.com/a/28589962/276129) is to add the class loader from one of the own classes to the extras bundle.

### How to test
Could not reproduce it, but according to others this fix should work.

### Ticket 
[PIA-326](https://ginis.atlassian.net/browse/PIA-326)
