### PR TITLE
Limits picture resolutions to 13 MP

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://repo.gini.net/nexus/content/repositories/open" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenLocal" />
+      <option name="name" value="MavenLocal" />
+      <option name="url" value="file:$MAVEN_REPOSITORY$/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,12 +3,13 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/buildSrc/buildSrc.iml" filepath="$PROJECT_DIR$/buildSrc/buildSrc.iml" />
-      <module fileurl="file://$PROJECT_DIR$/componentapiexample/componentapiexample.iml" filepath="$PROJECT_DIR$/componentapiexample/componentapiexample.iml" />
-      <module fileurl="file://$PROJECT_DIR$/gini-vision-lib-android.iml" filepath="$PROJECT_DIR$/gini-vision-lib-android.iml" />
-      <module fileurl="file://$PROJECT_DIR$/ginivision/ginivision.iml" filepath="$PROJECT_DIR$/ginivision/ginivision.iml" />
-      <module fileurl="file://$PROJECT_DIR$/ginivision-accounting-network/ginivision-accounting-network.iml" filepath="$PROJECT_DIR$/ginivision-accounting-network/ginivision-accounting-network.iml" />
-      <module fileurl="file://$PROJECT_DIR$/ginivision-network/ginivision-network.iml" filepath="$PROJECT_DIR$/ginivision-network/ginivision-network.iml" />
-      <module fileurl="file://$PROJECT_DIR$/screenapiexample/screenapiexample.iml" filepath="$PROJECT_DIR$/screenapiexample/screenapiexample.iml" />
+      <module fileurl="file://$PROJECT_DIR$/componentapiexample/componentapiexample.iml" filepath="$PROJECT_DIR$/componentapiexample/componentapiexample.iml" group="gini-vision-lib-android/componentapiexample" />
+      <module fileurl="file://$PROJECT_DIR$/gini-vision-lib-android.iml" filepath="$PROJECT_DIR$/gini-vision-lib-android.iml" group="gini-vision-lib-android" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/gini-vision-lib-android_buildSrc.iml" filepath="$PROJECT_DIR$/.idea/modules/gini-vision-lib-android_buildSrc.iml" group="gini-vision-lib-android/gini-vision-lib-android_buildSrc" />
+      <module fileurl="file://$PROJECT_DIR$/ginivision/ginivision.iml" filepath="$PROJECT_DIR$/ginivision/ginivision.iml" group="gini-vision-lib-android/ginivision" />
+      <module fileurl="file://$PROJECT_DIR$/ginivision-accounting-network/ginivision-accounting-network.iml" filepath="$PROJECT_DIR$/ginivision-accounting-network/ginivision-accounting-network.iml" group="gini-vision-lib-android/ginivision-accounting-network" />
+      <module fileurl="file://$PROJECT_DIR$/ginivision-network/ginivision-network.iml" filepath="$PROJECT_DIR$/ginivision-network/ginivision-network.iml" group="gini-vision-lib-android/ginivision-network" />
+      <module fileurl="file://$PROJECT_DIR$/screenapiexample/screenapiexample.iml" filepath="$PROJECT_DIR$/screenapiexample/screenapiexample.iml" group="gini-vision-lib-android/screenapiexample" />
     </modules>
   </component>
 </project>

--- a/gini-vision-lib-android.iml
+++ b/gini-vision-lib-android.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="gini-vision-lib-android" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="gini-vision-lib-android" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="3.12.0" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>

--- a/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/api/CameraControllerTest.java
+++ b/ginivision/src/androidTest/java/net/gini/android/vision/internal/camera/api/CameraControllerTest.java
@@ -11,6 +11,7 @@ import android.content.Intent;
 import android.hardware.Camera;
 
 import net.gini.android.vision.internal.util.Size;
+import net.gini.android.vision.requirements.CameraResolutionRequirement;
 
 import org.junit.After;
 import org.junit.Before;
