### PR TITLE
Pia 375 open application settings crash

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <option name="RIGHT_MARGIN" value="100" />
     <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="BLANK_LINES_AROUND_FIELD" value="1" />
@@ -27,9 +26,6 @@
     <option name="DOWHILE_BRACE_FORCE" value="3" />
     <option name="WHILE_BRACE_FORCE" value="3" />
     <option name="FOR_BRACE_FORCE" value="3" />
-    <AndroidXmlCodeStyleSettings>
-      <option name="USE_CUSTOM_SETTINGS" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
@@ -37,9 +33,6 @@
       <option name="GENERATE_FINAL_PARAMETERS" value="true" />
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
-      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
-        <value />
-      </option>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
           <package name="android" withSubpackages="true" static="true" />
@@ -96,9 +89,6 @@
       <option name="JD_P_AT_EMPTY_LINES" value="false" />
     </JavaCodeStyleSettings>
     <XML>
-      <option name="XML_KEEP_LINE_BREAKS" value="false" />
-      <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-      <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <ADDITIONAL_INDENT_OPTIONS fileType="java">
@@ -470,7 +460,6 @@
       </arrangement>
     </codeStyleSettings>
     <codeStyleSettings language="XML">
-      <option name="FORCE_REARRANGE_MODE" value="1" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,7 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <settings>
-    <option name="PROJECT_PROFILE" value="Project Default" />
-    <option name="USE_PROJECT_PROFILE" value="true" />
-    <version value="1.0" />
-  </settings>
-</component>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath('com.dicedmelon.gradle:jacoco-android:0.1.4') {
             exclude group: 'org.codehaus.groovy', module: 'groovy-all'
         }

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVisionBasePresenter.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVisionBasePresenter.java
@@ -1,6 +1,6 @@
 package net.gini.android.vision;
 
