### PR TITLE
Don't show the QR code hint popup after importing a document

### DIFF
--- a/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
+++ b/ginivision/src/main/java/net/gini/android/vision/camera/CameraFragmentImpl.java
@@ -338,7 +338,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                 new Function0<Unit>() {
                     @Override
                     public Unit invoke() {
-                        closeUploadHintPopUp(true);
+                        closeUploadHintPopUp();
                         return null;
                     }
                 });
@@ -844,7 +844,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         mCameraPreviewShade.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(final View v) {
-                closeUploadHintPopUp(true);
+                closeUploadHintPopUp();
                 closeQRCodeScannerHintPopUp();
             }
         });
@@ -868,7 +868,8 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         mImportButtonContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(final View view) {
-                closeUploadHintPopUp(false);
+                mUploadHintPopup.setIsLastPopup(true);
+                closeUploadHintPopUp();
                 showFileChooser();
             }
         });
@@ -1040,7 +1041,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         showError(activity.getString(R.string.gv_document_analysis_error), 3000);
     }
 
-    private void closeUploadHintPopUp(final boolean showQRCodeScannerHint) {
+    private void closeUploadHintPopUp() {
         if (!mUploadHintPopup.isShown()) {
             return;
         }
@@ -1049,7 +1050,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
             public void onAnimationEnd(final View view) {
                 final Context context = view.getContext();
                 saveUploadHintPopUpShown(context);
-                if (showQRCodeScannerHint && shouldShowQRCodeScannerHintPopup()) {
+                if (shouldShowQRCodeScannerHintPopup()) {
                     showQRCodeScannerHintPopUp();
                 }
             }
@@ -1103,7 +1104,9 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         if (activity == null) {
             return false;
         }
-        if (!isQRCodeScanningEnabled(mGiniVisionFeatureConfiguration) || mInterfaceHidden) {
+        if (!isQRCodeScanningEnabled(mGiniVisionFeatureConfiguration)
+                || mInterfaceHidden
+                || mUploadHintPopup.isLastPopup()) {
             return false;
         }
         final Context context = mFragment.getActivity();

--- a/ginivision/src/main/java/net/gini/android/vision/internal/camera/view/HintPopup.kt
+++ b/ginivision/src/main/java/net/gini/android/vision/internal/camera/view/HintPopup.kt
@@ -23,6 +23,9 @@ internal class HintPopup(
     var isShown = false
         private set
 
+    var isLastPopup = false
+        @JvmName("setIsLastPopup") set
+
     init {
         closeButton.setOnClickListener {
             onCloseClicked()


### PR DESCRIPTION
The QR code hint popup was shown after the user imported a document. This PR fixes that and shows the QR code hint popup only, if document import was not started.

[PIA-647](https://ginis.atlassian.net/browse/PIA-647)