### PR TITLE
Pick largest picture resolution with at least 4:3 aspect ratio

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/CameraController.java
@@ -474,8 +474,10 @@ public class CameraController implements CameraInterface {
         final List<Camera.Size> pictureSizes = params.getSupportedPictureSizes();
         final List<Camera.Size> previewSizes = params.getSupportedPreviewSizes();
 
-        final Pair<Size, Size> sizes = getBestSize(pictureSizes, previewSizes, CameraResolutionRequirement.MAX_PICTURE_AREA,
-                CameraResolutionRequirement.MIN_PICTURE_AREA);
+        final Pair<Size, Size> sizes = getBestSize(pictureSizes, previewSizes,
+                CameraResolutionRequirement.MAX_PICTURE_AREA,
+                CameraResolutionRequirement.MIN_PICTURE_AREA,
+                CameraResolutionRequirement.MIN_ASPECT_RATIO);
         if (sizes != null) {
             mPictureSize = sizes.first;
             params.setPictureSize(mPictureSize.width, mPictureSize.height);

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper.java
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper.java
@@ -24,13 +24,19 @@ public final class SizeSelectionHelper {
             @NonNull final List<Camera.Size> pictureSizes,
             @NonNull final List<Camera.Size> previewSizes,
             final int maxArea,
-            final int minArea
+            final int minArea,
+            final float minAspectRatio
     ) {
         Camera.Size bestPicture = null;
         Size bestPreview = null;
         for (final Camera.Size size : pictureSizes) {
             final long area = getArea(size);
-            if (minArea < area && area < maxArea && (bestPicture == null || getArea(bestPicture) < area)) {
+            final boolean isAreaInBounds = minArea < area && area < maxArea;
+            final boolean isNewAreaLarger = bestPicture == null || getArea(bestPicture) < area;
+            final boolean isAspectRatioLargeEnough = size.width > size.height ?
+                    (float) size.width / size.height >= minAspectRatio :
+                    (float) size.height / size.width >= minAspectRatio;
+            if (isAreaInBounds && isNewAreaLarger && isAspectRatioLargeEnough) {
                 final Size preview = getClosestSizeWithSimilarAspectRatio(previewSizes, new Size(size.width, size.height), maxArea);
                 if (preview != null) {
                     bestPicture = size;

--- a/ginivision/src/main/java/net/gini/android/vision/requirements/CameraResolutionRequirement.java
+++ b/ginivision/src/main/java/net/gini/android/vision/requirements/CameraResolutionRequirement.java
@@ -18,6 +18,8 @@ public class CameraResolutionRequirement implements Requirement {
     public static final int MIN_PICTURE_AREA = 7_900_000;
     // We allow up to 13MP picture resolutions
     public static final int MAX_PICTURE_AREA = 13_000_000;
+    // We require an aspect ratio of at least 4:3
+    public static final float MIN_ASPECT_RATIO = 1.33f;
 
     private final CameraHolder mCameraHolder;
 
@@ -43,7 +45,8 @@ public class CameraResolutionRequirement implements Requirement {
                 final Pair<Size, Size> sizes = SizeSelectionHelper.getBestSize(parameters.getSupportedPictureSizes(),
                         parameters.getSupportedPreviewSizes(),
                         MAX_PICTURE_AREA,
-                        MIN_PICTURE_AREA
+                        MIN_PICTURE_AREA,
+                        MIN_ASPECT_RATIO
                 );
                 if (sizes == null) {
                     result = false;

--- a/ginivision/src/main/java/net/gini/android/vision/requirements/DeviceMemoryRequirement.java
+++ b/ginivision/src/main/java/net/gini/android/vision/requirements/DeviceMemoryRequirement.java
@@ -34,7 +34,8 @@ class DeviceMemoryRequirement implements Requirement {
                 final Pair<Size, Size> sizes = SizeSelectionHelper.getBestSize(parameters.getSupportedPictureSizes(),
                         parameters.getSupportedPreviewSizes(),
                         CameraResolutionRequirement.MAX_PICTURE_AREA,
-                        CameraResolutionRequirement.MIN_PICTURE_AREA);
+                        CameraResolutionRequirement.MIN_PICTURE_AREA,
+                        CameraResolutionRequirement.MIN_ASPECT_RATIO);
                 if (sizes == null) {
                     result = false;
                     details =

--- a/ginivision/src/test/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper_GetBestSizeTest.java
+++ b/ginivision/src/test/java/net/gini/android/vision/internal/camera/api/SizeSelectionHelper_GetBestSizeTest.java
@@ -30,80 +30,88 @@ public class SizeSelectionHelper_GetBestSizeTest {
         return Arrays.asList(new Object[][]{
                 // 16:9, (~1.77)
                 {"Largest 16:9 from decreasing resolutions", DECREASING_RESOLUTIONS,
-                        new int[][]{{16, 9}}, new int[]{1920, 1080}, 8_000_000, 0},
+                        new int[][]{{16, 9}}, new int[][]{{1920, 1080}, {16, 9}}, 8_000_000, 0, 4f / 3f},
                 {"Largest 16:9 from increasing resolutions", INCREASING_RESOLUTIONS,
-                        new int[][]{{16, 9}}, new int[]{1920, 1080}, 8_000_000, 0},
+                        new int[][]{{16, 9}}, new int[][]{{1920, 1080}, {16, 9}}, 8_000_000, 0, 4f / 3f},
                 {"Largest 16:9 from unsorted resolutions", UNSORTED_RESOLUTIONS,
-                        new int[][]{{16, 9}}, new int[]{1920, 1080}, 8_000_000, 0},
+                        new int[][]{{16, 9}}, new int[][]{{1920, 1080}, {16, 9}}, 8_000_000, 0, 4f / 3f},
                 // 4:3, (~1.33)
                 {"Largest 4:3 from decreasing resolutions", DECREASING_RESOLUTIONS,
-                        new int[][]{{4, 3}}, new int[]{3264, 2448}, 8_000_000, 0},
+                        new int[][]{{4, 3}}, new int[][]{{3264, 2448}, {4, 3}}, 8_000_000, 0, 4f / 3f},
                 {"Largest 4:3 from increasing resolutions", INCREASING_RESOLUTIONS,
-                        new int[][]{{4, 3}}, new int[]{3264, 2448}, 8_000_000, 0},
+                        new int[][]{{4, 3}}, new int[][]{{3264, 2448}, {4, 3}}, 8_000_000, 0, 4f / 3f},
                 {"Largest 4:3 from unsorted resolutions", UNSORTED_RESOLUTIONS,
-                        new int[][]{{4, 3}}, new int[]{3264, 2448}, 8_000_000, 0},
+                        new int[][]{{4, 3}}, new int[][]{{3264, 2448}, {4, 3}}, 8_000_000, 0, 4f / 3f},
                 // 14:9 (~1.55)
                 {"Largest 14:9 from decreasing resolutions", DECREASING_RESOLUTIONS,
-                        new int[][]{{376, 240}}, new int[]{3200, 2048}, 8_000_000, 0},
+                        new int[][]{{376, 240}}, new int[][]{{3200, 2048}, {376, 240}}, 8_000_000, 0, 4f / 3f},
                 {"Largest 14:9 from increasing resolutions", INCREASING_RESOLUTIONS,
-                        new int[][]{{376, 240}}, new int[]{3200, 2048}, 8_000_000, 0},
+                        new int[][]{{376, 240}}, new int[][]{{3200, 2048}, {376, 240}}, 8_000_000, 0, 4f / 3f},
                 {"Largest 14:9 from unsorted resolutions", UNSORTED_RESOLUTIONS,
-                        new int[][]{{376, 240}}, new int[]{3200, 2048}, 8_000_000, 0},
+                        new int[][]{{376, 240}}, new int[][]{{3200, 2048}, {376, 240}}, 8_000_000, 0, 4f / 3f},
                 // No exact matching aspect ratio for 4224x3136 (~1.346939) but should still find
                 // a similar resolution
                 {"Largest similar for 4224x3136 from decreasing resolutions",
                         DECREASING_RESOLUTIONS,
-                        new int[][]{{4224, 3136}}, new int[]{3264, 2448}, 8_000_000, 0},
+                        new int[][]{{4224, 3136}}, new int[][]{{3264, 2448}, {4224, 3136}}, 8_000_000, 0, 4f / 3f},
                 {"Largest similar for 4224x3136 from increasing resolutions",
                         INCREASING_RESOLUTIONS,
-                        new int[][]{{4224, 3136}}, new int[]{3264, 2448}, 8_000_000, 0},
+                        new int[][]{{4224, 3136}}, new int[][]{{3264, 2448}, {4224, 3136}}, 8_000_000, 0, 4f / 3f},
                 {"Largest similar for 4224x3136 from unsorted resolutions", UNSORTED_RESOLUTIONS,
-                        new int[][]{{4224, 3136}}, new int[]{3264, 2448}, 8_000_000, 0},
+                        new int[][]{{4224, 3136}}, new int[][]{{3264, 2448}, {4224, 3136}}, 8_000_000, 0, 4f / 3f},
                 // No exact matching aspect ratio for 5376x3752 (~1.432836) but should still find
                 // a similar resolution
                 {"Largest similar for 5376x3752 from decreasing resolutions",
                         DECREASING_RESOLUTIONS,
-                        new int[][]{{5376, 3752}}, new int[]{3264, 2448}, 8_000_000, 0},
+                        new int[][]{{5376, 3752}}, new int[][]{{3264, 2448}, {5376, 3752}}, 8_000_000, 0, 4f / 3f},
                 {"Largest similar for 5376x3752 from increasing resolutions",
                         INCREASING_RESOLUTIONS,
-                        new int[][]{{5376, 3752}}, new int[]{3264, 2448}, 8_000_000, 0},
+                        new int[][]{{5376, 3752}}, new int[][]{{3264, 2448}, {5376, 3752}}, 8_000_000, 0, 4f / 3f},
                 {"Largest similar for 5376x3752 from unsorted resolutions", UNSORTED_RESOLUTIONS,
-                        new int[][]{{5376, 3752}}, new int[]{3264, 2448}, 8_000_000, 0},
+                        new int[][]{{5376, 3752}}, new int[][]{{3264, 2448}, {5376, 3752}}, 8_000_000, 0, 4f / 3f},
                 {"Fallback to smallest 16:9 above maxArea for unsorted resolutions", UNSORTED_RESOLUTIONS,
-                        new int[][]{{16, 9}}, new int[]{3840, 2160}, 8_000_000, 7_000_000},
+                        new int[][]{{16, 9}}, new int[][]{{3840, 2160}, {16, 9}}, 8_000_000, 7_000_000, 4f / 3f},
                 {"Fallback to smallest 4:3 above maxArea for unsorted resolutions", UNSORTED_RESOLUTIONS,
-                        new int[][]{{4, 3}}, new int[]{4096, 3072}, 8_100_000, 8_000_000},
+                        new int[][]{{4, 3}}, new int[][]{{4096, 3072}, {4, 3}}, 8_100_000, 8_000_000, 4f / 3f},
+                {"Largest resolution with at least 4:3 aspect ratio (landscape sizes)", new int[][]{{400, 300}, {500, 500}, {800, 700}},
+                        new int[][]{{4, 3}, {5, 5}}, new int[][]{{400, 300}, {4, 3}}, 8_000_000, 0, 4f / 3f},
+                {"Largest resolution with at least 4:3 aspect ratio (portrait sizes)", new int[][]{{300, 400}, {500, 500}, {700, 800}},
+                        new int[][]{{3, 4}, {5, 5}}, new int[][]{{300, 400}, {3, 4}}, 8_000_000, 0, 4f / 3f},
         });
     }
 
     private final String description;
     private final int[][] pictureResolution;
     private final int[][] previewResolutions;
