### PR TITLE
Pia 859 return exception in event tracker

### DIFF
--- a/ginivision-network/src/main/java/net/gini/android/vision/network/GiniVisionDefaultNetworkService.java
+++ b/ginivision-network/src/main/java/net/gini/android/vision/network/GiniVisionDefaultNetworkService.java
@@ -119,7 +119,7 @@ public class GiniVisionDefaultNetworkService implements GiniVisionNetworkService
                     public Void then(final Task<net.gini.android.models.Document> task)
                             throws Exception {
                         if (task.isFaulted()) {
-                            final Error error = new Error(getTaskErrorMessage(task));
+                            final Error error = new Error(getTaskErrorMessage(task), task.getError());
                             LOG.error("Document upload failed for {}: {}", document.getId(),
                                     error.getMessage());
                             callback.failure(error);
@@ -157,7 +157,7 @@ public class GiniVisionDefaultNetworkService implements GiniVisionNetworkService
                     @Override
                     public Void then(final Task<String> task) throws Exception {
                         if (task.isFaulted()) {
-                            final Error error = new Error(getTaskErrorMessage(task));
+                            final Error error = new Error(getTaskErrorMessage(task), task.getError());
                             LOG.error("Document deletion failed for api id {}: {}",
                                     giniApiDocumentId,
                                     error.getMessage());
@@ -254,7 +254,7 @@ public class GiniVisionDefaultNetworkService implements GiniVisionNetworkService
                                     final Task<Map<String, SpecificExtraction>> task)
                                     throws Exception {
                                 if (task.isFaulted()) {
-                                    final Error error = new Error(getTaskErrorMessage(task));
+                                    final Error error = new Error(getTaskErrorMessage(task), task.getError());
                                     LOG.error("Document analysis failed for documents {}: {}",
                                             giniApiDocumentIdRotationMap, error.getMessage());
                                     callback.failure(error);

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVision.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVision.java
@@ -136,6 +136,7 @@ public class GiniVision {
                 sInstance.mNetworkRequestsManager.cleanup();
             }
             sInstance.mImageMultiPageDocumentMemoryStore.clear();
+            sInstance.internal().setReviewScreenAnalysisError(null);
             sInstance = null; // NOPMD
         }
         ImageDiskStore.clear(context);
@@ -828,6 +829,8 @@ public class GiniVision {
 
         private final GiniVision mGiniVision;
 
+        private Throwable mReviewScreenAnalysisError;
+
         public Internal(@NonNull final GiniVision giniVision) {
             mGiniVision = giniVision;
         }
@@ -862,6 +865,15 @@ public class GiniVision {
 
         public EventTracker getEventTracker() {
             return mGiniVision.getEventTracker();
+        }
+
+        @Nullable
+        public Throwable getReviewScreenAnalysisError() {
+            return mReviewScreenAnalysisError;
+        }
+
+        public void setReviewScreenAnalysisError(@Nullable final Throwable analysisError) {
+            mReviewScreenAnalysisError = analysisError;
         }
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/internal/network/NetworkRequestsManager.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/network/NetworkRequestsManager.java
@@ -93,7 +93,7 @@ public class NetworkRequestsManager {
                                                 document.getId(),
                                                 error.getMessage());
                                         future.completeExceptionally(
-                                                new RuntimeException(error.getMessage()));
+                                                new RuntimeException(error.getMessage(), error.getCause()));
                                     }
 
                                     @Override
@@ -263,7 +263,7 @@ public class NetworkRequestsManager {
                                         error.getMessage());
                                 future.completeExceptionally(
                                         new RuntimeException(
-                                                error.getMessage()));
+                                                error.getMessage(), error.getCause()));
                             }
 
                             @Override
@@ -375,7 +375,7 @@ public class NetworkRequestsManager {
                                 LOG.error("Document analysis failed for {}: {}",
                                         multiPageDocument.getId(), error.getMessage());
                                 future.completeExceptionally(
-                                        new RuntimeException(error.getMessage()));
+                                        new RuntimeException(error.getMessage(), error.getCause()));
                             }
 
                             @Override

