### PR TITLE
Fix price (amount) input number formatting

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/returnassistant/LineItemsHelper.kt
+++ b/ginivision/src/main/java/net/gini/android/vision/returnassistant/LineItemsHelper.kt
@@ -11,9 +11,8 @@ import java.util.*
  * Copyright (c) 2019 Gini GmbH.
  */
 
-val INTEGRAL_FORMAT = DecimalFormat("#")
+val INTEGRAL_FORMAT = DecimalFormat("#,###")
 val FRACTION_FORMAT = DecimalFormat(".00").apply { roundingMode = RoundingMode.DOWN }
-val AMOUNT_FORMAT = DecimalFormat("#.00")
 
 fun lineItemsSumIntegralAndFractionParts(
         lineItems: List<SelectableLineItem>): Pair<String, String> {

--- a/ginivision/src/main/java/net/gini/android/vision/returnassistant/details/LineItemDetailsFragment.kt
+++ b/ginivision/src/main/java/net/gini/android/vision/returnassistant/details/LineItemDetailsFragment.kt
@@ -10,10 +10,8 @@ import android.view.View
 import android.view.ViewGroup
 import kotlinx.android.synthetic.main.gv_fragment_line_item_details.*
 import net.gini.android.vision.R
-import net.gini.android.vision.returnassistant.AMOUNT_FORMAT
 import net.gini.android.vision.returnassistant.LineItem
 import net.gini.android.vision.returnassistant.SelectableLineItem
-import java.math.BigDecimal
 
 private const val ARG_SELECTABLE_LINE_ITEM = "GV_ARG_SELECTABLE_LINE_ITEM"
 
@@ -110,11 +108,7 @@ class LineItemDetailsFragment : Fragment(), LineItemDetailsScreenContract.View,
             })
         }
         amountTextWatcher = gv_amount.doAfterTextChanged {
-            presenter?.setAmount(try {
-                BigDecimal(it)
-            } catch (_: NumberFormatException) {
-                BigDecimal.ZERO
-            })
+            presenter?.setAmount(it)
         }
         gv_save_button.setOnClickListener {
             presenter?.save()
@@ -150,8 +144,8 @@ class LineItemDetailsFragment : Fragment(), LineItemDetailsScreenContract.View,
         gv_quantity.setText(quantity.toString())
     }
 
