### PR TITLE
Added a feature flag for the return assistant which is disabled by default (after #270)

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/GiniVision.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVision.java
@@ -76,6 +76,7 @@ public class GiniVision {
     private final boolean mBackButtonsEnabled;
     private final boolean mIsFlashOnByDefault;
     private final EventTracker mEventTracker;
+    private final boolean mReturnAssistantEnabled;
 
     /**
      * Retrieve the current instance.
@@ -168,6 +169,7 @@ public class GiniVision {
         mBackButtonsEnabled = builder.areBackButtonsEnabled();
         mIsFlashOnByDefault = builder.isFlashOnByDefault();
         mEventTracker = builder.getEventTracker();
+        mReturnAssistantEnabled = builder.isReturnAssistantEnabled();
     }
 
     /**
@@ -330,6 +332,16 @@ public class GiniVision {
      */
     public boolean isFlashOnByDefault() {
         return mIsFlashOnByDefault;
+    }
+
+
+    /**
+     * Find out whether the return assistant has been enabled.
+     *
+     * @return {@code true} if the return assistant was enabled
+     */
+    public boolean isReturnAssistantEnabled() {
+        return mReturnAssistantEnabled;
     }
 
     /**
@@ -521,6 +533,7 @@ public class GiniVision {
             public void onAnalysisScreenEvent(@NotNull final Event<AnalysisScreenEvent> event) {
             }
         };
+        private boolean mReturnAssistantEnabled = false;
 
         /**
          * Create a new {@link GiniVision} instance.
@@ -818,6 +831,24 @@ public class GiniVision {
 
         EventTracker getEventTracker() {
             return mEventTracker;
+        }
+
+        /**
+         * Enable/disable the return assistant feature.
+         *
+         * <p> Disabled by default.
+         *
+         * @param enabled {@code true} to enable the return assistant
+         *
+         * @return the {@link Builder} instance
+         */
+        public Builder setReturnAssistantEnabled(final boolean enabled) {
+            mReturnAssistantEnabled = enabled;
+            return this;
+        }
+
+        boolean isReturnAssistantEnabled() {
+            return mReturnAssistantEnabled;
         }
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisScreenPresenter.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisScreenPresenter.java
@@ -1,7 +1,6 @@
 package net.gini.android.vision.analysis;
 
 import static net.gini.android.vision.internal.util.NullabilityHelper.getMapOrEmpty;
-
 import static net.gini.android.vision.tracking.EventTrackingHelper.trackAnalysisScreenEvent;
 
 import static java.util.Collections.singletonMap;
@@ -351,7 +350,7 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
                                 break;
                             case SUCCESS_WITH_EXTRACTIONS:
                                 mAnalysisCompleted = true;
-                                if (hasLineItems(resultHolder)) {
+                                if (isReturnAssistantEnabled() && hasLineItems(resultHolder)) {
                                     getAnalysisFragmentListenerOrNoOp()
                                             .onProceedToReturnAssistant(getMapOrEmpty(resultHolder.getExtractions()),
                                                     getMapOrEmpty(resultHolder.getCompoundExtractions()));
@@ -375,6 +374,10 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
                         return null;
                     }
                 });
+    }
+
+    private boolean isReturnAssistantEnabled() {
+        return GiniVision.hasInstance() && GiniVision.getInstance().isReturnAssistantEnabled();
     }
 
     private boolean hasLineItems(@NonNull final AnalysisInteractor.ResultHolder resultHolder) {

--- a/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisScreenPresenterTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisScreenPresenterTest.java
@@ -681,10 +681,15 @@ public class AnalysisScreenPresenterTest {
     }
 
     @Test
-    public void should_proceedToReturnAssistant_whenAnalysisSucceeded_withLineItems()
+    public void should_proceedToReturnAssistant_whenAnalysisSucceeded_withLineItems_andReturnAssistant_isEnabled()
             throws Exception {
         // Given
         when(mActivity.getString(anyInt())).thenReturn("A String");
+
+        final GiniVision giniVision = mock(GiniVision.class);
+        when(giniVision.isReturnAssistantEnabled()).thenReturn(true);
+
+        GiniVisionHelper.setGiniVisionInstance(giniVision);
 
         final ImageDocument imageDocument = new ImageDocumentFake();
 
@@ -709,6 +714,42 @@ public class AnalysisScreenPresenterTest {
 
         // Then
         verify(listener).onProceedToReturnAssistant(extractions, compoundExtractions);
+    }
+
+    @Test
+    public void should_notProceedToReturnAssistant_whenAnalysisSucceeded_withLineItems_andReturnAssistant_isNotEnabled()
+            throws Exception {
+        // Given
+        when(mActivity.getString(anyInt())).thenReturn("A String");
+
+        final GiniVision giniVision = mock(GiniVision.class);
+        when(giniVision.isReturnAssistantEnabled()).thenReturn(false);
+
+        GiniVisionHelper.setGiniVisionInstance(giniVision);
+
+        final ImageDocument imageDocument = new ImageDocumentFake();
+
+        final Map<String, GiniVisionSpecificExtraction> extractions = Collections.singletonMap(
+                "extraction", mock(GiniVisionSpecificExtraction.class));
+        final Map<String, GiniVisionCompoundExtraction> compoundExtractions = Collections.singletonMap(
+                "lineItems", mock(GiniVisionCompoundExtraction.class));
+        final CompletableFuture<AnalysisInteractor.ResultHolder> analysisFuture =
+                new CompletableFuture<>();
+        analysisFuture.complete(new AnalysisInteractor.ResultHolder(
+                AnalysisInteractor.Result.SUCCESS_WITH_EXTRACTIONS,
+                extractions, compoundExtractions));
+
+        final AnalysisScreenPresenter presenter = createPresenterWithAnalysisFuture(imageDocument,
+                analysisFuture);
+
+        final AnalysisFragmentListener listener = mock(AnalysisFragmentListener.class);
+        presenter.setListener(listener);
+
+        // When
+        presenter.start();
+
+        // Then
+        verify(listener).onExtractionsAvailable(extractions, compoundExtractions);
     }
 
     @Test

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
@@ -328,6 +328,7 @@ public class MainActivity extends AppCompatActivity {
         }
         builder.setFlashButtonEnabled(true);
         builder.setEventTracker(new GVLEventTracker());
+        builder.setReturnAssistantEnabled(true);
         // Uncomment to turn off the camera flash by default
 //        builder.setFlashOnByDefault(false);
         // Uncomment to disable back buttons (except in the review and analysis screens)


### PR DESCRIPTION
Review after #270.

The return assistant feature can be enabled/disabled when building a new `GiniVision` instance.

### How to test
Use the screen api example app to try out enabling and disabling the return assistant.

### Ticket 
[PIA-497](https://ginis.atlassian.net/browse/PIA-497)