@@ -46,8 +47,8 @@ public class CameraControllerTest {
     public void should_useLargestPictureResolution() throws InterruptedException {
         mCameraController = new CameraController(createNoOpActivity());
         final Camera.Parameters parameters = openAndGetCamera().getParameters();
-        final Size largestSize = SizeSelectionHelper.getLargestSize(
-                parameters.getSupportedPictureSizes());
+        final Size largestSize = SizeSelectionHelper.getLargestAllowedSize(
+                parameters.getSupportedPictureSizes(), CameraResolutionRequirement.MAX_PICTURE_AREA);
         assertThat(largestSize).isNotNull();
         final Camera.Size usedSize = parameters.getPictureSize();
         assertThat(usedSize.width).isEqualTo(largestSize.width);
@@ -78,8 +79,8 @@ public class CameraControllerTest {
         final Camera.Parameters parameters = openAndGetCamera().getParameters();
         final Size pictureSize = new Size(parameters.getPictureSize().width,
                 parameters.getPictureSize().height);
-        final Size largestSize = SizeSelectionHelper.getLargestSizeWithSimilarAspectRatio(
-                parameters.getSupportedPreviewSizes(), pictureSize);
+        final Size largestSize = SizeSelectionHelper.getLargestAllowedSizeWithSimilarAspectRatio(
+                parameters.getSupportedPreviewSizes(), pictureSize, CameraResolutionRequirement.MAX_PICTURE_AREA);
         assertThat(largestSize).isNotNull();
         final Camera.Size usedSize = parameters.getPreviewSize();
         assertThat(usedSize.width).isEqualTo(largestSize.width);

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
@@ -3,8 +3,8 @@ package net.gini.android.vision.internal.camera.api;
 import static net.gini.android.vision.internal.camera.api.CameraParametersHelper.isFlashModeSupported;
 import static net.gini.android.vision.internal.camera.api.CameraParametersHelper.isFocusModeSupported;
 import static net.gini.android.vision.internal.camera.api.CameraParametersHelper.isUsingFocusMode;
-import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper.getLargestSize;
-import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper.getLargestSizeWithSimilarAspectRatio;
+import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper.getLargestAllowedSize;
+import static net.gini.android.vision.internal.camera.api.SizeSelectionHelper.getLargestAllowedSizeWithSimilarAspectRatio;
 import static net.gini.android.vision.internal.util.DeviceHelper.getDeviceOrientation;
 import static net.gini.android.vision.internal.util.DeviceHelper.getDeviceType;
 
@@ -27,6 +27,7 @@ import net.gini.android.vision.Document;
 import net.gini.android.vision.internal.camera.photo.Photo;
 import net.gini.android.vision.internal.camera.photo.PhotoFactory;
 import net.gini.android.vision.internal.util.Size;
+import net.gini.android.vision.requirements.CameraResolutionRequirement;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -462,7 +463,7 @@ public class CameraController implements CameraInterface {
 
     private void selectPictureSize(final Camera.Parameters params) {
         final List<Camera.Size> pictureSizes = params.getSupportedPictureSizes();
-        final Size pictureSize = getLargestSize(pictureSizes);
+        final Size pictureSize = getLargestAllowedSize(pictureSizes, CameraResolutionRequirement.MAX_PICTURE_AREA);
         if (pictureSize != null) {
             mPictureSize = pictureSize;
             params.setPictureSize(mPictureSize.width, mPictureSize.height);
@@ -474,7 +475,8 @@ public class CameraController implements CameraInterface {
 
     private void selectPreviewSize(final Camera.Parameters params) {
         final List<Camera.Size> previewSizes = params.getSupportedPreviewSizes();
-        final Size previewSize = getLargestSizeWithSimilarAspectRatio(previewSizes, mPictureSize);
+        final Size previewSize = getLargestAllowedSizeWithSimilarAspectRatio(previewSizes, mPictureSize,
+                CameraResolutionRequirement.MAX_PICTURE_AREA);
         if (previewSize != null) {
             mPreviewSize = previewSize;
             params.setPreviewSize(mPreviewSize.width, mPreviewSize.height);

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper.java
@@ -15,10 +15,10 @@ import java.util.List;
 public final class SizeSelectionHelper {
 
     @Nullable
-    public static Size getLargestSize(@NonNull final List<Camera.Size> sizes) {
+    public static Size getLargestAllowedSize(@NonNull final List<Camera.Size> sizes, final int maxArea) {
         Camera.Size largest = null;
         for (final Camera.Size size : sizes) {
-            if (largest == null || getArea(largest) < getArea(size)) {
+            if ((largest == null || getArea(largest) < getArea(size)) && getArea(size) <= maxArea) {
                 largest = size;
             }
         }
@@ -26,10 +26,10 @@ public final class SizeSelectionHelper {
     }
 
     @Nullable
-    public static Size getLargestSizeWithSimilarAspectRatio(
-            @NonNull final List<Camera.Size> sizes, @NonNull final Size referenceSize) {
+    public static Size getLargestAllowedSizeWithSimilarAspectRatio(
+            @NonNull final List<Camera.Size> sizes, @NonNull final Size referenceSize, final int maxArea) {
         final List<Camera.Size> sameAspectSizes = getSameAspectRatioSizes(sizes, referenceSize);
-        return getLargestSize(sameAspectSizes);
+        return getLargestAllowedSize(sameAspectSizes, maxArea);
     }
 
     @NonNull

--- a/ginivision/src/main/java/net/gini/android/vision/requirements/CameraResolutionRequirement.java
+++ b/ginivision/src/main/java/net/gini/android/vision/requirements/CameraResolutionRequirement.java
@@ -8,14 +8,21 @@ import net.gini.android.vision.internal.util.Size;
 
 import java.util.Locale;
 
-class CameraResolutionRequirement implements Requirement {
+/**
+ * Internal use only.
+ *
+ * @exclude
+ */
+public class CameraResolutionRequirement implements Requirement {
 
     // We require ~8MP or higher picture resolutions
-    private static final int MIN_PICTURE_AREA = 7900000;
+    private static final int MIN_PICTURE_AREA = 7_900_000;
+    // We allow up to 13MP picture resolutions
+    public static final int MAX_PICTURE_AREA = 13_000_000;
 
     private final CameraHolder mCameraHolder;
 
-    CameraResolutionRequirement(CameraHolder cameraHolder) {
+    CameraResolutionRequirement(final CameraHolder cameraHolder) {
         mCameraHolder = cameraHolder;
     }
 
@@ -32,10 +39,10 @@ class CameraResolutionRequirement implements Requirement {
         String details = "";
 
         try {
-            Camera.Parameters parameters = mCameraHolder.getCameraParameters();
+            final Camera.Parameters parameters = mCameraHolder.getCameraParameters();
             if (parameters != null) {
-                Size pictureSize = SizeSelectionHelper.getLargestSize(
-                        parameters.getSupportedPictureSizes());
+                final Size pictureSize = SizeSelectionHelper.getLargestAllowedSize(
+                        parameters.getSupportedPictureSizes(), MAX_PICTURE_AREA);
                 if (pictureSize == null) {
                     result = false;
                     details = "Camera has no picture resolutions";
@@ -46,8 +53,8 @@ class CameraResolutionRequirement implements Requirement {
                     return new RequirementReport(getId(), result, details);
                 }
 
-                Size previewSize = SizeSelectionHelper.getLargestSizeWithSimilarAspectRatio(
-                        parameters.getSupportedPreviewSizes(), pictureSize);
+                final Size previewSize = SizeSelectionHelper.getLargestAllowedSizeWithSimilarAspectRatio(
+                        parameters.getSupportedPreviewSizes(), pictureSize, MAX_PICTURE_AREA);
                 if (previewSize == null) {
                     result = false;
                     details = String.format(Locale.US,
@@ -60,7 +67,7 @@ class CameraResolutionRequirement implements Requirement {
                 result = false;
                 details = "Camera not open";
             }
-        } catch (RuntimeException e) {
+        } catch (final RuntimeException e) {
             result = false;
             details = "Camera exception: " + e.getMessage();
         }
@@ -68,7 +75,7 @@ class CameraResolutionRequirement implements Requirement {
         return new RequirementReport(getId(), result, details);
     }
 
-    private boolean isAround8MPOrHigher(Size size) {
+    private boolean isAround8MPOrHigher(final Size size) {
         return size.width * size.height >= MIN_PICTURE_AREA;
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/requirements/DeviceMemoryRequirement.java
+++ b/ginivision/src/main/java/net/gini/android/vision/requirements/DeviceMemoryRequirement.java
@@ -11,7 +11,7 @@ class DeviceMemoryRequirement implements Requirement {
 
     private final CameraHolder mCameraHolder;
 
-    DeviceMemoryRequirement(CameraHolder cameraHolder) {
+    DeviceMemoryRequirement(final CameraHolder cameraHolder) {
         mCameraHolder = cameraHolder;
     }
 
@@ -28,10 +28,10 @@ class DeviceMemoryRequirement implements Requirement {
         String details = "";
 
         try {
-            Camera.Parameters parameters = mCameraHolder.getCameraParameters();
+            final Camera.Parameters parameters = mCameraHolder.getCameraParameters();
             if (parameters != null) {
-                Size pictureSize = SizeSelectionHelper.getLargestSize(
-                        parameters.getSupportedPictureSizes());
+                final Size pictureSize = SizeSelectionHelper.getLargestAllowedSize(
+                        parameters.getSupportedPictureSizes(), CameraResolutionRequirement.MAX_PICTURE_AREA);
                 if (pictureSize == null) {
                     result = false;
                     details =
@@ -44,7 +44,7 @@ class DeviceMemoryRequirement implements Requirement {
                 result = false;
                 details = "Camera not open";
             }
-        } catch (RuntimeException e) {
+        } catch (final RuntimeException e) {
             result = false;
             details = "Camera exception: " + e.getMessage();
         }
@@ -55,17 +55,18 @@ class DeviceMemoryRequirement implements Requirement {
     /**
      * Given a photo size, return whether there is (currently) enough memory available.
      *
-     * @param photoSize       the size of photos that will be used for image processing
+     * @param photoSize the size of photos that will be used for image processing
+     *
      * @return whether there is enough memory for the image processing to succeed
      */
     @VisibleForTesting
-    boolean sufficientMemoryAvailable(Size photoSize) {
-        Runtime runtime = Runtime.getRuntime();
+    boolean sufficientMemoryAvailable(final Size photoSize) {
+        final Runtime runtime = Runtime.getRuntime();
         return sufficientMemoryAvailable(runtime, photoSize);
     }
 
     @VisibleForTesting
-    boolean sufficientMemoryAvailable(Runtime runtime,
+    boolean sufficientMemoryAvailable(final Runtime runtime,
             final Size photoSize) {
         final float memoryUsed = (runtime.totalMemory() - runtime.freeMemory()) / 1024f / 1024f;
         final float memoryNeeded = calculateMemoryUsageForSize(photoSize) / 1024f / 1024f;

--- a/ginivision/src/test/java/net/gini/android/vision/internal/camera/api/Resolutions.java
+++ b/ginivision/src/test/java/net/gini/android/vision/internal/camera/api/Resolutions.java
@@ -86,19 +86,23 @@ final class Resolutions {
     static List<Camera.Size> toSizesList(final int[][] resolutions) {
         final List<Camera.Size> sizes = new ArrayList<>(resolutions.length);
         for (final int[] resolution : resolutions) {
-            final Camera.Size size = mock(Camera.Size.class);
-            size.width = resolution[0];
-            size.height = resolution[1];
-            sizes.add(size);
+            sizes.add(toCameraSize(resolution));
         }
         return sizes;
     }
 
-    static Size toSize(int[] resolution) {
+    static Camera.Size toCameraSize(final int[] resolution) {
+        final Camera.Size size = mock(Camera.Size.class);
+        size.width = resolution[0];
+        size.height = resolution[1];
+        return size;
+    }
+
+    static Size toSize(final int[] resolution) {
         return new Size(resolution[0], resolution[1]);
     }
 
-    static void assertSizeEqualsResolution(final Size largestSize, int[] expectedResolution) {
+    static void assertSizeEqualsResolution(final Size largestSize, final int[] expectedResolution) {
         assertThat(largestSize).isNotNull();
         assertThat(largestSize.width).isEqualTo(expectedResolution[0]);
         assertThat(largestSize.height).isEqualTo(expectedResolution[1]);

--- a/ginivision/src/test/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper_GetLargestAllowedSizeTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper_GetLargestAllowedSizeTest.java
@@ -19,35 +19,39 @@ import java.util.Collection;
 import java.util.List;
 
 @RunWith(Parameterized.class)
-public class SizeSelectionHelper_GetLargestSizeTest {
+public class SizeSelectionHelper_GetLargestAllowedSizeTest {
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][]{
                 {"Largest from decreasing resolutions", DECREASING_RESOLUTIONS,
-                        new int[]{4096, 3072}},
+                        new int[]{3264, 2448}, 8_000_000},
                 {"Largest from increasing resolutions", INCREASING_RESOLUTIONS,
-                        new int[]{4096, 3072}},
-                {"Largest from unsorted resolutions", UNSORTED_RESOLUTIONS, new int[]{4096, 3072}}
+                        new int[]{3264, 2448}, 8_000_000},
+                {"Largest from unsorted resolutions", UNSORTED_RESOLUTIONS,
+                        new int[]{3264, 2448}, 8_000_000}
         });
     }
 
     private final String description;
     private final int[][] resolutions;
     private final int[] expectedResolution;
+    private final int maxArea;
 
-    public SizeSelectionHelper_GetLargestSizeTest(final String description,
+    public SizeSelectionHelper_GetLargestAllowedSizeTest(final String description,
             final int[][] resolutions,
-            final int[] expectedResolution) {
+            final int[] expectedResolution,
+            final int maxArea) {
         this.description = description;
         this.resolutions = resolutions;
         this.expectedResolution = expectedResolution;
+        this.maxArea = maxArea;
     }
 
     @Test
-    public void should_returnLargestSize() {
-        List<Camera.Size> sizes = toSizesList(resolutions);
-        Size largestSize = SizeSelectionHelper.getLargestSize(sizes);
+    public void should_returnLargestAllowedSize() {
+        final List<Camera.Size> sizes = toSizesList(resolutions);
+        final Size largestSize = SizeSelectionHelper.getLargestAllowedSize(sizes, maxArea);
         assertSizeEqualsResolution(largestSize, expectedResolution);
     }
 }

--- a/ginivision/src/test/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper_GetLargestAllowedSizeWithSameAspectRatioTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper_GetLargestAllowedSizeWithSameAspectRatioTest.java
@@ -20,52 +20,52 @@ import java.util.Collection;
 import java.util.List;
 
 @RunWith(Parameterized.class)
-public class SizeSelectionHelper_GetLargestSizeWithSameAspectRatioTest {
+public class SizeSelectionHelper_GetLargestAllowedSizeWithSameAspectRatioTest {
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][]{
                 // 16:9, (~1.77)
                 {"Largest 16:9 from decreasing resolutions", DECREASING_RESOLUTIONS,
-                        new int[]{16, 9}, new int[]{4096, 2304}},
+                        new int[]{16, 9}, new int[]{1920, 1080}, 8_000_000},
                 {"Largest 16:9 from increasing resolutions", INCREASING_RESOLUTIONS,
-                        new int[]{16, 9}, new int[]{4096, 2304}},
+                        new int[]{16, 9}, new int[]{1920, 1080}, 8_000_000},
                 {"Largest 16:9 from unsorted resolutions", UNSORTED_RESOLUTIONS,
-                        new int[]{16, 9}, new int[]{4096, 2304}},
+                        new int[]{16, 9}, new int[]{1920, 1080}, 8_000_000},
                 // 4:3, (~1.33)
                 {"Largest 4:3 from decreasing resolutions", DECREASING_RESOLUTIONS,
-                        new int[]{4, 3}, new int[]{4096, 3072}},
+                        new int[]{4, 3}, new int[]{3264, 2448}, 8_000_000},
                 {"Largest 4:3 from increasing resolutions", INCREASING_RESOLUTIONS,
-                        new int[]{4, 3}, new int[]{4096, 3072}},
+                        new int[]{4, 3}, new int[]{3264, 2448}, 8_000_000},
                 {"Largest 4:3 from unsorted resolutions", UNSORTED_RESOLUTIONS,
-                        new int[]{4, 3}, new int[]{4096, 3072}},
+                        new int[]{4, 3}, new int[]{3264, 2448}, 8_000_000},
                 // 14:9 (~1.55)
                 {"Largest 14:9 from decreasing resolutions", DECREASING_RESOLUTIONS,
-                        new int[]{376, 240}, new int[]{3200, 2048}},
+                        new int[]{376, 240}, new int[]{3200, 2048}, 8_000_000},
                 {"Largest 14:9 from increasing resolutions", INCREASING_RESOLUTIONS,
-                        new int[]{376, 240}, new int[]{3200, 2048}},
+                        new int[]{376, 240}, new int[]{3200, 2048}, 8_000_000},
                 {"Largest 14:9 from unsorted resolutions", UNSORTED_RESOLUTIONS,
-                        new int[]{376, 240}, new int[]{3200, 2048}},
+                        new int[]{376, 240}, new int[]{3200, 2048}, 8_000_000},
                 // No exact matching aspect ratio for 4224x3136 (~1.346939) but should still find
                 // a similar resolution
                 {"Largest similar for 4224x3136 from decreasing resolutions",
                         DECREASING_RESOLUTIONS,
-                        new int[]{4224, 3136}, new int[]{4096, 3072}},
+                        new int[]{4224, 3136}, new int[]{3264, 2448}, 8_000_000},
                 {"Largest similar for 4224x3136 from increasing resolutions",
                         INCREASING_RESOLUTIONS,
-                        new int[]{4224, 3136}, new int[]{4096, 3072}},
+                        new int[]{4224, 3136}, new int[]{3264, 2448}, 8_000_000},
                 {"Largest similar for 4224x3136 from unsorted resolutions", UNSORTED_RESOLUTIONS,
-                        new int[]{4224, 3136}, new int[]{4096, 3072}},
+                        new int[]{4224, 3136}, new int[]{3264, 2448}, 8_000_000},
                 // No exact matching aspect ratio for 5376x3752 (~1.432836) but should still find
                 // a similar resolution
                 {"Largest similar for 5376x3752 from decreasing resolutions",
                         DECREASING_RESOLUTIONS,
-                        new int[]{5376, 3752}, new int[]{4096, 3072}},
+                        new int[]{5376, 3752}, new int[]{3264, 2448}, 8_000_000},
                 {"Largest similar for 5376x3752 from increasing resolutions",
                         INCREASING_RESOLUTIONS,
-                        new int[]{5376, 3752}, new int[]{4096, 3072}},
+                        new int[]{5376, 3752}, new int[]{3264, 2448}, 8_000_000},
                 {"Largest similar for 5376x3752 from unsorted resolutions", UNSORTED_RESOLUTIONS,
-                        new int[]{5376, 3752}, new int[]{4096, 3072}},
+                        new int[]{5376, 3752}, new int[]{3264, 2448}, 8_000_000},
         });
     }
 
@@ -73,21 +73,23 @@ public class SizeSelectionHelper_GetLargestSizeWithSameAspectRatioTest {
     private final int[][] resolutions;
     private final int[] referenceResolution;
     private final int[] expectedResolution;
+    private final int maxArea;
 
-    public SizeSelectionHelper_GetLargestSizeWithSameAspectRatioTest(final String description,
+    public SizeSelectionHelper_GetLargestAllowedSizeWithSameAspectRatioTest(final String description,
             final int[][] resolutions,
-            final int[] referenceResolution, final int[] expectedResolution) {
+            final int[] referenceResolution, final int[] expectedResolution, final int maxArea) {
         this.description = description;
         this.resolutions = resolutions;
         this.referenceResolution = referenceResolution;
         this.expectedResolution = expectedResolution;
+        this.maxArea = maxArea;
     }
 
     @Test
     public void should_returnLargestSameAspectRatioSize() {
-        List<Camera.Size> sizes = toSizesList(resolutions);
-        Size largestSize = SizeSelectionHelper.getLargestSizeWithSimilarAspectRatio(sizes,
-                toSize(referenceResolution));
+        final List<Camera.Size> sizes = toSizesList(resolutions);
+        final Size largestSize = SizeSelectionHelper.getLargestAllowedSizeWithSimilarAspectRatio(sizes,
+                toSize(referenceResolution), maxArea);
         assertSizeEqualsResolution(largestSize, expectedResolution);
     }
 }


### PR DESCRIPTION
To prevent receiving huge images on devices with large MP cameras we limit to 13 MPs. 

The limit is 13 MP and not 12 MP because resolutions are never exactly 12 MP and may exceed it.

### Ticket 
[PIA-720](https://ginis.atlassian.net/browse/PIA-720)
