### PR TITLE
Remove jcenter and update gini-android-sdk to 2.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
         // For com.hiya:jacoco-android
         maven {
             url "https://plugins.gradle.org/m2/"
@@ -28,7 +27,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         maven {
             // For Commons Imaging
             url 'https://repo.gini.net/nexus/content/repositories/open'

--- a/componentapiexample/build.gradle
+++ b/componentapiexample/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     }
 
     // For backward compatibility
-    implementation('net.gini:gini-android-sdk:2.3.0@aar') {
+    implementation('net.gini:gini-android-sdk:2.9.0@aar') {
         transitive = true
     }
 

--- a/exampleShared/build.gradle
+++ b/exampleShared/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation 'com.karumi:dexter:6.0.2'
 
     // For backward compatibility
-    implementation('net.gini:gini-android-sdk:2.3.0@aar') {
+    implementation('net.gini:gini-android-sdk:2.9.0@aar') {
         transitive = true
     }
 

--- a/ginivision-accounting-network/build.gradle
+++ b/ginivision-accounting-network/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation deps.androidxAnnotations
     implementation project(path: ':ginivision')
-    api('net.gini:gini-android-sdk:2.4.1@aar') {
+    api('net.gini:gini-android-sdk:2.9.0@aar') {
         transitive = true
     }
 

--- a/ginivision-network/build.gradle
+++ b/ginivision-network/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation deps.androidxAnnotations
     implementation project(path: ':ginivision')
-    api('net.gini:gini-android-sdk:2.7.0@aar') {
+    api('net.gini:gini-android-sdk:2.9.0@aar') {
         transitive = true
     }
 

--- a/screenapiexample/build.gradle
+++ b/screenapiexample/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     }
 
     // For backward compatibility
-    implementation('net.gini:gini-android-sdk:2.3.0@aar') {
+    implementation('net.gini:gini-android-sdk:2.9.0@aar') {
         transitive = true
     }
 


### PR DESCRIPTION
Had to update gini-android-sdk to use Volley 1.2.0 which is the first
version available on maven central.

### Ticket 
https://ginis.atlassian.net/browse/PIA-1190