-import android.app.Application;
+import android.app.Activity;
 import android.support.annotation.NonNull;
 
 /**
@@ -10,17 +10,17 @@ import android.support.annotation.NonNull;
  */
 public abstract class GiniVisionBasePresenter<V extends GiniVisionBaseView> {
 
-    private final Application mApp;
+    private final Activity mActivity;
     private final V mView;
 
-    protected GiniVisionBasePresenter(@NonNull final Application app, @NonNull final V view) {
-        mApp = app;
+    protected GiniVisionBasePresenter(@NonNull final Activity activity, @NonNull final V view) {
+        mActivity = activity;
         mView = view;
     }
 
     @NonNull
-    public Application getApp() {
-        return mApp;
+    public Activity getActivity() {
+        return mActivity;
     }
 
     @NonNull

--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisFragmentImpl.java
@@ -56,13 +56,14 @@ class AnalysisFragmentImpl extends AnalysisScreenContract.View {
         if (mFragment.getActivity() == null) {
             throw new IllegalStateException("Missing activity for fragment.");
         }
-        createPresenter(document, documentAnalysisErrorMessage); // NOPMD - overridable for testing
+        createPresenter(mFragment.getActivity(), document,
+                documentAnalysisErrorMessage); // NOPMD - overridable for testing
     }
 
     @VisibleForTesting
-    void createPresenter(@NonNull final Document document,
+    void createPresenter(@NonNull final Activity activity, @NonNull final Document document,
             final String documentAnalysisErrorMessage) {
-        new AnalysisScreenPresenter(mFragment.getActivity().getApplication(), this, document,
+        new AnalysisScreenPresenter(activity, this, document,
                 documentAnalysisErrorMessage);
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisScreenContract.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisScreenContract.java
@@ -1,6 +1,6 @@
 package net.gini.android.vision.analysis;
 
-import android.app.Application;
+import android.app.Activity;
 import android.content.DialogInterface;
 import android.graphics.Bitmap;
 import android.support.annotation.NonNull;
@@ -62,9 +62,9 @@ interface AnalysisScreenContract {
     abstract class Presenter extends GiniVisionBasePresenter<View> implements
             AnalysisFragmentInterface {
 
-        Presenter(@NonNull final Application app,
+        Presenter(@NonNull final Activity activity,
                 @NonNull final View view) {
-            super(app, view);
+            super(activity, view);
         }
 
         abstract void finish();

--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisScreenPresenter.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisScreenPresenter.java
@@ -1,6 +1,6 @@
 package net.gini.android.vision.analysis;
 
-import android.app.Application;
+import android.app.Activity;
 import android.content.DialogInterface;
 import android.graphics.Bitmap;
 import android.net.Uri;
@@ -85,22 +85,22 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
     private boolean mAnalysisCompleted;
 
     AnalysisScreenPresenter(
-            @NonNull final Application app,
+            @NonNull final Activity activity,
             @NonNull final AnalysisScreenContract.View view,
             @NonNull final Document document,
             @Nullable final String documentAnalysisErrorMessage) {
-        this(app, view, document, documentAnalysisErrorMessage,
-                new AnalysisInteractor(app));
+        this(activity, view, document, documentAnalysisErrorMessage,
+                new AnalysisInteractor(activity.getApplication()));
     }
 
     @VisibleForTesting
     AnalysisScreenPresenter(
-            @NonNull final Application app,
+            @NonNull final Activity activity,
             @NonNull final AnalysisScreenContract.View view,
             @NonNull final Document document,
             @Nullable final String documentAnalysisErrorMessage,
             @NonNull final AnalysisInteractor analysisInteractor) {
-        super(app, view);
+        super(activity, view);
         view.setPresenter(this);
         mMultiPageDocument = asMultiPageDocument(document);
         // Tag the documents to be able to clean up the automatically parcelled data
@@ -198,7 +198,7 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
 
     @VisibleForTesting
     void clearSavedImages() {
-        ImageDiskStore.clear(getApp());
+        ImageDiskStore.clear(getActivity());
     }
 
     @Override
@@ -263,7 +263,7 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
     String getPdfFilename(final PdfDocument pdfDocument) {
         final Uri uri = pdfDocument.getUri();
         try {
-            return UriHelper.getFilenameFromUri(uri, getApp());
+            return UriHelper.getFilenameFromUri(uri, getActivity());
         } catch (final IllegalStateException e) { // NOPMD
             // Ignore
         }
@@ -310,7 +310,7 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
     CompletableFuture<Void> showAlertIfOpenWithDocumentAndAppIsDefault(
             @NonNull final GiniVisionDocument document,
             @NonNull final FileImportHelper.ShowAlertCallback showAlertCallback) {
-        return FileImportHelper.showAlertIfOpenWithDocumentAndAppIsDefault(getApp(), document,
+        return FileImportHelper.showAlertIfOpenWithDocumentAndAppIsDefault(getActivity(), document,
                 showAlertCallback);
     }
 
@@ -358,7 +358,7 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
 
     private void loadDocumentData() {
         LOG.debug("Loading document data");
-        mMultiPageDocument.loadData(getApp(),
+        mMultiPageDocument.loadData(getActivity(),
                 new AsyncCallback<byte[], Exception>() {
                     @Override
                     public void onSuccess(final byte[] result) {
@@ -424,11 +424,11 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
             if (filename != null) {
                 getView().showPdfTitle(filename);
             }
-            mDocumentRenderer.getPageCount(getApp(), new AsyncCallback<Integer, Exception>() {
+            mDocumentRenderer.getPageCount(getActivity(), new AsyncCallback<Integer, Exception>() {
                 @Override
                 public void onSuccess(final Integer result) {
                     if (result > 0) {
-                        final String pageCount = getApp().getResources().getQuantityString(
+                        final String pageCount = getActivity().getResources().getQuantityString(
                                 R.plurals.gv_analysis_pdf_pages, result, result);
                         getView().showPdfPageCount(pageCount);
                     } else {
@@ -451,7 +451,7 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
 
     private void showDocument() {
         LOG.debug("Rendering the document");
-        mDocumentRenderer.toBitmap(getApp(), getView().getPdfPreviewSize(),
+        mDocumentRenderer.toBitmap(getActivity(), getView().getPdfPreviewSize(),
                 new DocumentRenderer.Callback() {
                     @Override
                     public void onBitmapReady(@Nullable final Bitmap bitmap,
@@ -468,7 +468,7 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
     private void showErrorIfAvailableAndAnalyzeDocument() {
         if (mDocumentAnalysisErrorMessage != null) {
             showError(mDocumentAnalysisErrorMessage,
-                    getApp().getString(
+                    getActivity().getString(
                             R.string.gv_document_analysis_error_retry),
                     new View.OnClickListener() {
                         @Override
@@ -482,8 +482,8 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
     }
 
     private void handleAnalysisError() {
-        showError(getApp().getString(R.string.gv_document_analysis_error),
-                getApp().getString(R.string.gv_document_analysis_error_retry),
+        showError(getActivity().getString(R.string.gv_document_analysis_error),
+                getActivity().getString(R.string.gv_document_analysis_error_retry),
                 new View.OnClickListener() {
                     @Override
                     public void onClick(final View v) {

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -1798,7 +1798,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         if (activity == null) {
             return;
         }
-        ApplicationHelper.startApplicationDetailsSettings(activity.getApplication());
+        ApplicationHelper.startApplicationDetailsSettings(activity);
     }
 
     private void initCameraController(final Activity activity) {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/fileimport/FileChooserActivity.java
@@ -401,7 +401,7 @@ public class FileChooserActivity extends AppCompatActivity implements AlertDialo
     }
 
     private void showAppDetailsSettingsScreen() {
-        ApplicationHelper.startApplicationDetailsSettings(getApplication());
+        ApplicationHelper.startApplicationDetailsSettings(this);
     }
 
     @Override

--- a/ginivision/src/main/java/net/gini/android/vision/internal/util/ApplicationHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/util/ApplicationHelper.java
@@ -2,6 +2,7 @@ package net.gini.android.vision.internal.util;
 
 import static net.gini.android.vision.internal.util.ContextHelper.getClientApplicationId;
 
+import android.app.Activity;
 import android.app.Application;
 import android.content.ComponentName;
 import android.content.Intent;
@@ -23,11 +24,11 @@ import java.util.ArrayList;
  */
 public final class ApplicationHelper {
 
-    public static void startApplicationDetailsSettings(@NonNull final Application app) {
+    public static void startApplicationDetailsSettings(@NonNull final Activity activity) {
         final Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-        final Uri uri = Uri.fromParts("package", getClientApplicationId(app), null);
+        final Uri uri = Uri.fromParts("package", getClientApplicationId(activity), null);
         intent.setData(uri);
-        app.startActivity(intent);
+        activity.startActivity(intent);
     }
 
     public static boolean isDefaultForMimeType(@NonNull final Application app,

--- a/ginivision/src/main/java/net/gini/android/vision/internal/util/FileImportHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/util/FileImportHelper.java
@@ -3,6 +3,7 @@ package net.gini.android.vision.internal.util;
 import static net.gini.android.vision.internal.util.ApplicationHelper.isDefaultForMimeType;
 import static net.gini.android.vision.internal.util.ApplicationHelper.startApplicationDetailsSettings;
 
+import android.app.Activity;
 import android.app.Application;
 import android.content.DialogInterface;
 import android.support.annotation.NonNull;
@@ -28,24 +29,25 @@ import jersey.repackaged.jsr166e.CompletableFuture;
 public final class FileImportHelper {
 
     public static CompletableFuture<Void> showAlertIfOpenWithDocumentAndAppIsDefault(
-            @NonNull final Application app,
+            @NonNull final Activity activity,
             @NonNull final GiniVisionDocument document,
             @NonNull final ShowAlertCallback showAlertCallback) {
         final CompletableFuture<Void> alertCompletion = new CompletableFuture<>();
         if (document.getImportMethod() == Document.ImportMethod.OPEN_WITH
-                && isDefaultForMimeType(app, document.getMimeType())) {
-            final String fileType = fileTypeForMimeType(app, document.getMimeType());
+                && isDefaultForMimeType(activity.getApplication(), document.getMimeType())) {
+            final String fileType = fileTypeForMimeType(activity.getApplication(),
+                    document.getMimeType());
             showAlertCallback.showAlertDialog(
-                    app.getString(R.string.gv_file_import_default_app_dialog_message,
+                    activity.getString(R.string.gv_file_import_default_app_dialog_message,
                             fileType),
-                    app.getString(R.string.gv_file_import_default_app_dialog_positive_button),
+                    activity.getString(R.string.gv_file_import_default_app_dialog_positive_button),
                     new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(final DialogInterface dialog, final int which) {
-                            startApplicationDetailsSettings(app);
+                            startApplicationDetailsSettings(activity);
                         }
                     },
-                    app.getString(R.string.gv_file_import_default_app_dialog_negative_button),
+                    activity.getString(R.string.gv_file_import_default_app_dialog_negative_button),
                     new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(final DialogInterface dialog, final int which) {

--- a/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingFragmentImpl.java
@@ -1,6 +1,7 @@
 package net.gini.android.vision.onboarding;
 
 import android.animation.Animator;
+import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -46,12 +47,16 @@ class OnboardingFragmentImpl extends OnboardingScreenContract.View {
     public OnboardingFragmentImpl(final OnboardingFragmentImplCallback fragment,
             final boolean showEmptyLastPage, final ArrayList<OnboardingPage> pages) { // NOPMD
         mFragment = fragment;
-        initPresenter(pages, showEmptyLastPage);
+        if (mFragment.getActivity() == null) {
+            throw new IllegalStateException("Missing activity for fragment.");
+        }
+        initPresenter(mFragment.getActivity(), pages, showEmptyLastPage);
     }
 
-    private void initPresenter(@Nullable final ArrayList<OnboardingPage> pages, // NOPMD - Bundle
+    private void initPresenter(@NonNull final Activity activity,
+            @Nullable final ArrayList<OnboardingPage> pages, // NOPMD - Bundle
             final boolean showEmptyLastPage) {
-        createPresenter();
+        createPresenter(activity);
         if (showEmptyLastPage) {
             getPresenter().addEmptyLastPage();
         }
@@ -61,8 +66,8 @@ class OnboardingFragmentImpl extends OnboardingScreenContract.View {
     }
 
     @VisibleForTesting
-    void createPresenter() {
-        new OnboardingScreenPresenter(mFragment.getActivity().getApplication(), this);
+    void createPresenter(@NonNull final Activity activity) {
+        new OnboardingScreenPresenter(activity, this);
     }
 
     @Override

--- a/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingPageContract.java
+++ b/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingPageContract.java
@@ -1,6 +1,6 @@
 package net.gini.android.vision.onboarding;
 
-import android.app.Application;
+import android.app.Activity;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
@@ -27,9 +27,9 @@ interface OnboardingPageContract {
     abstract class Presenter extends GiniVisionBasePresenter<View> {
 
         Presenter(
-                @NonNull final Application app,
+                @NonNull final Activity activity,
                 @NonNull final View view) {
-            super(app, view);
+            super(activity, view);
         }
 
         abstract void setPage(@NonNull final OnboardingPage page);

--- a/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingPageFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingPageFragmentImpl.java
@@ -33,16 +33,20 @@ class OnboardingPageFragmentImpl extends OnboardingPageContract.View {
     public OnboardingPageFragmentImpl(@NonNull final FragmentImplCallback fragment,
             @NonNull final OnboardingPage page) {
         mFragment = fragment;
-        initPresenter(page);
+        if (mFragment.getActivity() == null) {
+            throw new IllegalStateException("Missing activity for fragment.");
+        }
+        initPresenter(mFragment.getActivity(), page);
     }
 
-    private void initPresenter(@NonNull final OnboardingPage page) {
-        createPresenter();
+    private void initPresenter(@NonNull final Activity activity,
+            @NonNull final OnboardingPage page) {
+        createPresenter(activity);
         getPresenter().setPage(page);
     }
 
-    private void createPresenter() {
-        new OnboardingPagePresenter(mFragment.getActivity().getApplication(), this);
+    private void createPresenter(@NonNull final Activity activity) {
+        new OnboardingPagePresenter(activity, this);
     }
 
     @Override

--- a/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingPagePresenter.java
+++ b/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingPagePresenter.java
@@ -1,6 +1,6 @@
 package net.gini.android.vision.onboarding;
 
-import android.app.Application;
+import android.app.Activity;
 import android.support.annotation.NonNull;
 
 import net.gini.android.vision.internal.util.ContextHelper;
@@ -15,9 +15,9 @@ class OnboardingPagePresenter extends OnboardingPageContract.Presenter {
     private OnboardingPage mPage;
 
     OnboardingPagePresenter(
-            @NonNull final Application app,
+            @NonNull final Activity activity,
             @NonNull final OnboardingPageContract.View view) {
-        super(app, view);
+        super(activity, view);
         view.setPresenter(this);
     }
 
@@ -44,7 +44,7 @@ class OnboardingPagePresenter extends OnboardingPageContract.Presenter {
         if (mPage.getImageResId() == 0) {
             return;
         }
-        final boolean rotated = !ContextHelper.isPortraitOrientation(getApp())
+        final boolean rotated = !ContextHelper.isPortraitOrientation(getActivity())
                 && mPage.shouldRotateImageForLandscape();
         getView().showImage(mPage.getImageResId(), rotated);
     }

--- a/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingScreenContract.java
+++ b/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingScreenContract.java
@@ -1,6 +1,6 @@
 package net.gini.android.vision.onboarding;
 
-import android.app.Application;
+import android.app.Activity;
 import android.support.annotation.NonNull;
 
 import net.gini.android.vision.GiniVisionBasePresenter;
@@ -34,9 +34,9 @@ interface OnboardingScreenContract {
             OnboardingFragmentInterface {
 
         Presenter(
-                @NonNull final Application app,
+                @NonNull final Activity activity,
                 @NonNull final View view) {
-            super(app, view);
+            super(activity, view);
         }
 
         abstract void setCustomPages(@NonNull final List<OnboardingPage> pages);

--- a/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingScreenPresenter.java
+++ b/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingScreenPresenter.java
@@ -2,7 +2,7 @@ package net.gini.android.vision.onboarding;
 
 import static net.gini.android.vision.internal.util.ContextHelper.isTablet;
 
-import android.app.Application;
+import android.app.Activity;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
@@ -33,15 +33,15 @@ class OnboardingScreenPresenter extends OnboardingScreenContract.Presenter {
     private boolean mShowEmptyLastPage;
     private int mCurrentPageIndex;
 
-    OnboardingScreenPresenter(@NonNull final Application app,
+    OnboardingScreenPresenter(@NonNull final Activity activity,
             @NonNull final OnboardingScreenContract.View view) {
-        super(app, view);
+        super(activity, view);
         view.setPresenter(this);
         mPages = getDefaultPages();
     }
 
     private List<OnboardingPage> getDefaultPages() {
-        if (isTablet(getApp())) {
+        if (isTablet(getActivity())) {
             return DefaultPagesTablet.asArrayList();
         } else {
             return DefaultPagesPhone.asArrayList();

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
@@ -177,7 +177,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         if (activity == null) {
             return;
         }
-        showAlertIfOpenWithDocumentAndAppIsDefault(activity.getApplication(), mDocument,
+        showAlertIfOpenWithDocumentAndAppIsDefault(activity, mDocument,
                 new FileImportHelper.ShowAlertCallback() {
                     @Override
                     public void showAlertDialog(@NonNull final String message,

--- a/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewFragment.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewFragment.java
@@ -529,7 +529,7 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
         if (!mPreviewsShown) {
             observeViewTree();
         }
-        showAlertIfOpenWithDocumentAndAppIsDefault(activity.getApplication(),
+        showAlertIfOpenWithDocumentAndAppIsDefault(activity,
                 mMultiPageDocument, new FileImportHelper.ShowAlertCallback() {
                     @Override
                     public void showAlertDialog(@NonNull final String message,

--- a/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisFragmentImplTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisFragmentImplTest.java
@@ -21,6 +21,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibilit
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
+import android.app.Activity;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.graphics.Bitmap;
@@ -133,11 +134,14 @@ public class AnalysisFragmentImplTest {
                         final AnalysisFragmentImpl analysisFragmentImpl = new AnalysisFragmentImpl(
                                 fragment,
                                 document, null) {
+
                             @Override
-                            void createPresenter(@NonNull final Document document,
+                            void createPresenter(@NonNull final Activity activity,
+                                    @NonNull final Document document,
                                     final String documentAnalysisErrorMessage) {
                                 setPresenter(presenter);
                             }
+
                         };
                         analysisFragmentImplRef.set(analysisFragmentImpl);
                         return analysisFragmentImpl;

--- a/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisScreenPresenterTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisScreenPresenterTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import android.app.Application;
+import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.res.Resources;
@@ -70,7 +70,7 @@ import jersey.repackaged.jsr166e.CompletableFuture;
 public class AnalysisScreenPresenterTest {
 
     @Mock
-    private Application mApp;
+    private Activity mActivity;
     @Mock
     private AnalysisScreenContract.View mView;
 
@@ -145,7 +145,7 @@ public class AnalysisScreenPresenterTest {
             }
         };
         if (analysisInteractor == null) {
-            return new AnalysisScreenPresenter(mApp, mView, document,
+            return new AnalysisScreenPresenter(mActivity, mView, document,
                     documentAnalysisErrorMessage) {
                 @Override
                 void createDocumentRenderer() {
@@ -153,7 +153,8 @@ public class AnalysisScreenPresenterTest {
                 }
             };
         } else {
-            return new AnalysisScreenPresenter(mApp, mView, document, documentAnalysisErrorMessage,
+            return new AnalysisScreenPresenter(mActivity, mView, document,
+                    documentAnalysisErrorMessage,
                     analysisInteractor) {
                 @Override
                 void createDocumentRenderer() {
@@ -296,7 +297,7 @@ public class AnalysisScreenPresenterTest {
         final AnalysisScreenPresenter presenter = spy(createPresenterWithEmptyImageDocument());
         final File filesDir = spy(new File("file:///gv-images/12343.jpg"));
         when(filesDir.exists()).thenReturn(true);
-        when(mApp.getFilesDir()).thenReturn(filesDir);
+        when(mActivity.getFilesDir()).thenReturn(filesDir);
 
         // When
         presenter.onDocumentAnalyzed();
@@ -340,7 +341,7 @@ public class AnalysisScreenPresenterTest {
         presenter.start();
 
         // Then
-        verify(document).loadData(eq(mApp), any(AsyncCallback.class));
+        verify(document).loadData(eq(mActivity), any(AsyncCallback.class));
     }
 
     @Test
@@ -398,7 +399,7 @@ public class AnalysisScreenPresenterTest {
         final String pdfPageCountString = pdfPageCount + " pages";
         final Resources resources = mock(Resources.class);
         when(resources.getQuantityString(anyInt(), anyInt(), any())).thenReturn(pdfPageCountString);
-        when(mApp.getResources()).thenReturn(resources);
+        when(mActivity.getResources()).thenReturn(resources);
 
         final AnalysisScreenPresenter presenter = spy(
                 createPresenter(pdfDocument, pdfPageCount, null));
@@ -563,7 +564,7 @@ public class AnalysisScreenPresenterTest {
     @Test
     public void should_stopScanAnimation_whenAnalysisFinished() throws Exception {
         // Given
-        when(mApp.getString(anyInt())).thenReturn("A String");
+        when(mActivity.getString(anyInt())).thenReturn("A String");
 
         final ImageDocument imageDocument = new ImageDocumentFake();
 
@@ -601,7 +602,7 @@ public class AnalysisScreenPresenterTest {
     @Test
     public void should_showError_whenAnalysisFailed() throws Exception {
         // Given
-        when(mApp.getString(anyInt())).thenReturn("A String");
+        when(mActivity.getString(anyInt())).thenReturn("A String");
 
         final ImageDocument imageDocument = new ImageDocumentFake();
 
@@ -624,7 +625,7 @@ public class AnalysisScreenPresenterTest {
     public void should_requestProceedingToNoExtractionsScreen_whenAnalysisSucceeded_withoutExtractions()
             throws Exception {
         // Given
-        when(mApp.getString(anyInt())).thenReturn("A String");
+        when(mActivity.getString(anyInt())).thenReturn("A String");
 
         final ImageDocument imageDocument = new ImageDocumentFake();
 
@@ -650,7 +651,7 @@ public class AnalysisScreenPresenterTest {
     public void should_returnExtractions_whenAnalysisSucceeded_withExtractions()
             throws Exception {
         // Given
-        when(mApp.getString(anyInt())).thenReturn("A String");
+        when(mActivity.getString(anyInt())).thenReturn("A String");
 
         final ImageDocument imageDocument = new ImageDocumentFake();
 
@@ -678,7 +679,7 @@ public class AnalysisScreenPresenterTest {
     @Test
     public void should_requestDocumentAnalysis_whenNoNetworkService_wasSet() throws Exception {
         // Given
-        when(mApp.getString(anyInt())).thenReturn("A String");
+        when(mActivity.getString(anyInt())).thenReturn("A String");
 
         final ImageDocument imageDocument = new ImageDocumentFake();
 
@@ -703,7 +704,7 @@ public class AnalysisScreenPresenterTest {
     @Test
     public void should_clearSavedImages_afterAnalysis_whenNetworkService_wasSet() throws Exception {
         // Given
-        when(mApp.getString(anyInt())).thenReturn("A String");
+        when(mActivity.getString(anyInt())).thenReturn("A String");
 
         final ImageDocument imageDocument = new ImageDocumentFake();
 

--- a/ginivision/src/test/java/net/gini/android/vision/onboarding/OnboardingFragmentCompatTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/onboarding/OnboardingFragmentCompatTest.java
@@ -40,6 +40,7 @@ public class OnboardingFragmentCompatTest {
 
         final FragmentActivity activity = mock(FragmentActivity.class);
         when(activity.getApplication()).thenReturn(application);
+        when(activity.getResources()).thenReturn(mock(Resources.class));
 
         when(fragment.getActivity()).thenReturn(activity);
 

--- a/ginivision/src/test/java/net/gini/android/vision/onboarding/OnboardingFragmentImplTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/onboarding/OnboardingFragmentImplTest.java
@@ -18,6 +18,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withTagValue;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
+import android.app.Activity;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -84,10 +85,12 @@ public class OnboardingFragmentImplTest {
                             @NonNull final OnboardingFragmentCompat fragment) {
                         final OnboardingFragmentImpl onboardingFragmentImpl =
                                 new OnboardingFragmentImpl(fragment, showEmptyLastPage, pages) {
+
                                     @Override
-                                    void createPresenter() {
+                                    void createPresenter(@NonNull final Activity activity) {
                                         setPresenter(presenter);
                                     }
+
                                 };
                         onboardingFragmentImplRef.set(onboardingFragmentImpl);
                         return onboardingFragmentImpl;

--- a/ginivision/src/test/java/net/gini/android/vision/onboarding/OnboardingPagePresenterTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/onboarding/OnboardingPagePresenterTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import android.app.Application;
+import android.app.Activity;
 import android.content.res.Resources;
 import android.support.annotation.NonNull;
 
@@ -24,7 +24,7 @@ import org.mockito.Mock;
 public class OnboardingPagePresenterTest {
 
     @Mock
-    private Application mApp;
+    private Activity mActivity;
     @Mock
     private OnboardingPageContract.View mView;
 
@@ -57,9 +57,9 @@ public class OnboardingPagePresenterTest {
             final Boolean isPortrait) throws Exception {
         final Resources resources = mock(Resources.class);
         when(resources.getBoolean(R.bool.gv_is_portrait)).thenReturn(isPortrait);
-        when(mApp.getResources()).thenReturn(resources);
+        when(mActivity.getResources()).thenReturn(resources);
 
-        final OnboardingPagePresenter presenter = new OnboardingPagePresenter(mApp, mView);
+        final OnboardingPagePresenter presenter = new OnboardingPagePresenter(mActivity, mView);
         presenter.setPage(page);
 
         return presenter;

--- a/ginivision/src/test/java/net/gini/android/vision/onboarding/OnboardingScreenPresenterTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/onboarding/OnboardingScreenPresenterTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import android.app.Application;
+import android.app.Activity;
 import android.content.res.Resources;
 import android.support.annotation.NonNull;
 
@@ -31,7 +31,7 @@ import jersey.repackaged.jsr166e.CompletableFuture;
 public class OnboardingScreenPresenterTest {
 
     @Mock
-    private Application mApp;
+    private Activity mActivity;
     @Mock
     private OnboardingScreenContract.View mView;
 
@@ -54,9 +54,9 @@ public class OnboardingScreenPresenterTest {
     private OnboardingScreenPresenter createPresenter(final boolean isTablet) {
         final Resources resources = mock(Resources.class);
         when(resources.getBoolean(R.bool.gv_is_tablet)).thenReturn(isTablet);
-        when(mApp.getResources()).thenReturn(resources);
+        when(mActivity.getResources()).thenReturn(resources);
 
-        return new OnboardingScreenPresenter(mApp, mView);
+        return new OnboardingScreenPresenter(mActivity, mView);
     }
 
     @Test

--- a/gradle/codequality.gradle
+++ b/gradle/codequality.gradle
@@ -37,7 +37,7 @@ task findbugs(type: FindBugs, dependsOn: 'assembleDebug') {
     ignoreFailures = true
     effort = "max"
     excludeFilter = new File("${project.rootDir}/config/findbugs/findbugs-filter.xml")
-    classes = files("${project.projectDir}/build/intermediates/javac/debug/compileDebugJavaWithJavac/classes")
+    classes = files("${project.projectDir}/build/intermediates/javac/debug/classes")
 
     source 'src'
     include '**/*.java'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Apr 25 11:23:43 CEST 2019
+#Tue Oct 29 15:31:19 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
When the camera screen is launched without having camera permissions we ask the user to grant camera permissions by tapping a button to open the application details in the android settings app.

This caused a crash because `startActivity()` was called on the `Application` instance instead of the `Activity` instance.

Lots of files were touched in order to pass the `Activity` instance around instead of the `Application` one. The actual fix is [here](https://github.com/gini/gini-vision-lib-android/blob/9513b3f8de2d9f4332b3cdfb61f3b54e64e2581b/ginivision/src/main/java/net/gini/android/vision/internal/util/ApplicationHelper.java#L27-L31).

### Ticket 
[PIA-375](https://ginis.atlassian.net/browse/PIA-375)
