### PR TITLE
Deprecated unused methods and updated related javadoc comments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,110 +67,104 @@ pipeline {
                 }
             }
         }
-        stage('Run Tests') {
-            parallel {
-                stage('Unit Tests') {
-                    when {
-                        anyOf {
-                            not {
-                                branch 'master'
-                            }
-                            allOf {
-                                branch 'master'
-                                expression {
-                                    def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                                    return !tag.isEmpty()
-                                }
-                            }
-                        }
+        stage('Unit Tests') {
+            when {
+                anyOf {
+                    not {
+                        branch 'master'
                     }
-                    steps {
-                        sh './gradlew ginivision:testDebugUnitTest'
-                    }
-                    post {
-                        always {
-                            publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'ginivision/build/reports/tests/testDebugUnitTest', reportFiles: 'index.html', reportName: 'Unit Test Results', reportTitles: ''])
+                    allOf {
+                        branch 'master'
+                        expression {
+                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
+                            return !tag.isEmpty()
                         }
                     }
                 }
-                stage('Instrumentation Tests - Phone') {
-                    when {
-                        anyOf {
-                            not {
-                                branch 'master'
-                            }
-                            allOf {
-                                branch 'master'
-                                expression {
-                                    def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                                    return !tag.isEmpty()
-                                }
-                            }
-                        }
+            }
+            steps {
+                sh './gradlew ginivision:testDebugUnitTest'
+            }
+            post {
+                always {
+                    publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'ginivision/build/reports/tests/testDebugUnitTest', reportFiles: 'index.html', reportName: 'Unit Test Results', reportTitles: ''])
+                }
+            }
+        }
+        stage('Instrumentation Tests - Phone') {
+            when {
+                anyOf {
+                    not {
+                        branch 'master'
                     }
-                    steps {
-                        lock('emulator-phone') {
-                            script {
-                                def emulatorPort = emulator.start(avd.createName("api-25-pixel"), "pixel", "-prop persist.sys.language=en -prop persist.sys.country=US -gpu host -camera-back emulated -no-snapshot", 5562)
-                                sh "echo $emulatorPort > emulator_port_1_$BUILD_NUMBER"
-                                adb.setAnimationDurationScale("emulator-$emulatorPort", 0)
-                                withEnv(["PATH+TOOLS=$ANDROID_HOME/tools", "PATH+TOOLS_BIN=$ANDROID_HOME/tools/bin", "PATH+PLATFORM_TOOLS=$ANDROID_HOME/platform-tools"]) {
-                                    sh "ANDROID_SERIAL=emulator-$emulatorPort ./gradlew ginivision:connectedAndroidTest"
-                                }
-                            }
-                        }
-                    }
-                    post {
-                        always {
-                            junit allowEmptyResults: true, testResults: 'ginivision/build/outputs/androidTest-results/connected/*.xml'
-                            script {
-                                def emulatorPort = sh returnStdout: true, script: "cat emulator_port_1_$BUILD_NUMBER"
-                                emulatorPort = emulatorPort.trim().replaceAll("\r", "").replaceAll("\n", "")
-                                emulator.stop(emulatorPort)
-                                sh "rm emulator_port_1_$BUILD_NUMBER || true"
-                            }
+                    allOf {
+                        branch 'master'
+                        expression {
+                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
+                            return !tag.isEmpty()
                         }
                     }
                 }
-                stage('Instrumentation Tests - Tablet') {
-                    when {
-                        anyOf {
-                            not {
-                                branch 'master'
-                            }
-                            allOf {
-                                branch 'master'
-                                expression {
-                                    def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                                    return !tag.isEmpty()
-                                }
-                            }
+            }
+            steps {
+                lock('emulator-phone') {
+                    script {
+                        def emulatorPort = emulator.start(avd.createName("api-25-pixel"), "pixel", "-prop persist.sys.language=en -prop persist.sys.country=US -gpu host -camera-back emulated -no-snapshot", 5562)
+                        sh "echo $emulatorPort > emulator_port_1_$BUILD_NUMBER"
+                        adb.setAnimationDurationScale("emulator-$emulatorPort", 0)
+                        withEnv(["PATH+TOOLS=$ANDROID_HOME/tools", "PATH+TOOLS_BIN=$ANDROID_HOME/tools/bin", "PATH+PLATFORM_TOOLS=$ANDROID_HOME/platform-tools"]) {
+                            sh "ANDROID_SERIAL=emulator-$emulatorPort ./gradlew ginivision:connectedAndroidTest"
                         }
                     }
-                    steps {
-                        lock('emulator-tablet') {
-                            script {
-                                def emulatorPort = emulator.start(avd.createName("api-25-nexus-9"), "nexus_9", "-prop persist.sys.language=en -prop persist.sys.country=US -gpu host -camera-back emulated -no-snapshot", 5570)
-                                sh "echo $emulatorPort > emulator_port_2_$BUILD_NUMBER"
-                                adb.setAnimationDurationScale("emulator-$emulatorPort", 0)
-                                // need to wait, otherwise the processDebugAndroidTestResources task fails due to conflict with the build for the phone emulator
-                                sleep(time: 1, unit: "MINUTES")
-                                withEnv(["PATH+TOOLS=$ANDROID_HOME/tools", "PATH+TOOLS_BIN=$ANDROID_HOME/tools/bin", "PATH+PLATFORM_TOOLS=$ANDROID_HOME/platform-tools"]) {
-                                    sh "ANDROID_SERIAL=emulator-$emulatorPort ./gradlew ginivision:connectedAndroidTest"
-                                }
-                            }
+                }
+            }
+            post {
+                always {
+                    junit allowEmptyResults: true, testResults: 'ginivision/build/outputs/androidTest-results/connected/*.xml'
+                    script {
+                        def emulatorPort = sh returnStdout: true, script: "cat emulator_port_1_$BUILD_NUMBER"
+                        emulatorPort = emulatorPort.trim().replaceAll("\r", "").replaceAll("\n", "")
+                        emulator.stop(emulatorPort)
+                        sh "rm emulator_port_1_$BUILD_NUMBER || true"
+                    }
+                }
+            }
+        }
+        stage('Instrumentation Tests - Tablet') {
+            when {
+                anyOf {
+                    not {
+                        branch 'master'
+                    }
+                    allOf {
+                        branch 'master'
+                        expression {
+                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
+                            return !tag.isEmpty()
                         }
                     }
-                    post {
-                        always {
-                            junit allowEmptyResults: true, testResults: 'ginivision/build/outputs/androidTest-results/connected/*.xml'
-                            script {
-                                def emulatorPort = sh returnStdout: true, script: "cat emulator_port_2_$BUILD_NUMBER"
-                                emulatorPort = emulatorPort.trim().replaceAll("\r", "").replaceAll("\n", "")
-                                emulator.stop(emulatorPort)
-                                sh "rm emulator_port_2_$BUILD_NUMBER || true"
-                            }
+                }
+            }
+            steps {
+                lock('emulator-tablet') {
+                    script {
+                        def emulatorPort = emulator.start(avd.createName("api-25-nexus-9"), "nexus_9", "-prop persist.sys.language=en -prop persist.sys.country=US -gpu host -camera-back emulated -no-snapshot", 5570)
+                        sh "echo $emulatorPort > emulator_port_2_$BUILD_NUMBER"
+                        adb.setAnimationDurationScale("emulator-$emulatorPort", 0)
+                        withEnv(["PATH+TOOLS=$ANDROID_HOME/tools", "PATH+TOOLS_BIN=$ANDROID_HOME/tools/bin", "PATH+PLATFORM_TOOLS=$ANDROID_HOME/platform-tools"]) {
+                            sh "ANDROID_SERIAL=emulator-$emulatorPort ./gradlew ginivision:connectedAndroidTest"
                         }
+                    }
+                }
+            }
+            post {
+                always {
+                    junit allowEmptyResults: true, testResults: 'ginivision/build/outputs/androidTest-results/connected/*.xml'
+                    script {
+                        def emulatorPort = sh returnStdout: true, script: "cat emulator_port_2_$BUILD_NUMBER"
+                        emulatorPort = emulatorPort.trim().replaceAll("\r", "").replaceAll("\n", "")
+                        emulator.stop(emulatorPort)
+                        sh "rm emulator_port_2_$BUILD_NUMBER || true"
                     }
                 }
             }

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
@@ -18,6 +18,7 @@ import net.gini.android.vision.GiniVisionCoordinator;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.R;
 import net.gini.android.vision.analysis.AnalysisActivity;
+import net.gini.android.vision.analysis.AnalysisFragmentListener;
 import net.gini.android.vision.camera.CameraActivity;
 import net.gini.android.vision.network.GiniVisionNetworkApi;
 import net.gini.android.vision.network.GiniVisionNetworkService;
@@ -402,8 +403,8 @@ public class ReviewActivity extends AppCompatActivity implements ReviewFragmentL
      *
      * @deprecated When a {@link GiniVision} and a {@link GiniVisionNetworkService} instance is
      * available rotation is handled internally. The document is analyzed by using the configured
-     * {@link GiniVisionNetworkService} implementation. The extractions will be returned in {@link
-     * ReviewFragmentListener#onExtractionsAvailable(Map)}.
+     * {@link GiniVisionNetworkService} implementation. The extractions will be returned in the
+     * Analysis Screen in {@link AnalysisFragmentListener#onExtractionsAvailable(Map, Map)}.
      */
     @Override
     public void onDocumentWasRotated(@NonNull final Document document, final int oldRotation,

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentInterface.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentInterface.java
@@ -6,6 +6,7 @@ import net.gini.android.vision.Document;
 import net.gini.android.vision.GiniVision;
 import net.gini.android.vision.analysis.AnalysisActivity;
 import net.gini.android.vision.analysis.AnalysisFragmentCompat;
+import net.gini.android.vision.analysis.AnalysisFragmentListener;
 import net.gini.android.vision.analysis.AnalysisFragmentStandard;
 import net.gini.android.vision.network.GiniVisionNetworkService;
 
@@ -32,7 +33,8 @@ public interface ReviewFragmentInterface {
      *
      * @deprecated When a {@link GiniVision} instance is available the document is analyzed
      * internally by using the configured {@link GiniVisionNetworkService} implementation. The
-     * extractions will be returned in {@link ReviewFragmentListener#onExtractionsAvailable(Map)}.
+     * extractions will be returned in the Analysis Screen in
+     * {@link AnalysisFragmentListener#onExtractionsAvailable(Map, Map)}.
      */
     @Deprecated
     void onDocumentAnalyzed();

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentListener.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentListener.java
@@ -7,6 +7,7 @@ import net.gini.android.vision.Document;
 import net.gini.android.vision.GiniVision;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.analysis.AnalysisActivity;
+import net.gini.android.vision.analysis.AnalysisFragmentListener;
 import net.gini.android.vision.network.GiniVisionNetworkService;
 import net.gini.android.vision.network.model.GiniVisionSpecificExtraction;
 import net.gini.android.vision.noresults.NoResultsFragmentCompat;
@@ -35,7 +36,8 @@ public interface ReviewFragmentListener {
      *
      * @deprecated When a {@link GiniVision} instance is available the document is analyzed
      * internally by using the configured {@link GiniVisionNetworkService} implementation. The
-     * extractions will be returned in {@link ReviewFragmentListener#onExtractionsAvailable(Map)}.
+     * extractions will be returned in the Analysis Screen in
+     * {@link AnalysisFragmentListener#onExtractionsAvailable(Map, Map)}.
      */
     @Deprecated
     void onShouldAnalyzeDocument(@NonNull Document document);
@@ -67,7 +69,8 @@ public interface ReviewFragmentListener {
      *
      * @deprecated When a {@link GiniVision} instance is available the document is analyzed
      * internally by using the configured {@link GiniVisionNetworkService} implementation. The
-     * extractions will be returned in {@link ReviewFragmentListener#onExtractionsAvailable(Map)}.
+     * extractions will be returned in the Analysis Screen in
+     * {@link AnalysisFragmentListener#onExtractionsAvailable(Map, Map)}.
      */
     @Deprecated
     void onDocumentReviewedAndAnalyzed(@NonNull Document document);
@@ -84,9 +87,10 @@ public interface ReviewFragmentListener {
      *
      * @deprecated When a {@link GiniVision} and a {@link GiniVisionNetworkService} instance is
      * available rotation is handled internally. The document is analyzed by using the configured
-     * {@link GiniVisionNetworkService} implementation. The extractions will be returned in {@link
-     * ReviewFragmentListener#onExtractionsAvailable(Map)}.
+     * {@link GiniVisionNetworkService} implementation. The extractions will be returned in the
+     * Analysis Screen in {@link AnalysisFragmentListener#onExtractionsAvailable(Map, Map)}.
      */
+    @Deprecated
     void onDocumentWasRotated(@NonNull Document document, int oldRotation, int newRotation);
 
     /**
@@ -100,7 +104,13 @@ public interface ReviewFragmentListener {
      * Called when the document has been analyzed and extractions are available.
      *
      * @param extractions a map of the extractions with the extraction labels as keys
+     *
+     * @deprecated When a {@link GiniVision} instance is available the document is analyzed
+     * internally by using the configured {@link GiniVisionNetworkService} implementation. The
+     * extractions will be returned in the Analysis Screen in
+     * {@link AnalysisFragmentListener#onExtractionsAvailable(Map, Map)}.
      */
+    @Deprecated
     void onExtractionsAvailable(
             @NonNull final Map<String, GiniVisionSpecificExtraction> extractions);
 
@@ -111,7 +121,13 @@ public interface ReviewFragmentListener {
      * NoResultsFragmentCompat}.
      *
      * @param document contains the reviewed document
+     *
+     * @deprecated When a {@link GiniVision} instance is available the document is analyzed
+     * internally by using the configured {@link GiniVisionNetworkService} implementation. The
+     * extractions will be returned in the Analysis Screen in
+     * {@link AnalysisFragmentListener#onExtractionsAvailable(Map, Map)}.
      */
+    @Deprecated
     void onProceedToNoExtractionsScreen(@NonNull final Document document);
 
     /**


### PR DESCRIPTION
Noticed that two methods which were not used anymore were not deprecated and were wrongly referenced in some javadoc comments. Fixed it now.