--- a/ginivision/src/main/java/net/gini/android/vision/network/Error.java
+++ b/ginivision/src/main/java/net/gini/android/vision/network/Error.java
@@ -7,6 +7,7 @@ package net.gini.android.vision.network;
  */
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 /**
  * Used by the {@link GiniVisionNetworkService} and {@link GiniVisionNetworkApi} to return error
@@ -15,6 +16,7 @@ import android.support.annotation.NonNull;
 public class Error {
 
     private final String mMessage;
+    private final Throwable mCause;
 
     /**
      * Create a new error.
@@ -23,12 +25,33 @@ public class Error {
      */
     public Error(@NonNull final String message) {
         mMessage = message;
+        mCause = null;
+    }
+
+    /**
+     * Create a new error with a cause.
+     *
+     * @param message error message
+     * @param cause the cause of the error
+     */
+    public Error(@NonNull final String message, @NonNull final Throwable cause) {
+        mMessage = message;
+        mCause = cause;
     }
 
     /**
      * @return error message
      */
+    @NonNull
     public String getMessage() {
         return mMessage;
+    }
+
+    /**
+     * @return error cause
+     */
+    @Nullable
+    public Throwable getCause() {
+        return mCause;
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewFragmentImpl.java
@@ -265,7 +265,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
                                     final NetworkRequestResult<GiniVisionDocument> requestResult,
                                     final Throwable throwable) {
                                 if (throwable != null && !isCancellation(throwable)) {
-                                    handleAnalysisError();
+                                    handleAnalysisError(throwable);
                                 } else if (requestResult != null) {
                                     mDocumentWasUploaded = true;
                                 }
@@ -280,10 +280,13 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
         }
     }
 
-    private void handleAnalysisError() {
+    private void handleAnalysisError(@NonNull final Throwable throwable) {
         final Activity activity = mFragment.getActivity();
         if (activity == null) {
             return;
+        }
+        if (GiniVision.hasInstance()) {
+            GiniVision.getInstance().internal().setReviewScreenAnalysisError(throwable);
         }
         mDocumentAnalysisErrorMessage = activity.getString(R.string.gv_document_analysis_error);
     }

--- a/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewFragment.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewFragment.java
@@ -55,6 +55,7 @@ import net.gini.android.vision.review.multipage.thumbnails.ThumbnailsAdapter;
 import net.gini.android.vision.review.multipage.thumbnails.ThumbnailsAdapterListener;
 import net.gini.android.vision.review.multipage.thumbnails.ThumbnailsTouchHelperCallback;
 import net.gini.android.vision.tracking.ReviewScreenEvent;
+import net.gini.android.vision.tracking.ReviewScreenEvent.UPLOAD_ERROR_DETAILS_MAP_KEY;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,14 +112,17 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
 
     private static final Logger LOG = LoggerFactory.getLogger(MultiPageReviewFragment.class);
 
-    private final Map<String, Boolean> mDocumentUploadResults = new HashMap<>();
-    private ImageMultiPageDocument mMultiPageDocument;
+    @VisibleForTesting
+    Map<String, Boolean> mDocumentUploadResults = new HashMap<>();
+    @VisibleForTesting
+    ImageMultiPageDocument mMultiPageDocument;
     private MultiPageReviewFragmentListener mListener;
     private ViewPager mPreviewsPager;
     private PreviewsAdapter mPreviewsAdapter;
     private TextView mPageIndicator;
     private RecyclerView mThumbnailsRecycler;
-    private ThumbnailsAdapter mThumbnailsAdapter;
+    @VisibleForTesting
+    ThumbnailsAdapter mThumbnailsAdapter;
     private RecyclerView.SmoothScroller mThumbnailsScroller;
     private ImageButton mButtonNext;
     private ImageButton mRotateButton;
@@ -567,7 +571,8 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
         }
     }
 
-    private void uploadDocument(final ImageDocument document) {
+    @VisibleForTesting
+    void uploadDocument(final ImageDocument document) {
         if (!GiniVision.hasInstance()) {
             return;
         }
@@ -594,6 +599,7 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
                             final Throwable throwable) {
                         if (throwable != null
                                 && !NetworkRequestsManager.isCancellation(throwable)) {
+                            trackUploadError(throwable);
                             final String errorMessage = getString(
                                     R.string.gv_document_analysis_error);
                             showErrorOnPreview(errorMessage, document);
@@ -610,6 +616,13 @@ public class MultiPageReviewFragment extends Fragment implements MultiPageReview
                         return null;
                     }
                 });
