### PR TITLE
Disable return reasons picker

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/digitalinvoice/DigitalInvoice.kt
+++ b/ginivision/src/main/java/net/gini/android/vision/digitalinvoice/DigitalInvoice.kt
@@ -73,7 +73,7 @@ class DigitalInvoice(extractions: Map<String, GiniVisionSpecificExtraction>,
         }
     }
 
-    fun deselectLineItem(selectableLineItem: SelectableLineItem, reason: String) {
+    fun deselectLineItem(selectableLineItem: SelectableLineItem, reason: String?) {
         selectableLineItems.find { sli -> sli.lineItem.id == selectableLineItem.lineItem.id }?.let { sli ->
             sli.selected = false
             sli.reason = reason

--- a/ginivision/src/main/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceScreenPresenter.kt
+++ b/ginivision/src/main/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceScreenPresenter.kt
@@ -11,16 +11,6 @@ import net.gini.android.vision.network.model.GiniVisionSpecificExtraction
  * Copyright (c) 2019 Gini GmbH.
  */
 
-val mockReasons = listOf(
-        "Looks different than site image",
-        "Poor quality/fault",
-        "Doesn't fit properly",
-        "Doesn't suite me",
-        "Received wrong item",
-        "Parcel damaged",
-        "Arrived too late"
-)
-
 internal open class DigitalInvoiceScreenPresenter(activity: Activity,
                                                   view: DigitalInvoiceScreenContract.View,
                                                   val extractions: Map<String, GiniVisionSpecificExtraction> = emptyMap(),
@@ -31,7 +21,7 @@ internal open class DigitalInvoiceScreenPresenter(activity: Activity,
 
     @VisibleForTesting
     val digitalInvoice: DigitalInvoice
-    var returnReasons: List<String> = mockReasons
+    var returnReasons: List<String> = emptyList()
 
     init {
         view.setPresenter(this)
@@ -44,14 +34,18 @@ internal open class DigitalInvoiceScreenPresenter(activity: Activity,
     }
 
     override fun deselectLineItem(lineItem: SelectableLineItem) {
-        view.showReturnReasonDialog(returnReasons) { selectedReason ->
-            if (selectedReason != null) {
-                digitalInvoice.deselectLineItem(lineItem, selectedReason)
-            } else {
-                digitalInvoice.selectLineItem(lineItem)
+        if (returnReasons.isEmpty()) {
+            digitalInvoice.deselectLineItem(lineItem, null)
+        } else {
+            view.showReturnReasonDialog(returnReasons) { selectedReason ->
+                if (selectedReason != null) {
+                    digitalInvoice.deselectLineItem(lineItem, selectedReason)
+                } else {
+                    digitalInvoice.selectLineItem(lineItem)
+                }
             }
-            updateView()
         }
+        updateView()
     }
 
     override fun editLineItem(lineItem: SelectableLineItem) {

--- a/ginivision/src/main/java/net/gini/android/vision/digitalinvoice/details/LineItemDetailsScreenPresenter.kt
+++ b/ginivision/src/main/java/net/gini/android/vision/digitalinvoice/details/LineItemDetailsScreenPresenter.kt
@@ -6,7 +6,6 @@ import net.gini.android.vision.digitalinvoice.LineItem
 import net.gini.android.vision.digitalinvoice.SelectableLineItem
 import net.gini.android.vision.digitalinvoice.details.LineItemDetailsScreenContract.Presenter
 import net.gini.android.vision.digitalinvoice.details.LineItemDetailsScreenContract.View
-import net.gini.android.vision.digitalinvoice.mockReasons
 import java.math.BigDecimal
 import java.text.DecimalFormat
 import java.text.ParseException
@@ -26,7 +25,7 @@ class LineItemDetailsScreenPresenter(activity: Activity, view: View,
 
     override var listener: LineItemDetailsFragmentListener? = null
 
-    var returnReasons: List<String> = mockReasons
+    var returnReasons: List<String> = emptyList()
 
     private val originalLineItem: SelectableLineItem = selectableLineItem.copy()
 
@@ -53,21 +52,27 @@ class LineItemDetailsScreenPresenter(activity: Activity, view: View,
         if (!selectableLineItem.selected) {
             return
         }
-        view.showReturnReasonDialog(returnReasons) { selectedReason ->
-            if (selectedReason != null) {
-                selectableLineItem.selected = false
-                selectableLineItem.reason = selectedReason
-                view.disableInput()
-            } else {
-                selectableLineItem.selected = true
-                selectableLineItem.reason = null
-                view.enableInput()
-            }
-            selectableLineItem.let {
-                view.apply {
-                    showCheckbox(it.selected, it.lineItem.quantity)
-                    updateSaveButton(it, originalLineItem)
+        if (returnReasons.isEmpty()) {
+            selectableLineItem.selected = false
+            selectableLineItem.reason = null
+            view.disableInput()
+        } else {
+            view.showReturnReasonDialog(returnReasons) { selectedReason ->
+                if (selectedReason != null) {
+                    selectableLineItem.selected = false
+                    selectableLineItem.reason = selectedReason
+                    view.disableInput()
+                } else {
+                    selectableLineItem.selected = true
+                    selectableLineItem.reason = null
+                    view.enableInput()
                 }
+            }
+        }
+        selectableLineItem.let {
+            view.apply {
+                showCheckbox(it.selected, it.lineItem.quantity)
+                updateSaveButton(it, originalLineItem)
             }
         }
     }

--- a/ginivision/src/test/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceScreenPresenterTest.kt
+++ b/ginivision/src/test/java/net/gini/android/vision/digitalinvoice/DigitalInvoiceScreenPresenterTest.kt
@@ -53,6 +53,16 @@ class DigitalInvoiceScreenPresenterTest {
             )
     ))
 
+    private val returnReasonsFixture = listOf(
+            "Looks different than site image",
+            "Poor quality/fault",
+            "Doesn't fit properly",
+            "Doesn't suite me",
+            "Received wrong item",
+            "Parcel damaged",
+            "Arrived too late"
+    )
+
     private fun totalLineItemsCount(selectableLineItems: List<SelectableLineItem>) = selectableLineItems.fold(
             0) { c, sli -> c + sli.lineItem.quantity }
 
@@ -196,6 +206,8 @@ class DigitalInvoiceScreenPresenterTest {
         view = spy(ViewWithSelectedReturnReason("Item is not for me"))
 
         DigitalInvoiceScreenPresenter(activity, view, compoundExtractions = createLineItemsFixture()).run {
+            returnReasons = returnReasonsFixture
+
             // When
             deselectLineItem(digitalInvoice.selectableLineItems.first())
 
@@ -210,6 +222,8 @@ class DigitalInvoiceScreenPresenterTest {
         view = spy(ViewWithSelectedReturnReason(null))
 
         DigitalInvoiceScreenPresenter(activity, view, compoundExtractions = createLineItemsFixture()).run {
+            returnReasons = returnReasonsFixture
+
             // When
             deselectLineItem(digitalInvoice.selectableLineItems.first())
 
@@ -233,9 +247,11 @@ class DigitalInvoiceScreenPresenterTest {
     }
 
     @Test
-    fun `should show return reason dialog when deselecting a line item`() {
+    fun `should show return reason dialog when deselecting a line item, if there are return reasons`() {
         // Given
         DigitalInvoiceScreenPresenter(activity, view, compoundExtractions = createLineItemsFixture()).run {
+            returnReasons = returnReasonsFixture
+
             // When
             deselectLineItem(digitalInvoice.selectableLineItems.first())
 
@@ -255,6 +271,30 @@ class DigitalInvoiceScreenPresenterTest {
 
             // Then
             assertThat(digitalInvoice.selectableLineItems.first().selected).isFalse()
+        }
+    }
+
+    @Test
+    fun `should not show return reason dialog, if there are no return reasons`() {
+        // Given
+        DigitalInvoiceScreenPresenter(activity, view, compoundExtractions = createLineItemsFixture()).run {
+            // When
+            deselectLineItem(digitalInvoice.selectableLineItems.first())
+
+            // Then
+            assertThat(digitalInvoice.selectableLineItems.first().selected).isFalse()
+        }
+    }
+
+    @Test
+    fun `should update view when deselecting a line item, if there are no return reasons`() {
+        // Given
+        DigitalInvoiceScreenPresenter(activity, view, compoundExtractions = createLineItemsFixture()).run {
+            // When
+            deselectLineItem(digitalInvoice.selectableLineItems.first())
+
+            // Then
+            verify(view).showLineItems(digitalInvoice.selectableLineItems)
         }
     }
 
@@ -295,6 +335,7 @@ class DigitalInvoiceScreenPresenterTest {
         view = ViewWithSelectedReturnReason("Item is not for me")
 
         DigitalInvoiceScreenPresenter(activity, view, compoundExtractions = createLineItemsFixture()).run {
+            returnReasons = returnReasonsFixture
 
             // When
             deselectLineItem(digitalInvoice.selectableLineItems.first())
@@ -310,6 +351,8 @@ class DigitalInvoiceScreenPresenterTest {
         view = ViewWithSelectedReturnReason(null)
 
         DigitalInvoiceScreenPresenter(activity, view, compoundExtractions = createLineItemsFixture()).run {
+            returnReasons = returnReasonsFixture
+
             // When
             deselectLineItem(digitalInvoice.selectableLineItems.first())
 

--- a/ginivision/src/test/java/net/gini/android/vision/digitalinvoice/details/LineItemDetailsScreenPresenterTest.kt
+++ b/ginivision/src/test/java/net/gini/android/vision/digitalinvoice/details/LineItemDetailsScreenPresenterTest.kt
@@ -38,6 +38,16 @@ class LineItemDetailsScreenPresenterTest {
     private val decimalFormat = DecimalFormat("#,##0.00", DecimalFormatSymbols.getInstance(
             Locale.ENGLISH)).apply { isParseBigDecimal = true }
 
+    private val returnReasonsFixture = listOf(
+            "Looks different than site image",
+            "Poor quality/fault",
+            "Doesn't fit properly",
+            "Doesn't suite me",
+            "Received wrong item",
+            "Parcel damaged",
+            "Arrived too late"
+    )
+
     @Before
     fun setUp() {
         initMocks(this)
@@ -118,7 +128,7 @@ class LineItemDetailsScreenPresenterTest {
     }
 
     @Test
-    fun `should deselect line item when a reason was selected`() {
+    fun `should deselect line item when a reason was selected, if there are return reasons`() {
         // Given
         val view = spy(ViewWithSelectedReturnReason("Item is not for me"))
 
@@ -126,6 +136,8 @@ class LineItemDetailsScreenPresenterTest {
                 lineItem = LineItem(id = "1", description = "Line Item 1", quantity = 3,
                         rawGrossPrice = "1.19:EUR"))
         LineItemDetailsScreenPresenter(activity, view, sli).run {
+            returnReasons = returnReasonsFixture
+
             // When
             deselectLineItem()
 
@@ -145,6 +157,8 @@ class LineItemDetailsScreenPresenterTest {
                 lineItem = LineItem(id = "1", description = "Line Item 1", quantity = 3,
                         rawGrossPrice = "1.19:EUR"))
         LineItemDetailsScreenPresenter(activity, view, sli).run {
+            returnReasons = returnReasonsFixture
+
             // When
             deselectLineItem()
 
@@ -162,6 +176,8 @@ class LineItemDetailsScreenPresenterTest {
                 lineItem = LineItem(id = "1", description = "Line Item 1", quantity = 3,
                         rawGrossPrice = "1.19:EUR"))
         LineItemDetailsScreenPresenter(activity, view, sli).run {
+            returnReasons = returnReasonsFixture
+
             // When
             deselectLineItem()
 
@@ -186,6 +202,23 @@ class LineItemDetailsScreenPresenterTest {
 
             // Then
             assertThat(selectableLineItem.reason).isNull()
+        }
+    }
+
+    @Test
+    fun `should not show return reason dialog, if there are no return reasons`() {
+        // Given
+        val sli = SelectableLineItem(selected = true,
+                lineItem = LineItem(id = "1", description = "Line Item 1", quantity = 3,
+                        rawGrossPrice = "1.19:EUR"))
+        LineItemDetailsScreenPresenter(activity, view, sli).run {
+            // When
+            deselectLineItem()
+
+            // Then
+            verify(view).disableInput()
+            verify(view).showCheckbox(false, 3)
+            verify(view).enableSaveButton()
         }
     }
 


### PR DESCRIPTION
Return reasons picker is only shown if there is a list of return reasons to pick from. I've set an empty list which disables the picker.

### How to test
Run one of the example apps and check that return reasons picker is not shown.

### Ticket 
[PIA-575](https://ginis.atlassian.net/browse/PIA-575)