-    private final int[] expectedResolution;
+    private final int[][] expectedSizes;
     private final int maxArea;
     private final int minArea;
+    private final float minAspectRatio;
 
     public SizeSelectionHelper_GetBestSizeTest(final String description,
                                                final int[][] pictureResolution,
                                                final int[][] previewResolutions,
-                                               final int[] expectedResolution,
+                                               final int[][] expectedSizes,
                                                final int maxArea,
-                                               final int minArea) {
+                                               final int minArea,
+                                               final float minAspectRatio) {
         this.description = description;
         this.pictureResolution = pictureResolution;
         this.previewResolutions = previewResolutions;
-        this.expectedResolution = expectedResolution;
+        this.expectedSizes = expectedSizes;
         this.maxArea = maxArea;
         this.minArea = minArea;
+        this.minAspectRatio = minAspectRatio;
     }
 
     @Test
-    public void should_returnLargestSameAspectRatioSize() {
+    public void should_returnLargestPictureSizeWithMatchingPreviewSize() {
         final List<Camera.Size> picture = toSizesList(pictureResolution);
         final List<Camera.Size> preview = toSizesList(previewResolutions);
         final Pair<Size, Size> size = SizeSelectionHelper.getBestSize(picture,
-                preview, maxArea, minArea);
+                preview, maxArea, minArea, minAspectRatio);
         assertThat(size).isNotNull();
-        assertSizeEqualsResolution(size.first, expectedResolution);
+        assertSizeEqualsResolution(size.first, expectedSizes[0]);
+        assertSizeEqualsResolution(size.second, expectedSizes[1]);
     }
 }


### PR DESCRIPTION
To avoid selecting camera picture resolutions with square aspect ratios we introduced a minimum aspect ratio of 4:3.

### How to test
Run the unit tests and use the example apps to test it.

### Ticket 
https://ginis.atlassian.net/browse/PIA-1338