-    override fun showAmount(amount: BigDecimal, currency: String) {
-        gv_amount.setText(AMOUNT_FORMAT.format(amount))
+    override fun showAmount(amount: String, currency: String) {
+        gv_amount.setText(amount)
         gv_currency.text = currency
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/returnassistant/details/LineItemDetailsScreenContract.kt
+++ b/ginivision/src/main/java/net/gini/android/vision/returnassistant/details/LineItemDetailsScreenContract.kt
@@ -3,7 +3,6 @@ package net.gini.android.vision.returnassistant.details
 import android.app.Activity
 import net.gini.android.vision.GiniVisionBasePresenter
 import net.gini.android.vision.GiniVisionBaseView
-import java.math.BigDecimal
 
 /**
  * Created by Alpar Szotyori on 17.12.2019.
@@ -15,7 +14,7 @@ interface LineItemDetailsScreenContract {
     interface View : GiniVisionBaseView<Presenter> {
         fun showDescription(description: String)
         fun showQuantity(quantity: Int)
-        fun showAmount(amount: BigDecimal, currency: String)
+        fun showAmount(displayedAmount: String, currency: String)
         fun showCheckbox(selected: Boolean, quantity: Int)
         fun showTotalAmount(integralPart: String, fractionPart: String)
         fun enableSaveButton()
@@ -31,7 +30,7 @@ interface LineItemDetailsScreenContract {
         abstract fun deselectLineItem()
         abstract fun setDescription(description: String)
         abstract fun setQuantity(quantity: Int)
-        abstract fun setAmount(amount: BigDecimal)
+        abstract fun setAmount(displayedAmount: String)
         abstract fun save()
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/returnassistant/details/LineItemDetailsScreenPresenter.kt
+++ b/ginivision/src/main/java/net/gini/android/vision/returnassistant/details/LineItemDetailsScreenPresenter.kt
@@ -7,14 +7,20 @@ import net.gini.android.vision.returnassistant.details.LineItemDetailsScreenCont
 import net.gini.android.vision.returnassistant.details.LineItemDetailsScreenContract.View
 import net.gini.android.vision.returnassistant.lineItemTotalAmountIntegralAndFractionParts
 import java.math.BigDecimal
+import java.text.DecimalFormat
+import java.text.ParseException
 
 /**
  * Created by Alpar Szotyori on 17.12.2019.
  *
  * Copyright (c) 2019 Gini GmbH.
  */
+
+val AMOUNT_FORMAT = DecimalFormat("#,##0.00").apply { isParseBigDecimal = true }
+
 class LineItemDetailsScreenPresenter(activity: Activity, view: View,
-                                     var selectableLineItem: SelectableLineItem) :
+                                     var selectableLineItem: SelectableLineItem,
+                                     private val amountFormat: DecimalFormat = AMOUNT_FORMAT) :
         Presenter(activity, view) {
 
     override var listener: LineItemDetailsFragmentListener? = null
@@ -79,13 +85,18 @@ class LineItemDetailsScreenPresenter(activity: Activity, view: View,
         }
     }
 
-    override fun setAmount(amount: BigDecimal) {
+    override fun setAmount(displayedAmount: String) {
+        val amount = try {
+            amountFormat.parse(displayedAmount) as BigDecimal
+        } catch (_: ParseException) {
+            return
+        }
         if (selectableLineItem.lineItem.amount == amount) {
             return
         }
         selectableLineItem = selectableLineItem.copy(
                 lineItem = selectableLineItem.lineItem.copy(
-                        rawAmount = LineItem.createRawAmount(amount.toString(),
+                        rawAmount = LineItem.createRawAmount(amount,
                                 selectableLineItem.lineItem.rawCurrency)
                 )
         ).also {
@@ -107,7 +118,7 @@ class LineItemDetailsScreenPresenter(activity: Activity, view: View,
                 lineItem.run {
                     showDescription(description)
                     showQuantity(quantity)
-                    showAmount(amount, currency?.symbol ?: "")
+                    showAmount(amountFormat.format(amount), currency?.symbol ?: "")
                 }
                 showTotalAmount(this)
                 updateSaveButton(this, originalLineItem)

--- a/ginivision/src/main/res/layout/gv_fragment_line_item_details.xml
+++ b/ginivision/src/main/res/layout/gv_fragment_line_item_details.xml
@@ -101,6 +101,7 @@
                 android:gravity="end"
                 android:hint="@string/gv_return_assistant_line_item_details_amount_label"
                 android:inputType="numberDecimal"
+                android:digits="0123456789,."
                 android:selectAllOnFocus="true"
                 android:textAppearance="@style/GiniVisionTheme.ReturnAssistant.LineItemDetails.InputField.TextStyle"
                 tools:text="152.95" />

--- a/ginivision/src/test/java/net/gini/android/vision/returnassistant/LineItemTest.kt
+++ b/ginivision/src/test/java/net/gini/android/vision/returnassistant/LineItemTest.kt
@@ -5,6 +5,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.math.BigDecimal
+import java.util.*
 
 /**
  * Created by Alpar Szotyori on 17.12.2019.
@@ -27,5 +29,49 @@ class LineItemTest {
 
         // Then
         assertThat(fromParcel).isEqualTo(orig)
+    }
+
+    @Test
+    fun `should parse raw amount with dot decimal separator`() {
+        // Given
+        val lineItem = LineItem("id", "description", 3, "12.13:EUR")
+
+        // Then
+        assertThat(lineItem.amount).isEqualTo(BigDecimal("12.13"))
+        assertThat(lineItem.totalAmount).isEqualTo(BigDecimal("36.39"))
+        assertThat(lineItem.currency).isEqualTo(Currency.getInstance("EUR"))
+        assertThat(lineItem.rawCurrency).isEqualTo("EUR")
+    }
+
+    @Test
+    fun `should parse raw amount with comma decimal separator`() {
+        // Given
+        val lineItem = LineItem("id", "description", 3, "12,13:EUR")
+
+        // Then
+        assertThat(lineItem.amount).isEqualTo(BigDecimal("12.13"))
+        assertThat(lineItem.totalAmount).isEqualTo(BigDecimal("36.39"))
+        assertThat(lineItem.currency).isEqualTo(Currency.getInstance("EUR"))
+        assertThat(lineItem.rawCurrency).isEqualTo("EUR")
+    }
+
+    @Test
+    fun `should create raw amount in english format`() {
+        // Given
+        val rawAmount = LineItem.createRawAmount(BigDecimal("12.13"), "EUR")
+
+        // Then
+        assertThat(rawAmount).isEqualTo("12.13:EUR")
+    }
+
+    @Test
+    fun `should default amount to 0 when the raw amount format is not supported`() {
+        val lineItem = LineItem("id", "description", 3, "100,200.13:EUR")
+
+        // Then
+        assertThat(lineItem.amount).isEqualTo(BigDecimal("0"))
+        assertThat(lineItem.totalAmount).isEqualTo(BigDecimal("0"))
+        assertThat(lineItem.currency).isEqualTo(Currency.getInstance("EUR"))
+        assertThat(lineItem.rawCurrency).isEqualTo("EUR")
     }
 }


### PR DESCRIPTION
* Line item raw amount string (e.g. "31.99:EUR") parsing works for both dot and comma as decimal separator. When creating a raw amount from the modified amount then dot is used.
* Amounts are displayed to the user using the device's locale and with grouping separators.
* User input for amounts must be in the device's locale (in the same format as it was displayed the first time).

### How to test
Run the Screen API example app.

### Ticket 
[PIA-461](https://ginis.atlassian.net/browse/PIA-461)
