### PR TITLE
Component API - Return total price and line items 

### DIFF
--- a/componentapiexample/src/main/java/net/gini/android/vision/component/digitalinvoice/DigitalInvoiceExampleActivity.java
+++ b/componentapiexample/src/main/java/net/gini/android/vision/component/digitalinvoice/DigitalInvoiceExampleActivity.java
@@ -15,7 +15,6 @@ import net.gini.android.vision.component.R;
 import net.gini.android.vision.component.digitalinvoice.details.LineItemDetailsExampleActivity;
 import net.gini.android.vision.digitalinvoice.DigitalInvoiceFragment;
 import net.gini.android.vision.digitalinvoice.DigitalInvoiceFragmentListener;
-import net.gini.android.vision.digitalinvoice.LineItem;
 import net.gini.android.vision.digitalinvoice.SelectableLineItem;
 import net.gini.android.vision.network.model.GiniVisionCompoundExtraction;
 import net.gini.android.vision.network.model.GiniVisionSpecificExtraction;
@@ -25,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -113,14 +111,12 @@ public class DigitalInvoiceExampleActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onPayInvoice(final List<LineItem> selectedLineItems, final String selectedLineItemsTotalPrice,
-            final List<LineItem> deselectedLineItems,
-            final Map<String, ? extends GiniVisionCompoundExtraction> reviewedCompoundExtractions,
-            final Map<String, ? extends GiniVisionSpecificExtraction> reviewedExtractions) {
+    public void onPayInvoice(@NonNull final Map<String, ? extends GiniVisionSpecificExtraction> specificxtractions,
+            @NonNull final Map<String, ? extends GiniVisionCompoundExtraction> compoundExtractions) {
         LOG.debug("Show extractions with line items");
         final Intent intent = new Intent(this, ExtractionsActivity.class);
-        intent.putExtra(ExtractionsActivity.EXTRA_IN_EXTRACTIONS, mapToBundle(reviewedExtractions));
-        intent.putExtra(ExtractionsActivity.EXTRA_IN_COMPOUND_EXTRACTIONS, mapToBundle(reviewedCompoundExtractions));
+        intent.putExtra(ExtractionsActivity.EXTRA_IN_EXTRACTIONS, mapToBundle(specificxtractions));
+        intent.putExtra(ExtractionsActivity.EXTRA_IN_COMPOUND_EXTRACTIONS, mapToBundle(compoundExtractions));
         startActivity(intent);
         setResult(RESULT_OK);
         finish();

--- a/ginivision/src/main/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceActivity.kt
+++ b/ginivision/src/main/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceActivity.kt
@@ -95,15 +95,14 @@ class DigitalInvoiceActivity : AppCompatActivity(), DigitalInvoiceFragmentListen
                 EDIT_LINE_ITEM_REQUEST)
     }
 