+    }
+
+    private void trackUploadError(@NonNull final Throwable throwable) {
+        final Map<String, Object> errorDetails = new HashMap<>();
+        errorDetails.put(UPLOAD_ERROR_DETAILS_MAP_KEY.MESSAGE, throwable.getMessage());
+        errorDetails.put(UPLOAD_ERROR_DETAILS_MAP_KEY.ERROR_OBJECT, throwable);
+        trackReviewScreenEvent(ReviewScreenEvent.UPLOAD_ERROR, errorDetails);
     }
 
     private void showErrorOnPreview(final String errorMessage, final ImageDocument imageDocument) {

--- a/ginivision/src/main/java/net/gini/android/vision/tracking/AnalysisScreenEvent.java
+++ b/ginivision/src/main/java/net/gini/android/vision/tracking/AnalysisScreenEvent.java
@@ -38,8 +38,13 @@ public enum AnalysisScreenEvent {
     public static class ERROR_DETAILS_MAP_KEY {
 
         /**
-         * Error message key in the details map.
+         * Error message key in the details map. Value type is {@link String}.
          */
         public static String MESSAGE = "MESSAGE";
+
+        /**
+         * Error object key in the details map. Value type is {@link Throwable}.
+         */
+        public static String ERROR_OBJECT = "ERROR_OBJECT";
     }
 }

--- a/ginivision/src/main/java/net/gini/android/vision/tracking/Event.java
+++ b/ginivision/src/main/java/net/gini/android/vision/tracking/Event.java
@@ -19,12 +19,12 @@ import java.util.Map;
 public class Event<T extends Enum<T>> {
 
     private final T type;
-    private final Map<String, String> details;
+    private final Map<String, Object> details;
 
     /**
      * @exclude
      */
-    public Event(@NonNull final T type, @NonNull final Map<String, String> details) {
+    public Event(@NonNull final T type, @NonNull final Map<String, Object> details) {
         this.type = type;
         this.details = details;
     }
@@ -33,7 +33,7 @@ public class Event<T extends Enum<T>> {
      * @exclude
      */
     public Event(@NonNull final T type) {
-        this(type, Collections.<String, String>emptyMap());
+        this(type, Collections.<String, Object>emptyMap());
     }
 
     /**
@@ -52,7 +52,7 @@ public class Event<T extends Enum<T>> {
      * @return a map containing details about the event
      */
     @NonNull
-    public Map<String, String> getDetails() {
+    public Map<String, Object> getDetails() {
         return details;
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/tracking/EventTrackingHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/tracking/EventTrackingHelper.java
@@ -21,7 +21,7 @@ public final class EventTrackingHelper {
     /**
      * @exclude
      */
-    public static void trackOnboardingScreenEvent(@NonNull final OnboardingScreenEvent event, @NonNull final Map<String, String> details) {
+    public static void trackOnboardingScreenEvent(@NonNull final OnboardingScreenEvent event, @NonNull final Map<String, Object> details) {
         if (GiniVision.hasInstance()) {
             GiniVision.getInstance().internal().getEventTracker().onOnboardingScreenEvent(new Event<>(event, details));
         }
@@ -31,13 +31,13 @@ public final class EventTrackingHelper {
      * @exclude
      */
     public static void trackOnboardingScreenEvent(@NonNull final OnboardingScreenEvent event) {
-        trackOnboardingScreenEvent(event, Collections.<String, String>emptyMap());
+        trackOnboardingScreenEvent(event, Collections.<String, Object>emptyMap());
     }
 
     /**
      * @exclude
      */
-    public static void trackCameraScreenEvent(@NonNull final CameraScreenEvent event, @NonNull final Map<String, String> details) {
+    public static void trackCameraScreenEvent(@NonNull final CameraScreenEvent event, @NonNull final Map<String, Object> details) {
         if (GiniVision.hasInstance()) {
             GiniVision.getInstance().internal().getEventTracker().onCameraScreenEvent(new Event<>(event, details));
         }
@@ -47,13 +47,13 @@ public final class EventTrackingHelper {
      * @exclude
      */
     public static void trackCameraScreenEvent(@NonNull final CameraScreenEvent event) {
-        trackCameraScreenEvent(event, Collections.<String, String>emptyMap());
+        trackCameraScreenEvent(event, Collections.<String, Object>emptyMap());
     }
 
     /**
      * @exclude
      */
-    public static void trackReviewScreenEvent(@NonNull final ReviewScreenEvent event, @NonNull final Map<String, String> details) {
+    public static void trackReviewScreenEvent(@NonNull final ReviewScreenEvent event, @NonNull final Map<String, Object> details) {
         if (GiniVision.hasInstance()) {
             GiniVision.getInstance().internal().getEventTracker().onReviewScreenEvent(new Event<>(event, details));
         }
@@ -63,13 +63,13 @@ public final class EventTrackingHelper {
      * @exclude
      */
     public static void trackReviewScreenEvent(@NonNull final ReviewScreenEvent event) {
-        trackReviewScreenEvent(event, Collections.<String, String>emptyMap());
+        trackReviewScreenEvent(event, Collections.<String, Object>emptyMap());
     }
 
     /**
      * @exclude
      */
-    public static void trackAnalysisScreenEvent(@NonNull final AnalysisScreenEvent event, @NonNull final Map<String, String> details) {
+    public static void trackAnalysisScreenEvent(@NonNull final AnalysisScreenEvent event, @NonNull final Map<String, Object> details) {
         if (GiniVision.hasInstance()) {
             GiniVision.getInstance().internal().getEventTracker().onAnalysisScreenEvent(new Event<>(event, details));
         }
@@ -79,7 +79,7 @@ public final class EventTrackingHelper {
      * @exclude
      */
     public static void trackAnalysisScreenEvent(@NonNull final AnalysisScreenEvent event) {
-        trackAnalysisScreenEvent(event, Collections.<String, String>emptyMap());
+        trackAnalysisScreenEvent(event, Collections.<String, Object>emptyMap());
     }
 
     private EventTrackingHelper() {

--- a/ginivision/src/main/java/net/gini/android/vision/tracking/ReviewScreenEvent.java
+++ b/ginivision/src/main/java/net/gini/android/vision/tracking/ReviewScreenEvent.java
@@ -24,5 +24,27 @@ public enum ReviewScreenEvent {
     /**
      * Triggers when the user presses the next button.(<b>Screen API + Component API</b>)
      */
-    NEXT
+    NEXT,
+    /**
+     * Triggers when upload failed.(<b>Screen API + Component API</b>)
+     *
+     * <p> Use the keys in {@link ReviewScreenEvent.UPLOAD_ERROR_DETAILS_MAP_KEY} to get details about the event from the details map.
+     */
+    UPLOAD_ERROR;
+
+    /**
+     * Keys to retrieve details about the {@link ReviewScreenEvent#UPLOAD_ERROR} event.
+     */
+    public static class UPLOAD_ERROR_DETAILS_MAP_KEY {
+
+        /**
+         * Error message key in the details map. Value type is {@link String}.
+         */
+        public static String MESSAGE = "MESSAGE";
+
+        /**
+         * Error object key in the details map. Value type is {@link Throwable}.
+         */
+        public static String ERROR_OBJECT = "ERROR_OBJECT";
+    }
 }

--- a/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisScreenPresenterTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/analysis/AnalysisScreenPresenterTest.java
@@ -56,6 +56,7 @@ import org.mockito.Mock;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
@@ -982,6 +983,9 @@ public class AnalysisScreenPresenterTest {
 
         final ImageDocument imageDocument = new ImageDocumentFake();
 
+        final Exception exception = new Exception("Something is not working");
+        GiniVision.getInstance().internal().setReviewScreenAnalysisError(exception);
+
         final String errorMessage = "Something went wrong";
         final AnalysisScreenPresenter presenter = createPresenter(imageDocument, errorMessage);
 
@@ -989,8 +993,10 @@ public class AnalysisScreenPresenterTest {
         presenter.start();
 
         // Then
-        verify(eventTracker).onAnalysisScreenEvent(new Event<>(AnalysisScreenEvent.ERROR,
-                Collections.singletonMap(AnalysisScreenEvent.ERROR_DETAILS_MAP_KEY.MESSAGE, errorMessage)));
+        final Map<String, Object> errorDetails = new HashMap<>();
+        errorDetails.put(AnalysisScreenEvent.ERROR_DETAILS_MAP_KEY.MESSAGE, errorMessage);
+        errorDetails.put(AnalysisScreenEvent.ERROR_DETAILS_MAP_KEY.ERROR_OBJECT, exception);
+        verify(eventTracker).onAnalysisScreenEvent(new Event<>(AnalysisScreenEvent.ERROR, errorDetails));
     }
 
     @Test
@@ -1003,7 +1009,8 @@ public class AnalysisScreenPresenterTest {
 
         final CompletableFuture<AnalysisInteractor.ResultHolder> analysisFuture =
                 new CompletableFuture<>();
-        analysisFuture.completeExceptionally(new RuntimeException("error message"));
+        final RuntimeException exception = new RuntimeException("error message");
+        analysisFuture.completeExceptionally(exception);
 
         final AnalysisScreenPresenter presenter = createPresenterWithAnalysisFuture(imageDocument,
                 analysisFuture);
@@ -1012,8 +1019,10 @@ public class AnalysisScreenPresenterTest {
         presenter.start();
 
         // Then
-        verify(eventTracker).onAnalysisScreenEvent(new Event<>(AnalysisScreenEvent.ERROR,
-                Collections.singletonMap(AnalysisScreenEvent.ERROR_DETAILS_MAP_KEY.MESSAGE, "error message")));
+        final Map<String, Object> errorDetails = new HashMap<>();
+        errorDetails.put(AnalysisScreenEvent.ERROR_DETAILS_MAP_KEY.MESSAGE, exception.getMessage());
+        errorDetails.put(AnalysisScreenEvent.ERROR_DETAILS_MAP_KEY.ERROR_OBJECT, exception);
+        verify(eventTracker).onAnalysisScreenEvent(new Event<>(AnalysisScreenEvent.ERROR, errorDetails));
     }
 
     @Test

--- a/ginivision/src/test/java/net/gini/android/vision/review/multipage/MultipageReviewFragmentTest.kt
+++ b/ginivision/src/test/java/net/gini/android/vision/review/multipage/MultipageReviewFragmentTest.kt
@@ -1,17 +1,26 @@
 package net.gini.android.vision.review.multipage
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
+import jersey.repackaged.jsr166e.CompletableFuture
 import net.gini.android.vision.GiniVision
+import net.gini.android.vision.GiniVisionHelper
+import net.gini.android.vision.document.GiniVisionDocument
+import net.gini.android.vision.document.ImageDocumentFake
+import net.gini.android.vision.internal.network.NetworkRequestResult
+import net.gini.android.vision.internal.network.NetworkRequestsManager
 import net.gini.android.vision.tracking.Event
 import net.gini.android.vision.tracking.EventTracker
 import net.gini.android.vision.tracking.ReviewScreenEvent
+import net.gini.android.vision.tracking.ReviewScreenEvent.UPLOAD_ERROR_DETAILS_MAP_KEY.*
 import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.any
 
 /**
  * Created by Alpar Szotyori on 02.03.2020.
@@ -24,14 +33,21 @@ class MultipageReviewFragmentTest {
 
     @After
     fun after() {
-        GiniVision.cleanup(InstrumentationRegistry.getInstrumentation().targetContext)
+        GiniVisionHelper.setGiniVisionInstance(null)
+//        GiniVision.cleanup(InstrumentationRegistry.getInstrumentation().targetContext)
     }
 
     @Test
     fun `triggers Next event`() {
         // Given
+        val giniVision = mock<GiniVision>()
+        GiniVisionHelper.setGiniVisionInstance(giniVision)
+
+        val internal = mock<GiniVision.Internal>()
+        `when`(giniVision.internal()).thenReturn(internal)
+
         val eventTracker = spy<EventTracker>()
-        GiniVision.Builder().setEventTracker(eventTracker).build()
+        `when`(giniVision.internal().eventTracker).thenReturn(eventTracker)
 
         val fragment = MultiPageReviewFragment()
         fragment.setListener(mock())
@@ -41,5 +57,49 @@ class MultipageReviewFragmentTest {
 
         // Then
         verify(eventTracker).onReviewScreenEvent(Event(ReviewScreenEvent.NEXT))
+    }
+
+    @Test
+    fun `triggers Upload Error event`() {
+        // Given
+        // Note: Use FragmentScenario in the future
+        val fragment = mock<MultiPageReviewFragment>()
+        fragment.setListener(mock())
+
+        `when`(fragment.activity).thenReturn(mock())
+        fragment.mThumbnailsAdapter = mock()
+        fragment.mMultiPageDocument = mock()
+        fragment.mDocumentUploadResults = mock()
+
+        `when`(fragment.uploadDocument(any())).thenCallRealMethod()
+
+        val exception = RuntimeException("error message")
+
+        val future = CompletableFuture<NetworkRequestResult<GiniVisionDocument>>()
+        future.completeExceptionally(exception)
+
+        val networkRequestsManager = mock<NetworkRequestsManager>()
+        `when`(networkRequestsManager.upload(any(), any())).thenReturn(future)
+
+        val internal = mock<GiniVision.Internal>()
+        `when`(internal.networkRequestsManager).thenReturn(networkRequestsManager)
+
+        val giniVision = mock<GiniVision>()
+        GiniVisionHelper.setGiniVisionInstance(giniVision)
+
+        `when`(giniVision.internal()).thenReturn(internal)
+
+        val eventTracker = spy<EventTracker>()
+        `when`(giniVision.internal().eventTracker).thenReturn(eventTracker)
+
+        // When
+        fragment.uploadDocument(ImageDocumentFake())
+
+        // Then
+        val errorDetails = mapOf(
+                MESSAGE to exception.message,
+                ERROR_OBJECT to exception
+        )
+        Mockito.verify(eventTracker).onReviewScreenEvent(Event(ReviewScreenEvent.UPLOAD_ERROR, errorDetails))
     }
 }

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
@@ -528,6 +528,12 @@ public class MainActivity extends AppCompatActivity {
                 case BACK:
                     LOG.info("Go back to the camera");
                     break;
+                case UPLOAD_ERROR:
+                    final Throwable error = (Throwable) event.getDetails().get(ReviewScreenEvent.UPLOAD_ERROR_DETAILS_MAP_KEY.ERROR_OBJECT);
+                    LOG.info("Upload failed:\nmessage: {}\nerror:",
+                            event.getDetails().get(ReviewScreenEvent.UPLOAD_ERROR_DETAILS_MAP_KEY.MESSAGE),
+                            error);
+                    break;
             }
         }
 

--- a/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/vision/screen/MainActivity.java
@@ -535,7 +535,10 @@ public class MainActivity extends AppCompatActivity {
         public void onAnalysisScreenEvent(final Event<AnalysisScreenEvent> event) {
             switch (event.getType()) {
                 case ERROR:
-                    LOG.info("Analysis failed {}", event.getDetails().get(AnalysisScreenEvent.ERROR_DETAILS_MAP_KEY.MESSAGE));
+                    final Throwable error = (Throwable) event.getDetails().get(AnalysisScreenEvent.ERROR_DETAILS_MAP_KEY.ERROR_OBJECT);
+                    LOG.info("Analysis failed:\nmessage: {}\nerror:",
+                            event.getDetails().get(AnalysisScreenEvent.ERROR_DETAILS_MAP_KEY.MESSAGE),
+                            error);
                     break;
                 case RETRY:
                     LOG.info("Retry analysis");


### PR DESCRIPTION
We only returned a message in the analysis error event. I added the `Throwable` object to the event so that clients can get the most information possible about errors.

I also forward now the Volley exception from the API SDK in the default networking implementation. Previously we only forwarded the message.

I also report upload errors from the review screens, too, now. I extended the review screen events with an upload error event for that.

### How to test
Automated tests on Jenkins.

### Merging
Automatic.

### Ticket 
[PIA-859](https://ginis.atlassian.net/browse/PIA-859)
