### PR TITLE
Make locale customizable

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/GiniVision.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVision.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Locale;
 
 /**
  * Created by Alpar Szotyori on 22.02.2018.
@@ -76,6 +77,7 @@ public class GiniVision {
     private final boolean mBackButtonsEnabled;
     private final boolean mIsFlashOnByDefault;
     private final EventTracker mEventTracker;
+    private final Locale mCustomLocale;
 
     /**
      * Retrieve the current instance.
@@ -168,6 +170,7 @@ public class GiniVision {
         mBackButtonsEnabled = builder.areBackButtonsEnabled();
         mIsFlashOnByDefault = builder.isFlashOnByDefault();
         mEventTracker = builder.getEventTracker();
+        mCustomLocale = builder.getCustomLocale();
     }
 
     /**
@@ -330,6 +333,15 @@ public class GiniVision {
      */
     public boolean isFlashOnByDefault() {
         return mIsFlashOnByDefault;
+    }
+
+    /**
+     * Returns the custom {@link Locale} or {@code null} if not set.
+     * 
+     * @return a {@link Locale} or {@code null}
+     */
+    public Locale getCustomLocale() {
+        return mCustomLocale;
     }
 
     /**
@@ -521,6 +533,7 @@ public class GiniVision {
             public void onAnalysisScreenEvent(@NotNull final Event<AnalysisScreenEvent> event) {
             }
         };
+        private Locale mCustomLocale = null;
 
         /**
          * Create a new {@link GiniVision} instance.
@@ -818,6 +831,22 @@ public class GiniVision {
 
         EventTracker getEventTracker() {
             return mEventTracker;
+        }
+
+        /**
+         * Sets a custom locale. If no custom locale is set or the given locale is null, the devices locale will be used.
+         * 
+         * @param customLocale a {@link Locale} or {@code null}.
+         * 
+         * @return the {@link Builder} instance
+         */
+        public Builder setCustomLocale(final Locale customLocale) {
+            mCustomLocale = customLocale;
+            return this;
+        }
+
+        Locale getCustomLocale() {
+            return mCustomLocale;
         }
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVisionActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVisionActivity.java
@@ -1,0 +1,34 @@
+package net.gini.android.vision;
+
+import java.util.Locale;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+
+public abstract class GiniVisionActivity extends AppCompatActivity {
+
+    @Override
+    protected void attachBaseContext(Context newBase) {
+        if (GiniVision.hasInstance()) {
+            Locale customLocale = GiniVision.getInstance().getCustomLocale();                    
+            if (customLocale != null) {
+                newBase.getResources().getConfiguration().setLocale(customLocale);
+                newBase = newBase.createConfigurationContext(newBase.getResources().getConfiguration());
+                newBase.getResources().updateConfiguration(newBase.getResources().getConfiguration(), newBase.getResources().getDisplayMetrics());
+            }
+        }
+        super.attachBaseContext(newBase);        
+    }
+
+    public void translateTitle() {
+        try {
+            int labelRes = getPackageManager().getActivityInfo(getComponentName(), 0).labelRes;
+            setTitle(getResources().getString(labelRes));
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e("CameraActivity", "Error getting label resource for Activity.", e);
+        }
+    }
+
+}

--- a/ginivision/src/main/java/net/gini/android/vision/GiniVisionActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/GiniVisionActivity.java
@@ -27,7 +27,7 @@ public abstract class GiniVisionActivity extends AppCompatActivity {
             int labelRes = getPackageManager().getActivityInfo(getComponentName(), 0).labelRes;
             setTitle(getResources().getString(labelRes));
         } catch (PackageManager.NameNotFoundException e) {
-            Log.e("CameraActivity", "Error getting label resource for Activity.", e);
+            Log.e(getClass().getSimpleName(), "Error getting label resource for Activity.", e);
         }
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisActivity.java
@@ -7,12 +7,12 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
-import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.View;
 
 import net.gini.android.vision.Document;
 import net.gini.android.vision.GiniVision;
+import net.gini.android.vision.GiniVisionActivity;
 import net.gini.android.vision.GiniVisionCoordinator;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.R;
@@ -206,7 +206,7 @@ import java.util.Map;
  *
  * </ul>
  */
