### PR TITLE
Line item extractions in the networking plugin

### DIFF
--- a/exampleShared/java/net/gini/android/vision/example/BaseExampleApp.java
+++ b/exampleShared/java/net/gini/android/vision/example/BaseExampleApp.java
@@ -92,6 +92,8 @@ public abstract class BaseExampleApp extends MultiDexApplication {
                 case DEFAULT:
                     mGiniVisionNetworkService = GiniVisionDefaultNetworkService.builder(this)
                             .setClientCredentials(clientId, clientSecret, "example.com")
+                            .setBaseUrl("https://api.stage.gini.net/") // TODO: remove after line items are live
+                            .setUserCenterBaseUrl("https://user.stage.gini.net/") // TODO: remove after line items are live
                             .setDocumentMetadata(documentMetadata)
                             .build();
                     break;

--- a/ginivision-network/build.gradle
+++ b/ginivision-network/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation deps.supportAnnotations
     implementation project(path: ':ginivision')
-    api('net.gini:gini-android-sdk:2.3.0@aar') {
+    api('net.gini:gini-android-sdk:2.4.0@aar') {
         transitive = true
     }
 

--- a/ginivision-network/src/main/java/net/gini/android/vision/network/model/SpecificExtractionMapper.java
+++ b/ginivision-network/src/main/java/net/gini/android/vision/network/model/SpecificExtractionMapper.java
@@ -4,7 +4,9 @@ import android.support.annotation.NonNull;
 
 import net.gini.android.models.SpecificExtraction;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -46,12 +48,22 @@ public final class SpecificExtractionMapper {
      * @return a Gini Vision Library {@link GiniVisionSpecificExtraction}
      */
     @NonNull
-    public static GiniVisionSpecificExtraction map(
+    private static GiniVisionSpecificExtraction map(
             @NonNull final SpecificExtraction source) {
         return new GiniVisionSpecificExtraction(source.getName(), source.getValue(),
                 source.getEntity(),
                 BoxMapper.map(source.getBox()),
-                ExtractionMapper.mapListToGVL(source.getCandidate()));
+                ExtractionMapper.mapListToGVL(source.getCandidate()),
+                mapListToGVL(source.getSpecificExtractions()));
+    }
+
+    @NonNull
+    private static List<GiniVisionSpecificExtraction> mapListToGVL(final List<SpecificExtraction> specificExtractions) {
+        final List<GiniVisionSpecificExtraction> targetList = new ArrayList<>(specificExtractions.size());
+        for (final SpecificExtraction specificExtraction : specificExtractions) {
+            targetList.add(map(specificExtraction));
+        }
+        return targetList;
     }
 
     /**
@@ -85,7 +97,17 @@ public final class SpecificExtractionMapper {
             @NonNull final GiniVisionSpecificExtraction source) {
         return new SpecificExtraction(source.getName(), source.getValue(), source.getEntity(),
                 BoxMapper.map(source.getBox()),
-                ExtractionMapper.mapListToApiSdk(source.getCandidate()));
+                ExtractionMapper.mapListToApiSdk(source.getCandidate()),
+                mapListToApiSdk(source.getSpecificExtractions()));
+    }
+
+    @NonNull
+    private static List<SpecificExtraction> mapListToApiSdk(final List<GiniVisionSpecificExtraction> specificExtractions) {
+        final List<SpecificExtraction> targetList = new ArrayList<>(specificExtractions.size());
+        for (final GiniVisionSpecificExtraction specificExtraction : specificExtractions) {
+            targetList.add(map(specificExtraction));
+        }
+        return targetList;
     }
 
     private SpecificExtractionMapper() {

--- a/ginivision/src/main/java/net/gini/android/vision/network/model/GiniVisionSpecificExtraction.java
+++ b/ginivision/src/main/java/net/gini/android/vision/network/model/GiniVisionSpecificExtraction.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -37,6 +38,7 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
             };
     private final String mName;
     private final List<GiniVisionExtraction> mCandidates;
+    private final List<GiniVisionSpecificExtraction> mSpecificExtractions;
 
     /**
      * Value object for a specific extraction from the Gini API.
@@ -60,9 +62,34 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
             @NonNull final String entity,
             @Nullable final GiniVisionBox box,
             @NonNull final List<GiniVisionExtraction> candidates) {
+        this(name, value, entity, box, candidates, Collections.<GiniVisionSpecificExtraction>emptyList());
+    }
+
+    /**
+     * Value object for a specific extraction from the Gini API.
+     *
+     * @param name                The specific extraction's name, e.g. "amountToPay". See <a href="http://developer.gini.net/gini-api/html/document_extractions.html#available-specific-extractions">Available
+     *                            Specific Extractions</a> for a full list
+     * @param value               normalized textual representation of the text/information provided by the extraction value (e. g. bank
+     *                            number without spaces between the digits). Changing this value marks the extraction as dirty
+     * @param entity              key (primary identification) of an entity type (e.g. banknumber). See <a
+     *                            href="http://developer.gini.net/gini-api/html/document_extractions.html#available-extraction-entities">Extraction
+     *                            Entities</a> for a full list
+     * @param box                 (optional) bounding box containing the position of the extraction value on the document. Only available
+     *                            for some extractions. Changing this value marks the extraction as dirty
+     * @param candidates          A list containing other candidates for this specific extraction. Candidates are of the same entity as the
+     *                            found extraction
+     * @param specificExtractions A list of other specific extractions which are part of this one.
+     */
+    public GiniVisionSpecificExtraction(@NonNull final String name, @NonNull final String value,
+            @NonNull final String entity,
+            @Nullable final GiniVisionBox box,
+            @NonNull final List<GiniVisionExtraction> candidates,
+            @NonNull final List<GiniVisionSpecificExtraction> specificExtractions) {
         super(value, entity, box);
         mName = name;
         mCandidates = candidates;
+        mSpecificExtractions = specificExtractions;
     }
 
     private GiniVisionSpecificExtraction(final Parcel in) {
@@ -71,6 +98,9 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
         final List<GiniVisionExtraction> candidates = new ArrayList<>();
         in.readTypedList(candidates, GiniVisionExtraction.CREATOR);
         mCandidates = candidates;
+        final List<GiniVisionSpecificExtraction> specificExtractions = new ArrayList<>();
+        in.readTypedList(specificExtractions, GiniVisionSpecificExtraction.CREATOR);
+        mSpecificExtractions = specificExtractions;
     }
 
     @Override
@@ -83,6 +113,7 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
         super.writeToParcel(dest, flags);
         dest.writeString(mName);
         dest.writeTypedList(mCandidates);
+        dest.writeTypedList(mSpecificExtractions);
     }
 
     /**
@@ -103,11 +134,20 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
     }
 
 
+    /**
+     * @return a list containing the specific extractions which are part of this one
+     */
+    @NonNull
+    public List<GiniVisionSpecificExtraction> getSpecificExtractions() {
+        return mSpecificExtractions;
+    }
+
     @Override
     public String toString() {
         return "GiniVisionSpecificExtraction{"
                 + "mName='" + mName + '\''
                 + ", mCandidates=" + mCandidates
+                + ", mCandidates=" + mSpecificExtractions
                 + "} " + super.toString();
     }
 }

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
@@ -24,7 +24,6 @@ import net.gini.android.vision.GiniVisionDebug;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.ImportedFileValidationException;
 import net.gini.android.vision.camera.CameraActivity;
-import net.gini.android.vision.digitalinvoice.DigitalInvoiceActivity;
 import net.gini.android.vision.example.BaseExampleApp;
 import net.gini.android.vision.example.RuntimePermissionHandler;
 import net.gini.android.vision.onboarding.DefaultPagesPhone;
@@ -300,8 +299,7 @@ public class MainActivity extends AppCompatActivity {
         // Start for result in order to receive the error result, in case something went wrong, or the extractions
         // To receive the extractions add it to the result Intent in ReviewActivity#onAddDataToResult(Intent) or
         // AnalysisActivity#onAddDataToResult(Intent) and retrieve them here in onActivityResult()
-        final Intent debug = new Intent(this, DigitalInvoiceActivity.class);
-        startActivityForResult(debug, REQUEST_SCAN);
+        startActivityForResult(intent, REQUEST_SCAN);
     }
 
     private void configureGiniVision() {


### PR DESCRIPTION
Added support for line items to the networking plugin's default implementation.

**Note**: the networking plugin's default implementation won't compile until the Gini API SDK version 2.4.0 is not released. See this [PR](https://github.com/gini/gini-sdk-android/pull/18).

## How to test
Use the stage client `gini-mobile-test` (credentials in 1Password) with the Screen API example. Put a breakpoint [here](https://github.com/gini/gini-vision-lib-android/blob/8ad0dd10aead6ec2d70c053eccbedafbecf233c0/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisActivity.java#L459) and analyze an image or pdf. The extractions map should have a `lineItems` key with a `GiniVisionSpecificExtraction` which contains a list of `GiniVisionSpecificExtractions` for each line item. These line item "specific extractions" also contain a list of `GiniVisionSpecificExtractions` for each of their columns.

### Ticket 
[PIA-477](https://ginis.atlassian.net/browse/PIA-477)