-    override fun onPayInvoice(selectedLineItems: List<LineItem>, selectedLineItemsTotalPrice: String, deselectedLineItems: List<LineItem>,
-                              reviewedCompoundExtractions: Map<String, GiniVisionCompoundExtraction>,
-                              reviewedExtractions: Map<String, GiniVisionSpecificExtraction>) {
+    override fun onPayInvoice(specificExtractions: Map<String, GiniVisionSpecificExtraction>,
+                              compoundExtractions: Map<String, GiniVisionCompoundExtraction>) {
         setResult(Activity.RESULT_OK, Intent().apply {
             putExtra(CameraActivity.EXTRA_OUT_EXTRACTIONS, Bundle().apply {
-                reviewedExtractions.forEach { putParcelable(it.key, it.value) }
+                specificExtractions.forEach { putParcelable(it.key, it.value) }
             })
             putExtra(CameraActivity.EXTRA_OUT_COMPOUND_EXTRACTIONS, Bundle().apply {
-                reviewedCompoundExtractions.forEach { putParcelable(it.key, it.value) }
+                compoundExtractions.forEach { putParcelable(it.key, it.value) }
             })
         })
         finish()

--- a/ginivision/src/main/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceFragmentListener.kt
+++ b/ginivision/src/main/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceFragmentListener.kt
@@ -12,9 +12,6 @@ interface DigitalInvoiceFragmentListener {
 
     fun onEditLineItem(selectableLineItem: SelectableLineItem)
 
-    fun onPayInvoice(selectedLineItems: List<LineItem>,
-                     selectedLineItemsTotalPrice: String,
-                     deselectedLineItems: List<LineItem>,
-                     reviewedCompoundExtractions: Map<String, GiniVisionCompoundExtraction>,
-                     reviewedExtractions: Map<String, GiniVisionSpecificExtraction>)
+    fun onPayInvoice(specificExtractions: Map<String, GiniVisionSpecificExtraction>,
+                     compoundExtractions: Map<String, GiniVisionCompoundExtraction>)
 }

--- a/ginivision/src/main/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceScreenPresenter.kt
+++ b/ginivision/src/main/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceScreenPresenter.kt
@@ -63,20 +63,9 @@ internal open class DigitalInvoiceScreenPresenter(activity: Activity,
     }
 
     override fun pay() {
-        val (selected, deselected) = digitalInvoice.selectableLineItems.groupBy { it.selected }.run {
-            Pair(get(true)?.map { it.lineItem } ?: emptyList(), get(false)?.map { it.lineItem } ?: emptyList())
-        }
-        val totalPrice =
-                LineItem.createRawGrossPrice(digitalInvoice.selectedLineItemsTotalGrossPriceSum(),
-                        digitalInvoice.selectableLineItems.firstOrNull()?.lineItem?.rawCurrency ?: "EUR")
         digitalInvoice.updateLineItemExtractionsWithReviewedLineItems()
         digitalInvoice.updateAmountToPayExtractionWithTotalGrossPrice()
-        listener?.onPayInvoice(
-                selectedLineItems = selected,
-                selectedLineItemsTotalPrice = totalPrice,
-                deselectedLineItems = deselected,
-                reviewedCompoundExtractions = digitalInvoice.compoundExtractions,
-                reviewedExtractions = digitalInvoice.extractions)
+        listener?.onPayInvoice(digitalInvoice.extractions, digitalInvoice.compoundExtractions)
     }
 
     override fun updateLineItem(selectableLineItem: SelectableLineItem) {

--- a/ginivision/src/test/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceActivityTest.kt
+++ b/ginivision/src/test/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceActivityTest.kt
@@ -32,11 +32,8 @@ class DigitalInvoiceActivityTest {
 
             // When
             scenario.onActivity { activity ->
-                activity.onPayInvoice(selectedLineItems = emptyList(),
-                        selectedLineItemsTotalPrice = "",
-                        deselectedLineItems = emptyList(),
-                        reviewedExtractions = mapOf("amountToPay" to mock()),
-                        reviewedCompoundExtractions = mapOf("lineItems" to mock()))
+                activity.onPayInvoice(specificExtractions = mapOf("amountToPay" to mock()),
+                        compoundExtractions = mapOf("lineItems" to mock()))
             }
 
             // Then

--- a/ginivision/src/test/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceScreenPresenterTest.kt
+++ b/ginivision/src/test/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceScreenPresenterTest.kt
@@ -26,6 +26,7 @@ class DigitalInvoiceScreenPresenterTest {
 
     @Mock
     private lateinit var activity: Activity
+
     @Mock
     private lateinit var view: View
 
@@ -351,52 +352,6 @@ class DigitalInvoiceScreenPresenterTest {
     }
 
     @Test
-    fun `should return selected and deselected line items when the 'Pay' button was clicked`() {
-        // Given
-        view = ViewWithSelectedReturnReason("Item is not for me")
-
-        DigitalInvoiceScreenPresenter(activity, view, compoundExtractions = createLineItemsFixture()).run {
-            listener = mock()
-
-            deselectLineItem(digitalInvoice.selectableLineItems[0])
-
-            // When
-            pay()
-
-            // Then
-            verify(listener)?.onPayInvoice(
-                    selectedLineItems = eq(digitalInvoice.selectableLineItems.takeLast(2).map { it.lineItem }),
-                    selectedLineItemsTotalPrice = any(),
-                    deselectedLineItems = eq(listOf(digitalInvoice.selectableLineItems[0].lineItem)),
-                    reviewedCompoundExtractions = any(),
-                    reviewedExtractions = any())
-        }
-    }
-
-    @Test
-    fun `should return total price of selected line items when the 'Pay' button was clicked`() {
-        // Given
-        view = ViewWithSelectedReturnReason("Item is not for me")
-
-        DigitalInvoiceScreenPresenter(activity, view, compoundExtractions = createLineItemsFixture()).run {
-            listener = mock()
-
-            deselectLineItem(digitalInvoice.selectableLineItems[0])
-
-            // When
-            pay()
-
-            // Then
-            verify(listener)?.onPayInvoice(
-                    selectedLineItems = any(),
-                    selectedLineItemsTotalPrice = eq("28.58:EUR"),
-                    deselectedLineItems = any(),
-                    reviewedCompoundExtractions = any(),
-                    reviewedExtractions = any())
-        }
-    }
-
-    @Test
     fun `should update amount in extractions when the 'Pay' button was clicked`() {
         // Given
         view = ViewWithSelectedReturnReason("Item is not for me")
@@ -412,12 +367,8 @@ class DigitalInvoiceScreenPresenterTest {
             pay()
 
             // Then
-            verify(listener)?.onPayInvoice(
-                    selectedLineItems = any(),
-                    selectedLineItemsTotalPrice = any(),
-                    deselectedLineItems = any(),
-                    reviewedCompoundExtractions = any(),
-                    reviewedExtractions = argThat { get("amountToPay")?.value?.equals("28.58:EUR") ?: false })
+            verify(listener)?.onPayInvoice(specificExtractions = argThat { get("amountToPay")?.value?.equals("28.58:EUR") ?: false },
+                    compoundExtractions = any())
         }
     }
 
@@ -443,18 +394,14 @@ class DigitalInvoiceScreenPresenterTest {
             pay()
 
             // Then
-            verify(listener)?.onPayInvoice(
-                    selectedLineItems = any(),
-                    selectedLineItemsTotalPrice = any(),
-                    deselectedLineItems = any(),
-                    reviewedCompoundExtractions = argThat {
+            verify(listener)?.onPayInvoice(specificExtractions = any(),
+                    compoundExtractions = argThat {
                         val specificExtractionMaps = get("lineItems")?.specificExtractionMaps
                         specificExtractionMaps?.size == 3
                                 && specificExtractionMaps[0]["quantity"]?.value.equals("0")
                                 && specificExtractionMaps[1]["quantity"]?.value.equals("99")
                                 && specificExtractionMaps[2]["baseGross"]?.value.equals("203.19:EUR")
-                    },
-                    reviewedExtractions = any())
+                    })
         }
     }
 


### PR DESCRIPTION
Review after #273 .

Return the extractions with the following modifications:
* Update (or adds if missing) the "amountToPay" with the total price of the selected line items.
* Update the line item extractions with the changes made by the user. Deselected line items have their quantity set to 0.

### How to test
Run the component api example app, modify the line items and check that the extraction results have changed accordingly.

### Ticket 
[PIA-570](https://ginis.atlassian.net/browse/PIA-570)