-public class AnalysisActivity extends AppCompatActivity implements
+public class AnalysisActivity extends GiniVisionActivity implements
         AnalysisFragmentListener, AnalysisFragmentInterface {
 
     /**
@@ -288,6 +288,7 @@ public class AnalysisActivity extends AppCompatActivity implements
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        translateTitle();
         setContentView(R.layout.gv_activity_analysis);
         setTitle("");
         readExtras();

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
@@ -12,7 +12,6 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -504,7 +503,7 @@ public class CameraActivity extends GiniVisionActivity implements CameraFragment
     }
 
     @Override
-    protected void onCreate(final Bundle savedInstanceState) {        
+    protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         translateTitle();
         setContentView(R.layout.gv_activity_camera);

--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraActivity.java
@@ -12,13 +12,14 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 
 import net.gini.android.vision.Document;
 import net.gini.android.vision.DocumentImportEnabledFileTypes;
 import net.gini.android.vision.GiniVision;
+import net.gini.android.vision.GiniVisionActivity;
 import net.gini.android.vision.GiniVisionCoordinator;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.GiniVisionFeatureConfiguration;
@@ -37,6 +38,7 @@ import net.gini.android.vision.review.multipage.MultiPageReviewActivity;
 import net.gini.android.vision.tracking.CameraScreenEvent;
 
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -345,7 +347,7 @@ import java.util.Map;
  *
  * </ul>
  **/
-public class CameraActivity extends AppCompatActivity implements CameraFragmentListener,
+public class CameraActivity extends GiniVisionActivity implements CameraFragmentListener,
         CameraFragmentInterface {
 
     /**
@@ -502,9 +504,11 @@ public class CameraActivity extends AppCompatActivity implements CameraFragmentL
     }
 
     @Override
-    protected void onCreate(final Bundle savedInstanceState) {
+    protected void onCreate(final Bundle savedInstanceState) {        
         super.onCreate(savedInstanceState);
+        translateTitle();
         setContentView(R.layout.gv_activity_camera);
+        
         readExtras();
         createGiniVisionCoordinator();
         if (savedInstanceState == null) {

--- a/ginivision/src/main/java/net/gini/android/vision/help/FileImportActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/help/FileImportActivity.java
@@ -6,12 +6,12 @@ import static net.gini.android.vision.internal.util.ActivityHelper.forcePortrait
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 
 import net.gini.android.vision.GiniVision;
+import net.gini.android.vision.GiniVisionActivity;
 import net.gini.android.vision.GiniVisionFeatureConfiguration;
 import net.gini.android.vision.R;
 import net.gini.android.vision.analysis.AnalysisActivity;
@@ -130,11 +130,12 @@ import net.gini.android.vision.review.ReviewActivity;
  * </ul>
  * </p>
  */
-public class FileImportActivity extends AppCompatActivity {
+public class FileImportActivity extends GiniVisionActivity {
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        translateTitle();
         setContentView(R.layout.gv_activity_file_import);
         forcePortraitOrientationOnPhones(this);
 

--- a/ginivision/src/main/java/net/gini/android/vision/help/HelpActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/help/HelpActivity.java
@@ -6,12 +6,12 @@ import static net.gini.android.vision.internal.util.ActivityHelper.forcePortrait
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.MenuItem;
 
 import net.gini.android.vision.GiniVision;
+import net.gini.android.vision.GiniVisionActivity;
 import net.gini.android.vision.GiniVisionFeatureConfiguration;
 import net.gini.android.vision.R;
 import net.gini.android.vision.analysis.AnalysisActivity;
@@ -93,7 +93,7 @@ import org.slf4j.LoggerFactory;
  * </ul>
  * </p>
  */
-public class HelpActivity extends AppCompatActivity {
+public class HelpActivity extends GiniVisionActivity {
 
     /**
      * Optional extra which must contain a {@link GiniVisionFeatureConfiguration} instance.
@@ -122,6 +122,7 @@ public class HelpActivity extends AppCompatActivity {
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        translateTitle();
         setContentView(R.layout.gv_activity_help);
         readExtras();
         setUpHelpItems();

--- a/ginivision/src/main/java/net/gini/android/vision/help/PhotoTipsActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/help/PhotoTipsActivity.java
@@ -4,11 +4,11 @@ import static net.gini.android.vision.internal.util.ActivityHelper.enableHomeAsU
 import static net.gini.android.vision.internal.util.ActivityHelper.forcePortraitOrientationOnPhones;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.View;
 
 import net.gini.android.vision.GiniVision;
+import net.gini.android.vision.GiniVisionActivity;
 import net.gini.android.vision.R;
 import net.gini.android.vision.analysis.AnalysisActivity;
 import net.gini.android.vision.camera.CameraActivity;
@@ -100,13 +100,14 @@ import net.gini.android.vision.review.ReviewActivity;
  * </ul>
  * </p>
  */
-public class PhotoTipsActivity extends AppCompatActivity {
+public class PhotoTipsActivity extends GiniVisionActivity {
 
     static final int RESULT_SHOW_CAMERA_SCREEN = RESULT_FIRST_USER + 1;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        translateTitle();
         if (FeatureConfiguration.isMultiPageEnabled()) {
             setContentView(R.layout.gv_activity_photo_tips_with_multipage);
         } else {

--- a/ginivision/src/main/java/net/gini/android/vision/help/SupportedFormatsActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/help/SupportedFormatsActivity.java
@@ -4,12 +4,12 @@ import static net.gini.android.vision.internal.util.ActivityHelper.enableHomeAsU
 import static net.gini.android.vision.internal.util.ActivityHelper.forcePortraitOrientationOnPhones;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.MenuItem;
 
 import net.gini.android.vision.GiniVision;
+import net.gini.android.vision.GiniVisionActivity;
 import net.gini.android.vision.GiniVisionFeatureConfiguration;
 import net.gini.android.vision.R;
 import net.gini.android.vision.analysis.AnalysisActivity;
@@ -95,7 +95,7 @@ import net.gini.android.vision.review.ReviewActivity;
  * </ul>
  * </p>
  */
-public class SupportedFormatsActivity extends AppCompatActivity {
+public class SupportedFormatsActivity extends GiniVisionActivity {
 
     /**
      * @exclude
@@ -111,6 +111,7 @@ public class SupportedFormatsActivity extends AppCompatActivity {
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        translateTitle();
         setContentView(R.layout.gv_activity_supported_formats);
         readExtras();
         setUpFormatsList();

--- a/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/onboarding/OnboardingActivity.java
@@ -5,10 +5,10 @@ import static net.gini.android.vision.internal.util.ActivityHelper.enableHomeAsU
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
-import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import net.gini.android.vision.GiniVision;
+import net.gini.android.vision.GiniVisionActivity;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.R;
 import net.gini.android.vision.analysis.AnalysisActivity;
@@ -154,7 +154,7 @@ import java.util.ArrayList;
  *
  * </ul>
  */
-public class OnboardingActivity extends AppCompatActivity implements OnboardingFragmentListener {
+public class OnboardingActivity extends GiniVisionActivity implements OnboardingFragmentListener {
 
     /**
      * @exclude
@@ -171,6 +171,7 @@ public class OnboardingActivity extends AppCompatActivity implements OnboardingF
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        translateTitle();
         setContentView(R.layout.gv_activity_onboarding);
         readExtras();
         initFragment();

--- a/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/ReviewActivity.java
@@ -9,11 +9,11 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import net.gini.android.vision.Document;
 import net.gini.android.vision.GiniVision;
+import net.gini.android.vision.GiniVisionActivity;
 import net.gini.android.vision.GiniVisionCoordinator;
 import net.gini.android.vision.GiniVisionError;
 import net.gini.android.vision.R;
@@ -161,7 +161,7 @@ import java.util.Map;
  *
  * </ul>
  */
-public class ReviewActivity extends AppCompatActivity implements ReviewFragmentListener,
+public class ReviewActivity extends GiniVisionActivity implements ReviewFragmentListener,
         ReviewFragmentInterface {
 
     /**
@@ -219,6 +219,7 @@ public class ReviewActivity extends AppCompatActivity implements ReviewFragmentL
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        translateTitle();
         setContentView(R.layout.gv_activity_review);
         readExtras();
         if (savedInstanceState == null) {

--- a/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewActivity.java
+++ b/ginivision/src/main/java/net/gini/android/vision/review/multipage/MultiPageReviewActivity.java
@@ -9,10 +9,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import net.gini.android.vision.GiniVision;
+import net.gini.android.vision.GiniVisionActivity;
 import net.gini.android.vision.R;
 import net.gini.android.vision.analysis.AnalysisActivity;
 import net.gini.android.vision.camera.CameraActivity;
@@ -203,7 +203,7 @@ import java.util.List;
  *
  * </ul>
  */
-public class MultiPageReviewActivity extends AppCompatActivity implements
+public class MultiPageReviewActivity extends GiniVisionActivity implements
         MultiPageReviewFragmentListener {
 
     private static final String MP_REVIEW_FRAGMENT = "MP_REVIEW_FRAGMENT";
@@ -218,6 +218,7 @@ public class MultiPageReviewActivity extends AppCompatActivity implements
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        translateTitle();
         setContentView(R.layout.gv_activity_multi_page_review);
         if (savedInstanceState == null) {
             initFragment();


### PR DESCRIPTION
Added the ability to customize the locale that is used for translating string resources. An abstract super class for activities was introduced to assure that the custom locale will be applied. The super class also provides a helper method for translating the activitie's title.

### How to test
Set a custom locale when initializing GiniVision, that is different to the locale of the device. The GiniVision screens should use the custom locale.