### PR TITLE
Line item extractions in the networking plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
             steps {
                 script {
                     avd.deleteCorrupt()
-                    avd.create("api-25-nexus-5x", "system-images;android-25;google_apis;x86", "Nexus 5X")
+                    avd.create("api-25-pixel", "system-images;android-25;google_apis;x86", "pixel")
                     avd.create("api-25-nexus-9", "system-images;android-25;google_apis;x86", "Nexus 9")
                 }
             }
@@ -107,7 +107,7 @@ pipeline {
             }
             steps {
                 script {
-                    def emulatorPort = emulator.start(avd.createName("api-25-nexus-5x"), "nexus_5x", "-prop persist.sys.language=en -prop persist.sys.country=US -gpu on -camera-back emulated -no-boot-anim -no-window -no-audio -snapshot snapshot1")
+                    def emulatorPort = emulator.start(avd.createName("api-25-pixel"), "pixel", "-prop persist.sys.language=en -prop persist.sys.country=US -gpu host -camera-back emulated -no-snapshot")
                     sh "echo $emulatorPort > emulator_port"
                     adb.setAnimationDurationScale("emulator-$emulatorPort", 0)
                     withEnv(["PATH+TOOLS=$ANDROID_HOME/tools", "PATH+TOOLS_BIN=$ANDROID_HOME/tools/bin", "PATH+PLATFORM_TOOLS=$ANDROID_HOME/platform-tools"]) {
@@ -144,7 +144,7 @@ pipeline {
             }
             steps {
                 script {
-                    def emulatorPort = emulator.start(avd.createName("api-25-nexus-9"), "nexus_9", "-prop persist.sys.language=en -prop persist.sys.country=US -gpu on -camera-back emulated -no-boot-anim -no-window -no-audio -snapshot snapshot1")
+                    def emulatorPort = emulator.start(avd.createName("api-25-nexus-9"), "nexus_9", "-prop persist.sys.language=en -prop persist.sys.country=US -gpu host -camera-back emulated -no-snapshot")
                     sh "echo $emulatorPort > emulator_port"
                     adb.setAnimationDurationScale("emulator-$emulatorPort", 0)
                     withEnv(["PATH+TOOLS=$ANDROID_HOME/tools", "PATH+TOOLS_BIN=$ANDROID_HOME/tools/bin", "PATH+PLATFORM_TOOLS=$ANDROID_HOME/platform-tools"]) {
@@ -325,12 +325,12 @@ pipeline {
                 archiveArtifacts 'screenapiexample/build/outputs/apk/screenapiexample-release.apk,componentapiexample/build/outputs/apk/componentapiexample-release.apk,screenapiexample/build/outputs/mapping/release/mapping.txt,componentapiexample/build/outputs/mapping/release/mapping.txt'
             }
         }
-        stage('Upload Example Apps to Hockeyapp') {
-            steps {
-                step([$class: 'HockeyappRecorder', applications: [[apiToken: SCREEN_API_EXAMPLE_APP_HOCKEYAPP_API_TOKEN, downloadAllowed: true, dsymPath: 'screenapiexample/build/outputs/mapping/release/mapping.txt', filePath: 'screenapiexample/build/outputs/apk/release/screenapiexample-release.apk', mandatory: false, notifyTeam: false, releaseNotesMethod: [$class: 'ChangelogReleaseNotes'], uploadMethod: [$class: 'AppCreation', publicPage: false]]], debugMode: false, failGracefully: false])
-                step([$class: 'HockeyappRecorder', applications: [[apiToken: COMPONENT_API_EXAMPLE_APP_HOCKEYAPP_API_TOKEN, downloadAllowed: true, dsymPath: 'componentapiexample/build/outputs/mapping/release/mapping.txt', filePath: 'componentapiexample/build/outputs/apk/release/componentapiexample-release.apk', mandatory: false, notifyTeam: false, releaseNotesMethod: [$class: 'ChangelogReleaseNotes'], uploadMethod: [$class: 'AppCreation', publicPage: false]]], debugMode: false, failGracefully: false])
-            }
-        }
+//        stage('Upload Example Apps to Hockeyapp') {
+//            steps {
+//                step([$class: 'HockeyappRecorder', applications: [[apiToken: SCREEN_API_EXAMPLE_APP_HOCKEYAPP_API_TOKEN, downloadAllowed: true, dsymPath: 'screenapiexample/build/outputs/mapping/release/mapping.txt', filePath: 'screenapiexample/build/outputs/apk/release/screenapiexample-release.apk', mandatory: false, notifyTeam: false, releaseNotesMethod: [$class: 'ChangelogReleaseNotes'], uploadMethod: [$class: 'AppCreation', publicPage: false]]], debugMode: false, failGracefully: false])
+//                step([$class: 'HockeyappRecorder', applications: [[apiToken: COMPONENT_API_EXAMPLE_APP_HOCKEYAPP_API_TOKEN, downloadAllowed: true, dsymPath: 'componentapiexample/build/outputs/mapping/release/mapping.txt', filePath: 'componentapiexample/build/outputs/apk/release/componentapiexample-release.apk', mandatory: false, notifyTeam: false, releaseNotesMethod: [$class: 'ChangelogReleaseNotes'], uploadMethod: [$class: 'AppCreation', publicPage: false]]], debugMode: false, failGracefully: false])
+//            }
+//        }
         stage('Release Documentation') {
             when {
                 expression {

--- a/exampleShared/java/net/gini/android/vision/example/BaseExampleApp.java
+++ b/exampleShared/java/net/gini/android/vision/example/BaseExampleApp.java
@@ -92,6 +92,8 @@ public abstract class BaseExampleApp extends MultiDexApplication {
                 case DEFAULT:
                     mGiniVisionNetworkService = GiniVisionDefaultNetworkService.builder(this)
                             .setClientCredentials(clientId, clientSecret, "example.com")
+                            .setBaseUrl("https://api.stage.gini.net/") // TODO: remove after line items are live
+                            .setUserCenterBaseUrl("https://user.stage.gini.net/") // TODO: remove after line items are live
                             .setDocumentMetadata(documentMetadata)
                             .build();
                     break;

--- a/ginivision-accounting-network/src/main/java/net/gini/android/vision/accounting/network/GiniVisionAccountingNetworkApi.java
+++ b/ginivision-accounting-network/src/main/java/net/gini/android/vision/accounting/network/GiniVisionAccountingNetworkApi.java
@@ -9,6 +9,7 @@ import net.gini.android.vision.internal.camera.api.UIExecutor;
 import net.gini.android.vision.network.Error;
 import net.gini.android.vision.network.GiniVisionNetworkApi;
 import net.gini.android.vision.network.GiniVisionNetworkCallback;
+import net.gini.android.vision.network.model.GiniVisionCompoundExtraction;
 import net.gini.android.vision.network.model.GiniVisionSpecificExtraction;
 
 import org.json.JSONException;
@@ -108,6 +109,13 @@ public class GiniVisionAccountingNetworkApi implements GiniVisionNetworkApi {
             LOG.error("Send feedback failed: no Gini Api Document available");
             callback.failure(new Error("Feedback not set: no Gini Api Document available"));
         }
+    }
+
+    @Override
+    public void sendFeedback(@NonNull final Map<String, GiniVisionSpecificExtraction> extractions,
+            @NonNull final Map<String, GiniVisionCompoundExtraction> compoundExtractions,
+            @NonNull final GiniVisionNetworkCallback<Void, Error> callback) {
+        throw new UnsupportedOperationException("Sending feedback for compound extractions is not possible yet.");
     }
 
     @Override

--- a/ginivision-accounting-network/src/main/java/net/gini/android/vision/accounting/network/GiniVisionAccountingNetworkService.java
+++ b/ginivision-accounting-network/src/main/java/net/gini/android/vision/accounting/network/GiniVisionAccountingNetworkService.java
@@ -27,6 +27,7 @@ import net.gini.android.vision.network.Error;
 import net.gini.android.vision.network.GiniVisionNetworkCallback;
 import net.gini.android.vision.network.GiniVisionNetworkService;
 import net.gini.android.vision.network.Result;
+import net.gini.android.vision.network.model.GiniVisionCompoundExtraction;
 import net.gini.android.vision.network.model.GiniVisionSpecificExtraction;
 import net.gini.android.vision.util.CancellationToken;
 import net.gini.android.vision.util.NoOpCancellationToken;
@@ -34,6 +35,7 @@ import net.gini.android.vision.util.NoOpCancellationToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -268,7 +270,8 @@ public class GiniVisionAccountingNetworkService implements GiniVisionNetworkServ
                                     LOG.debug("Document analysis success for document {}: {}",
                                             giniApiDocumentIdRotationMap, extractions);
                                     callback.success(
-                                            new AnalysisResult(giniApiDocumentId, extractions));
+                                            new AnalysisResult(giniApiDocumentId, extractions,
+                                                    Collections.<String, GiniVisionCompoundExtraction>emptyMap()));
                                 } else {
                                     LOG.debug("Document analysis cancelled for document {}",
                                             giniApiDocumentIdRotationMap);

--- a/ginivision-accounting-network/src/main/java/net/gini/android/vision/accounting/network/model/SpecificExtractionMapper.java
+++ b/ginivision-accounting-network/src/main/java/net/gini/android/vision/accounting/network/model/SpecificExtractionMapper.java
@@ -86,7 +86,7 @@ public final class SpecificExtractionMapper {
             @NonNull final GiniVisionSpecificExtraction source) {
         return new SpecificExtraction(source.getName(), source.getValue(), source.getEntity(),
                 BoxMapper.map(source.getBox()),
-                ExtractionMapper.mapListToApiSdk(source.getCandidate()));
+                ExtractionMapper.mapListToApiSdk(source.getCandidates()));
     }
 
     private SpecificExtractionMapper() {

--- a/ginivision-network/build.gradle
+++ b/ginivision-network/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation deps.supportAnnotations
     implementation project(path: ':ginivision')
-    api('net.gini:gini-android-sdk:2.3.0@aar') {
+    api('net.gini:gini-android-sdk:2.4.0@aar') {
         transitive = true
     }
 

--- a/ginivision-network/src/main/java/net/gini/android/vision/network/GiniVisionDefaultNetworkApi.java
+++ b/ginivision-network/src/main/java/net/gini/android/vision/network/GiniVisionDefaultNetworkApi.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 import net.gini.android.DocumentTaskManager;
 import net.gini.android.vision.GiniVision;
 import net.gini.android.vision.internal.camera.api.UIExecutor;
+import net.gini.android.vision.network.model.GiniVisionCompoundExtraction;
 import net.gini.android.vision.network.model.GiniVisionSpecificExtraction;
 import net.gini.android.vision.network.model.SpecificExtractionMapper;
 
@@ -105,6 +106,13 @@ public class GiniVisionDefaultNetworkApi implements GiniVisionNetworkApi {
             LOG.error("Send feedback failed: no Gini Api Document available");
             callback.failure(new Error("Feedback not set: no Gini Api Document available"));
         }
+    }
+
+    @Override
+    public void sendFeedback(@NonNull final Map<String, GiniVisionSpecificExtraction> extractions,
+            @NonNull final Map<String, GiniVisionCompoundExtraction> compoundExtractions,
+            @NonNull final GiniVisionNetworkCallback<Void, Error> callback) {
+        throw new UnsupportedOperationException("Sending feedback for compound extractions is not possible yet.");
     }
 
     @Override

--- a/ginivision-network/src/main/java/net/gini/android/vision/network/model/CompoundExtractionsMapper.java
+++ b/ginivision-network/src/main/java/net/gini/android/vision/network/model/CompoundExtractionsMapper.java
@@ -1,0 +1,44 @@
+package net.gini.android.vision.network.model;
+
+import android.support.annotation.NonNull;
+
+import net.gini.android.models.CompoundExtraction;
+import net.gini.android.models.SpecificExtraction;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by Alpar Szotyori on 17.02.2020.
+ *
+ * Copyright (c) 2020 Gini GmbH.
+ */
+public final class CompoundExtractionsMapper {
+
+    @NonNull
+    public static Map<String, GiniVisionCompoundExtraction> mapToGVL(@NonNull final Map<String, CompoundExtraction> sourceMap) {
+        final Map<String, GiniVisionCompoundExtraction> targetMap = new HashMap<>(sourceMap.size());
+        for (final Map.Entry<String, CompoundExtraction> source : sourceMap.entrySet()) {
+            targetMap.put(source.getKey(), mapList(source.getValue()));
+        }
+        return targetMap;
+    }
+
+    private static GiniVisionCompoundExtraction mapList(@NonNull final CompoundExtraction source) {
+        return new GiniVisionCompoundExtraction(source.getName(), mapList(source.getSpecificExtractionMaps()));
+    }
+
+    @NonNull
+    private static List<Map<String, GiniVisionSpecificExtraction>> mapList(final List<Map<String, SpecificExtraction>> sourceList) {
+        final List<Map<String, GiniVisionSpecificExtraction>> targetList = new ArrayList<>(sourceList.size());
+        for (final Map<String, SpecificExtraction> sourceMap : sourceList) {
+            targetList.add(SpecificExtractionMapper.mapToGVL(sourceMap));
+        }
+        return targetList;
+    }
+
+    private CompoundExtractionsMapper() {
+    }
+}

--- a/ginivision-network/src/main/java/net/gini/android/vision/network/model/SpecificExtractionMapper.java
+++ b/ginivision-network/src/main/java/net/gini/android/vision/network/model/SpecificExtractionMapper.java
@@ -4,7 +4,9 @@ import android.support.annotation.NonNull;
 
 import net.gini.android.models.SpecificExtraction;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -46,12 +48,22 @@ public final class SpecificExtractionMapper {
      * @return a Gini Vision Library {@link GiniVisionSpecificExtraction}
      */
     @NonNull
-    public static GiniVisionSpecificExtraction map(
+    private static GiniVisionSpecificExtraction map(
             @NonNull final SpecificExtraction source) {
         return new GiniVisionSpecificExtraction(source.getName(), source.getValue(),
                 source.getEntity(),
                 BoxMapper.map(source.getBox()),
-                ExtractionMapper.mapListToGVL(source.getCandidate()));
+                ExtractionMapper.mapListToGVL(source.getCandidate()),
+                mapListToGVL(source.getSpecificExtractions()));
+    }
+
+    @NonNull
+    private static List<GiniVisionSpecificExtraction> mapListToGVL(final List<SpecificExtraction> specificExtractions) {
+        final List<GiniVisionSpecificExtraction> targetList = new ArrayList<>(specificExtractions.size());
+        for (final SpecificExtraction specificExtraction : specificExtractions) {
+            targetList.add(map(specificExtraction));
+        }
+        return targetList;
     }
 
     /**
@@ -85,7 +97,17 @@ public final class SpecificExtractionMapper {
             @NonNull final GiniVisionSpecificExtraction source) {
         return new SpecificExtraction(source.getName(), source.getValue(), source.getEntity(),
                 BoxMapper.map(source.getBox()),
-                ExtractionMapper.mapListToApiSdk(source.getCandidate()));
+                ExtractionMapper.mapListToApiSdk(source.getCandidate()),
+                mapListToApiSdk(source.getSpecificExtractions()));
+    }
+
+    @NonNull
+    private static List<SpecificExtraction> mapListToApiSdk(final List<GiniVisionSpecificExtraction> specificExtractions) {
+        final List<SpecificExtraction> targetList = new ArrayList<>(specificExtractions.size());
+        for (final GiniVisionSpecificExtraction specificExtraction : specificExtractions) {
+            targetList.add(map(specificExtraction));
+        }
+        return targetList;
     }
 
     private SpecificExtractionMapper() {

--- a/ginivision-network/src/main/java/net/gini/android/vision/network/model/SpecificExtractionMapper.java
+++ b/ginivision-network/src/main/java/net/gini/android/vision/network/model/SpecificExtractionMapper.java
@@ -4,9 +4,7 @@ import android.support.annotation.NonNull;
 
 import net.gini.android.models.SpecificExtraction;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -53,17 +51,7 @@ public final class SpecificExtractionMapper {
         return new GiniVisionSpecificExtraction(source.getName(), source.getValue(),
                 source.getEntity(),
                 BoxMapper.map(source.getBox()),
-                ExtractionMapper.mapListToGVL(source.getCandidate()),
-                mapListToGVL(source.getSpecificExtractions()));
-    }
-
-    @NonNull
-    private static List<GiniVisionSpecificExtraction> mapListToGVL(final List<SpecificExtraction> specificExtractions) {
-        final List<GiniVisionSpecificExtraction> targetList = new ArrayList<>(specificExtractions.size());
-        for (final SpecificExtraction specificExtraction : specificExtractions) {
-            targetList.add(map(specificExtraction));
-        }
-        return targetList;
+                ExtractionMapper.mapListToGVL(source.getCandidate()));
     }
 
     /**
@@ -97,17 +85,7 @@ public final class SpecificExtractionMapper {
             @NonNull final GiniVisionSpecificExtraction source) {
         return new SpecificExtraction(source.getName(), source.getValue(), source.getEntity(),
                 BoxMapper.map(source.getBox()),
-                ExtractionMapper.mapListToApiSdk(source.getCandidate()),
-                mapListToApiSdk(source.getSpecificExtractions()));
-    }
-
-    @NonNull
-    private static List<SpecificExtraction> mapListToApiSdk(final List<GiniVisionSpecificExtraction> specificExtractions) {
-        final List<SpecificExtraction> targetList = new ArrayList<>(specificExtractions.size());
-        for (final GiniVisionSpecificExtraction specificExtraction : specificExtractions) {
-            targetList.add(map(specificExtraction));
-        }
-        return targetList;
+                ExtractionMapper.mapListToApiSdk(source.getCandidates()));
     }
 
     private SpecificExtractionMapper() {

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/network/GiniVisionNetworkServiceStub.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/network/GiniVisionNetworkServiceStub.java
@@ -9,6 +9,7 @@ import net.gini.android.vision.network.GiniVisionNetworkCallback;
 import net.gini.android.vision.network.GiniVisionNetworkService;
 import net.gini.android.vision.network.Result;
 import net.gini.android.vision.network.model.GiniVisionBox;
+import net.gini.android.vision.network.model.GiniVisionCompoundExtraction;
 import net.gini.android.vision.network.model.GiniVisionExtraction;
 import net.gini.android.vision.network.model.GiniVisionSpecificExtraction;
 import net.gini.android.vision.util.CancellationToken;
@@ -58,7 +59,8 @@ public class GiniVisionNetworkServiceStub implements GiniVisionNetworkService {
                         new GiniVisionSpecificExtraction("amountToPay",
                                 "1:00EUR", "amountToPay",
                                 new GiniVisionBox(1, 0,0,0,0),
-                                Collections.<GiniVisionExtraction>emptyList())));
+                                Collections.<GiniVisionExtraction>emptyList())),
+                Collections.<String, GiniVisionCompoundExtraction>emptyMap());
     }
 
     public static class CallbackCancellationToken implements CancellationToken {

--- a/ginivision/src/main/java/net/gini/android/vision/internal/util/BundleHelper.kt
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/util/BundleHelper.kt
@@ -1,0 +1,35 @@
+package net.gini.android.vision.internal.util
+
+import android.os.Bundle
+import android.os.Parcelable
+import java.util.*
+
+/**
+ * Created by Alpar Szotyori on 17.02.2020.
+ *
+ * Copyright (c) 2020 Gini GmbH.
+ */
+
+fun <V : Parcelable> fromMap(map: Map<String, V>): Bundle = Bundle().apply {
+    for ((key, value) in map) {
+        putParcelable(key, value)
+    }
+}
+
+fun <V : Parcelable> fromMapList(mapList: List<Map<String, V>>): List<Bundle> = mapList.map { fromMap(it) }
+
+@JvmOverloads
+fun <V : Parcelable> toMap(bundle: Bundle, classLoader: ClassLoader? = null): Map<String, V> = HashMap<String, V>().apply {
+    if (classLoader != null) {
+        bundle.classLoader = classLoader
+    }
+    for (key in bundle.keySet()) {
+        bundle.getParcelable<V>(key)?.let { parcelable ->
+            put(key, parcelable)
+        }
+    }
+}
+
+@JvmOverloads
+fun <V : Parcelable> toMapList(bundleList: List<Bundle>,
+                               classLoader: ClassLoader? = null): List<Map<String, V>> = bundleList.map { toMap<V>(it, classLoader) }

--- a/ginivision/src/main/java/net/gini/android/vision/network/AnalysisResult.java
+++ b/ginivision/src/main/java/net/gini/android/vision/network/AnalysisResult.java
@@ -2,6 +2,7 @@ package net.gini.android.vision.network;
 
 import android.support.annotation.NonNull;
 
+import net.gini.android.vision.network.model.GiniVisionCompoundExtraction;
 import net.gini.android.vision.network.model.GiniVisionSpecificExtraction;
 
 import java.util.Map;
@@ -18,6 +19,7 @@ import java.util.Map;
 public class AnalysisResult extends Result {
 
     private final Map<String, GiniVisionSpecificExtraction> extractions;
+    private final Map<String, GiniVisionCompoundExtraction> compoundExtractions;
 
     /**
      * Create a new analysis result for a Gini API document id.
@@ -26,9 +28,11 @@ public class AnalysisResult extends Result {
      * @param extractions       the extractions from the Gini API
      */
     public AnalysisResult(@NonNull final String giniApiDocumentId,
-            @NonNull final Map<String, GiniVisionSpecificExtraction> extractions) {
+            @NonNull final Map<String, GiniVisionSpecificExtraction> extractions,
+            @NonNull final Map<String, GiniVisionCompoundExtraction> compoundExtractions) {
         super(giniApiDocumentId);
         this.extractions = extractions;
+        this.compoundExtractions = compoundExtractions;
     }
 
     /**
@@ -37,5 +41,13 @@ public class AnalysisResult extends Result {
     @NonNull
     public Map<String, GiniVisionSpecificExtraction> getExtractions() {
         return extractions;
+    }
+
+    /**
+     * @return map of extraction labels and compound extractions
+     */
+    @NonNull
+    public Map<String, GiniVisionCompoundExtraction> getCompoundExtractions() {
+        return compoundExtractions;
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/network/GiniVisionNetworkApi.java
+++ b/ginivision/src/main/java/net/gini/android/vision/network/GiniVisionNetworkApi.java
@@ -3,6 +3,7 @@ package net.gini.android.vision.network;
 import android.support.annotation.NonNull;
 
 import net.gini.android.vision.GiniVision;
+import net.gini.android.vision.network.model.GiniVisionCompoundExtraction;
 import net.gini.android.vision.network.model.GiniVisionSpecificExtraction;
 
 import java.util.Map;
@@ -32,6 +33,19 @@ public interface GiniVisionNetworkApi {
      * @param callback    a callback implementation to return the outcome
      */
     void sendFeedback(@NonNull final Map<String, GiniVisionSpecificExtraction> extractions,
+            @NonNull final GiniVisionNetworkCallback<Void, Error> callback);
+
+    /**
+     * Call this method with the extractions and compound extractions the user has seen and accepted. The {@link
+     * GiniVisionSpecificExtraction}s and {@link GiniVisionCompoundExtraction}s must contain the final user corrected and/or accepted
+     * values.
+     *
+     * @param extractions         a map of extraction labels and specific extractions
+     * @param compoundExtractions a map of extraction labels and compound extractions
+     * @param callback            a callback implementation to return the outcome
+     */
+    void sendFeedback(@NonNull final Map<String, GiniVisionSpecificExtraction> extractions,
+            @NonNull final Map<String, GiniVisionCompoundExtraction> compoundExtractions,
             @NonNull final GiniVisionNetworkCallback<Void, Error> callback);
 
     /**

--- a/ginivision/src/main/java/net/gini/android/vision/network/model/GiniVisionCompoundExtraction.java
+++ b/ginivision/src/main/java/net/gini/android/vision/network/model/GiniVisionCompoundExtraction.java
@@ -1,0 +1,91 @@
+package net.gini.android.vision.network.model;
+
+import static net.gini.android.vision.internal.util.BundleHelperKt.fromMapList;
+import static net.gini.android.vision.internal.util.BundleHelperKt.toMapList;
+
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by Alpar Szotyori on 13.02.2020.
+ *
+ * Copyright (c) 2020 Gini GmbH.
+ */
+
+/**
+ * Contains a Gini API compound extraction.
+ *
+ * <p> A compound extraction contains one or more specific extraction maps. For example line items are compound extractions where each line
+ * is represented by a specific extraction map. Each specific extraction represents a column on that line.
+ */
+public class GiniVisionCompoundExtraction implements Parcelable {
+
+    public static final Parcelable.Creator<GiniVisionCompoundExtraction> CREATOR = new Parcelable.Creator<GiniVisionCompoundExtraction>() {
+        @Override
+        public GiniVisionCompoundExtraction createFromParcel(final Parcel in) {
+            return new GiniVisionCompoundExtraction(in);
+        }
+
+        @Override
+        public GiniVisionCompoundExtraction[] newArray(final int size) {
+            return new GiniVisionCompoundExtraction[size];
+        }
+    };
+    private final String mName;
+    private final List<Map<String, GiniVisionSpecificExtraction>> mSpecificExtractionMaps;
+
+    /**
+     * Value object for a compound extraction from the Gini API.
+     *
+     * @param name                   The compound extraction's name, e.g. "amountToPay".
+     * @param specificExtractionMaps A list of specific extractions bundled into separate maps.
+     */
+    public GiniVisionCompoundExtraction(@NonNull final String name,
+            @NonNull final List<Map<String, GiniVisionSpecificExtraction>> specificExtractionMaps) {
+        mName = name;
+        mSpecificExtractionMaps = specificExtractionMaps;
+    }
+
+    protected GiniVisionCompoundExtraction(final Parcel in) {
+        mName = in.readString();
+        final List<Bundle> bundleList = new ArrayList<>();
+        in.readTypedList(bundleList, Bundle.CREATOR);
+        mSpecificExtractionMaps = toMapList(bundleList, getClass().getClassLoader());
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(@NonNull final Parcel dest, final int flags) {
+        dest.writeString(mName);
+        dest.writeTypedList(fromMapList(mSpecificExtractionMaps));
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "GiniVisionCompoundExtraction{" +
+                "mName='" + mName + '\'' +
+                ", mSpecificExtractionMaps=" + mSpecificExtractionMaps +
+                '}';
+    }
+
+    @NonNull
+    public String getName() {
+        return mName;
+    }
+
+    @NonNull
+    public List<Map<String, GiniVisionSpecificExtraction>> getSpecificExtractionMaps() {
+        return mSpecificExtractionMaps;
+    }
+}

--- a/ginivision/src/main/java/net/gini/android/vision/network/model/GiniVisionSpecificExtraction.java
+++ b/ginivision/src/main/java/net/gini/android/vision/network/model/GiniVisionSpecificExtraction.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -37,6 +38,7 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
             };
     private final String mName;
     private final List<GiniVisionExtraction> mCandidates;
+    private final List<GiniVisionSpecificExtraction> mSpecificExtractions;
 
     /**
      * Value object for a specific extraction from the Gini API.
@@ -60,9 +62,34 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
             @NonNull final String entity,
             @Nullable final GiniVisionBox box,
             @NonNull final List<GiniVisionExtraction> candidates) {
+        this(name, value, entity, box, candidates, Collections.<GiniVisionSpecificExtraction>emptyList());
+    }
+
+    /**
+     * Value object for a specific extraction from the Gini API.
+     *
+     * @param name                The specific extraction's name, e.g. "amountToPay". See <a href="http://developer.gini.net/gini-api/html/document_extractions.html#available-specific-extractions">Available
+     *                            Specific Extractions</a> for a full list
+     * @param value               normalized textual representation of the text/information provided by the extraction value (e. g. bank
+     *                            number without spaces between the digits). Changing this value marks the extraction as dirty
+     * @param entity              key (primary identification) of an entity type (e.g. banknumber). See <a
+     *                            href="http://developer.gini.net/gini-api/html/document_extractions.html#available-extraction-entities">Extraction
+     *                            Entities</a> for a full list
+     * @param box                 (optional) bounding box containing the position of the extraction value on the document. Only available
+     *                            for some extractions. Changing this value marks the extraction as dirty
+     * @param candidates          A list containing other candidates for this specific extraction. Candidates are of the same entity as the
+     *                            found extraction
+     * @param specificExtractions A list of other specific extractions which are part of this one.
+     */
+    public GiniVisionSpecificExtraction(@NonNull final String name, @NonNull final String value,
+            @NonNull final String entity,
+            @Nullable final GiniVisionBox box,
+            @NonNull final List<GiniVisionExtraction> candidates,
+            @NonNull final List<GiniVisionSpecificExtraction> specificExtractions) {
         super(value, entity, box);
         mName = name;
         mCandidates = candidates;
+        mSpecificExtractions = specificExtractions;
     }
 
     private GiniVisionSpecificExtraction(final Parcel in) {
@@ -71,6 +98,9 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
         final List<GiniVisionExtraction> candidates = new ArrayList<>();
         in.readTypedList(candidates, GiniVisionExtraction.CREATOR);
         mCandidates = candidates;
+        final List<GiniVisionSpecificExtraction> specificExtractions = new ArrayList<>();
+        in.readTypedList(specificExtractions, GiniVisionSpecificExtraction.CREATOR);
+        mSpecificExtractions = specificExtractions;
     }
 
     @Override
@@ -83,6 +113,7 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
         super.writeToParcel(dest, flags);
         dest.writeString(mName);
         dest.writeTypedList(mCandidates);
+        dest.writeTypedList(mSpecificExtractions);
     }
 
     /**
@@ -103,11 +134,20 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
     }
 
 
+    /**
+     * @return a list containing the specific extractions which are part of this one
+     */
+    @NonNull
+    public List<GiniVisionSpecificExtraction> getSpecificExtractions() {
+        return mSpecificExtractions;
+    }
+
     @Override
     public String toString() {
         return "GiniVisionSpecificExtraction{"
                 + "mName='" + mName + '\''
                 + ", mCandidates=" + mCandidates
+                + ", mCandidates=" + mSpecificExtractions
                 + "} " + super.toString();
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/network/model/GiniVisionSpecificExtraction.java
+++ b/ginivision/src/main/java/net/gini/android/vision/network/model/GiniVisionSpecificExtraction.java
@@ -6,7 +6,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -38,7 +37,6 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
             };
     private final String mName;
     private final List<GiniVisionExtraction> mCandidates;
-    private final List<GiniVisionSpecificExtraction> mSpecificExtractions;
 
     /**
      * Value object for a specific extraction from the Gini API.
@@ -62,34 +60,9 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
             @NonNull final String entity,
             @Nullable final GiniVisionBox box,
             @NonNull final List<GiniVisionExtraction> candidates) {
-        this(name, value, entity, box, candidates, Collections.<GiniVisionSpecificExtraction>emptyList());
-    }
-
-    /**
-     * Value object for a specific extraction from the Gini API.
-     *
-     * @param name                The specific extraction's name, e.g. "amountToPay". See <a href="http://developer.gini.net/gini-api/html/document_extractions.html#available-specific-extractions">Available
-     *                            Specific Extractions</a> for a full list
-     * @param value               normalized textual representation of the text/information provided by the extraction value (e. g. bank
-     *                            number without spaces between the digits). Changing this value marks the extraction as dirty
-     * @param entity              key (primary identification) of an entity type (e.g. banknumber). See <a
-     *                            href="http://developer.gini.net/gini-api/html/document_extractions.html#available-extraction-entities">Extraction
-     *                            Entities</a> for a full list
-     * @param box                 (optional) bounding box containing the position of the extraction value on the document. Only available
-     *                            for some extractions. Changing this value marks the extraction as dirty
-     * @param candidates          A list containing other candidates for this specific extraction. Candidates are of the same entity as the
-     *                            found extraction
-     * @param specificExtractions A list of other specific extractions which are part of this one.
-     */
-    public GiniVisionSpecificExtraction(@NonNull final String name, @NonNull final String value,
-            @NonNull final String entity,
-            @Nullable final GiniVisionBox box,
-            @NonNull final List<GiniVisionExtraction> candidates,
-            @NonNull final List<GiniVisionSpecificExtraction> specificExtractions) {
         super(value, entity, box);
         mName = name;
         mCandidates = candidates;
-        mSpecificExtractions = specificExtractions;
     }
 
     private GiniVisionSpecificExtraction(final Parcel in) {
@@ -98,9 +71,6 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
         final List<GiniVisionExtraction> candidates = new ArrayList<>();
         in.readTypedList(candidates, GiniVisionExtraction.CREATOR);
         mCandidates = candidates;
-        final List<GiniVisionSpecificExtraction> specificExtractions = new ArrayList<>();
-        in.readTypedList(specificExtractions, GiniVisionSpecificExtraction.CREATOR);
-        mSpecificExtractions = specificExtractions;
     }
 
     @Override
@@ -113,7 +83,6 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
         super.writeToParcel(dest, flags);
         dest.writeString(mName);
         dest.writeTypedList(mCandidates);
-        dest.writeTypedList(mSpecificExtractions);
     }
 
     /**
@@ -129,25 +98,16 @@ public class GiniVisionSpecificExtraction extends GiniVisionExtraction {
      * @return a list containing other candidates for this specific extraction
      */
     @NonNull
-    public List<GiniVisionExtraction> getCandidate() {
+    public List<GiniVisionExtraction> getCandidates() {
         return mCandidates;
     }
 
-
-    /**
-     * @return a list containing the specific extractions which are part of this one
-     */
     @NonNull
-    public List<GiniVisionSpecificExtraction> getSpecificExtractions() {
-        return mSpecificExtractions;
-    }
-
     @Override
     public String toString() {
         return "GiniVisionSpecificExtraction{"
                 + "mName='" + mName + '\''
                 + ", mCandidates=" + mCandidates
-                + ", mCandidates=" + mSpecificExtractions
                 + "} " + super.toString();
     }
 }

--- a/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisInteractorTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisInteractorTest.java
@@ -19,6 +19,7 @@ import net.gini.android.vision.internal.network.AnalysisNetworkRequestResult;
 import net.gini.android.vision.internal.network.NetworkRequestResult;
 import net.gini.android.vision.internal.network.NetworkRequestsManager;
 import net.gini.android.vision.network.AnalysisResult;
+import net.gini.android.vision.network.model.GiniVisionCompoundExtraction;
 import net.gini.android.vision.network.model.GiniVisionSpecificExtraction;
 
 import org.junit.After;
@@ -222,7 +223,7 @@ public class AnalysisInteractorTest {
                 multiPageDocument = mock(GiniVisionMultiPageDocument.class);
 
         final AnalysisResult analysisResult = new AnalysisResult("apiDocumentId",
-                Collections.<String, GiniVisionSpecificExtraction>emptyMap());
+                Collections.<String, GiniVisionSpecificExtraction>emptyMap(), Collections.<String, GiniVisionCompoundExtraction>emptyMap());
 
         final NetworkRequestsManager networkRequestsManager = createtNetworkRequestsManager(
                 analysisResult);
@@ -272,7 +273,7 @@ public class AnalysisInteractorTest {
         extractions.put("paymentReference", mock(GiniVisionSpecificExtraction.class));
 
         final AnalysisResult analysisResult = new AnalysisResult("apiDocumentId",
-                extractions);
+                extractions, Collections.<String, GiniVisionCompoundExtraction>emptyMap());
 
         final NetworkRequestsManager networkRequestsManager = createtNetworkRequestsManager(
                 analysisResult);

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
@@ -24,7 +24,6 @@ import net.gini.android.vision.GiniVisionDebug;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.ImportedFileValidationException;
 import net.gini.android.vision.camera.CameraActivity;
-import net.gini.android.vision.digitalinvoice.DigitalInvoiceActivity;
 import net.gini.android.vision.example.BaseExampleApp;
 import net.gini.android.vision.example.RuntimePermissionHandler;
 import net.gini.android.vision.onboarding.DefaultPagesPhone;
@@ -300,8 +299,7 @@ public class MainActivity extends AppCompatActivity {
         // Start for result in order to receive the error result, in case something went wrong, or the extractions
         // To receive the extractions add it to the result Intent in ReviewActivity#onAddDataToResult(Intent) or
         // AnalysisActivity#onAddDataToResult(Intent) and retrieve them here in onActivityResult()
-        final Intent debug = new Intent(this, DigitalInvoiceActivity.class);
-        startActivityForResult(debug, REQUEST_SCAN);
+        startActivityForResult(intent, REQUEST_SCAN);
     }
 
     private void configureGiniVision() {


### PR DESCRIPTION
#268 was merged by accident. I reset everything, but had to open a new PR 🤦‍♂:

Added support for line items to the networking plugin's default implementation.

**Note**: the networking plugin's default implementation won't compile until the Gini API SDK version 2.4.0 is not released. See this [PR](https://github.com/gini/gini-sdk-android/pull/18).

## How to test
Use the stage client `gini-mobile-test` (credentials in 1Password) with the Screen API example. Put a breakpoint [here](https://github.com/gini/gini-vision-lib-android/blob/8ad0dd10aead6ec2d70c053eccbedafbecf233c0/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisActivity.java#L459) and analyze an image or pdf. The extractions map should have a `lineItems` key with a `GiniVisionSpecificExtraction` which contains a list of `GiniVisionSpecificExtractions` for each line item. These line item "specific extractions" also contain a list of `GiniVisionSpecificExtractions` for each of their columns.

### Ticket 
[PIA-477](https://ginis.atlassian.net/browse/PIA-477)
