### PR TITLE
Pia 1192 update to gradle7 publish plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath "com.android.tools.build:gradle:$androidGradlePluginVersion"
         classpath('com.hiya:jacoco-android:0.2')
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,8 @@
 
 
 buildscript {
-    ext.kotlinVersion = '1.4.21'
+    ext.kotlinVersion = '1.5.21'
+    ext.dokkaVersion = '1.5.0'
 
     repositories {
         google()
@@ -10,14 +11,15 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath('com.hiya:jacoco-android:0.2')
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.10"
-        classpath "org.jetbrains.dokka:kotlin-as-java-plugin:1.4.10"
-        classpath 'com.google.gms:google-services:4.3.8'
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
+        classpath "org.jetbrains.dokka:kotlin-as-java-plugin:$dokkaVersion"
+        classpath 'com.google.gms:google-services:4.3.10'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
         // For com.hiya:jacoco-android
         maven {
             url "https://plugins.gradle.org/m2/"
@@ -28,7 +27,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         maven {
             // For Commons Imaging
             url 'https://repo.gini.net/nexus/content/repositories/open'

--- a/buildSrc/src/main/groovy/GenerateJavadoc.groovy
+++ b/buildSrc/src/main/groovy/GenerateJavadoc.groovy
@@ -1,8 +1,10 @@
 import org.gradle.api.Task
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.javadoc.Javadoc
 
 class GenerateJavadoc extends Javadoc {
 
+    @Input
     String projectTitle = "Unknown Title"
 
     @Override

--- a/componentapiexample/build.gradle
+++ b/componentapiexample/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     }
 
     // For backward compatibility
-    implementation('net.gini:gini-android-sdk:2.3.0@aar') {
+    implementation('net.gini:gini-android-sdk:2.9.0@aar') {
         transitive = true
     }
 

--- a/exampleShared/build.gradle
+++ b/exampleShared/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation 'com.karumi:dexter:6.0.2'
 
     // For backward compatibility
-    implementation('net.gini:gini-android-sdk:2.3.0@aar') {
+    implementation('net.gini:gini-android-sdk:2.9.0@aar') {
         transitive = true
     }
 

--- a/ginivision-accounting-network/build.gradle
+++ b/ginivision-accounting-network/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'com.android.library'
+plugins {
+    id 'com.android.library'
+    id 'maven-publish'
+}
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -52,7 +55,6 @@ dependencies {
 }
 
 apply from: rootProject.file('gradle/codequality.gradle')
-apply from: rootProject.file('gradle/maven.gradle')
 apply from: rootProject.file('gradle/javadoc_coverage.gradle')
 
 task generateJavadoc(type: GenerateJavadoc) {
@@ -71,7 +73,4 @@ task javadocJar(type: Jar, dependsOn: generateJavadoc) {
     from destinationDir
 }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-}
+apply from: rootProject.file('gradle/maven.gradle')

--- a/ginivision-accounting-network/build.gradle
+++ b/ginivision-accounting-network/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation deps.androidxAnnotations
     implementation project(path: ':ginivision')
-    api('net.gini:gini-android-sdk:2.4.1@aar') {
+    api('net.gini:gini-android-sdk:2.9.0@aar') {
         transitive = true
     }
 

--- a/ginivision-accounting-network/gradle.properties
+++ b/ginivision-accounting-network/gradle.properties
@@ -1,3 +1,4 @@
+groupId=net.gini
 artifactId=gini-vision-accounting-network-lib
 android.useAndroidX=true
 android.enableJetifier=true

--- a/ginivision-network/build.gradle
+++ b/ginivision-network/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation deps.androidxAnnotations
     implementation project(path: ':ginivision')
-    api('net.gini:gini-android-sdk:2.7.0@aar') {
+    api('net.gini:gini-android-sdk:2.9.0@aar') {
         transitive = true
     }
 

--- a/ginivision-network/build.gradle
+++ b/ginivision-network/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'com.android.library'
+plugins {
+    id 'com.android.library'
+    id 'maven-publish'
+}
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -52,7 +55,6 @@ dependencies {
 }
 
 apply from: rootProject.file('gradle/codequality.gradle')
-apply from: rootProject.file('gradle/maven.gradle')
 apply from: rootProject.file('gradle/javadoc_coverage.gradle')
 
 task generateJavadoc(type: GenerateJavadoc) {
@@ -70,8 +72,4 @@ task javadocJar(type: Jar, dependsOn: generateJavadoc) {
     classifier = 'javadoc'
     from destinationDir
 }
-
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-}
+apply from: rootProject.file('gradle/maven.gradle')

--- a/ginivision-network/gradle.properties
+++ b/ginivision-network/gradle.properties
@@ -1,3 +1,4 @@
+groupId=net.gini
 artifactId=gini-vision-network-lib
 android.useAndroidX=true
 android.enableJetifier=true

--- a/ginivision/build.gradle
+++ b/ginivision/build.gradle
@@ -1,7 +1,10 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'com.hiya.jacoco-android'
-apply plugin: 'org.jetbrains.dokka'
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'com.hiya.jacoco-android'
+    id 'org.jetbrains.dokka'
+    id 'maven-publish'
+}
 
 jacoco {
     toolVersion = "0.8.3"
@@ -103,11 +106,10 @@ dependencies {
 
     androidTestUtil deps.androidxTestOrchestrator
 
-    dokkaHtmlPlugin 'org.jetbrains.dokka:kotlin-as-java-plugin:1.4.10'
+    dokkaHtmlPlugin "org.jetbrains.dokka:kotlin-as-java-plugin:$dokkaVersion"
 }
 
 apply from: rootProject.file('gradle/codequality.gradle')
-apply from: rootProject.file('gradle/maven.gradle')
 apply from: rootProject.file('gradle/javadoc_coverage.gradle')
 apply from: rootProject.file('gradle/multidex_for_tests.gradle')
 
@@ -167,7 +169,4 @@ task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
     from dokkaJavadoc.outputDirectory
 }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-}
+apply from: rootProject.file('gradle/maven.gradle')

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,6 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
 # mavenOpenRepoUrl=https://repo.i.gini.net/nexus/content/repositories/open
 groupId=net.gini
 version=4.1.1
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,5 @@ version=4.1.1
 
 android.useAndroidX=true
 android.enableJetifier=true
+
+androidGradlePluginVersion=7.0.0

--- a/gradle/git_utils.gradle
+++ b/gradle/git_utils.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'org.ajoberstar:grgit:1.5.0'

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,71 +1,85 @@
-apply plugin: 'maven'
-
-// In order to upload to the repo, you can create a file ~/.gradle/gradle.properties with
-//
+// Publishing requires the following parameters (you can either pass them in as gradle parameters with -P<paramName>=...
+// or you can add them to a gradle.properties file (for ex. in your global ~/.gradle/gradle.properties file)):
 // repoUser=<your user name>
 // repoPassword=<your password>
-// mavenSnapshotsRepoUrl=<url for snapshots>
-// mavenRepoUrl=<url for releases>
-// mavenLocalRepoUrl=<url for local releases>
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            pom.groupId = groupId
-            pom.artifactId = artifactId
-            pom.version = version
-            if (project.hasProperty('devVersionSuffix')) {
-                pom.version = "${pom.version}.${devVersionSuffix}"
-            }
-            if (project.hasProperty('mavenSnapshotsRepoUrl')) {
-                pom.version = "${pom.version}-SNAPSHOT"
-            }
+//
+// Also at least one of the following parameters are required:
+// mavenOpenRepoUrl=<URL>
+// mavenSnapshotsRepoUrl=<URL>
+// mavenLocalRepoUrl=<URL>
 
-            pom.project {
-                licenses {
-                    license {
-                        name 'Private License'
-                        url 'https://raw.githubusercontent.com/gini/gini-vision-lib-android/master/LICENSE.md'
-                        distribution 'repo'
+// Because the components are created only during the afterEvaluate phase, we must
+// configure our publications using the afterEvaluate() lifecycle method
+afterEvaluate {
+
+    // Create source and javadoc artifacts
+    def sourcesArtifact = artifacts.add('archives', sourcesJar)
+    def javadocArtifact = artifacts.add('archives', javadocJar)
+
+    publishing {
+        publications {
+            // Creates a Maven publication called "release"
+            release(MavenPublication) {
+                // Applies the component for the release build variant
+                from components.release
+
+                // Adds additional artifacts
+                artifact sourcesArtifact
+                artifact javadocArtifact
+
+                // Customizes attributes of the publication
+                groupId = project.groupId
+                artifactId = project.artifactId
+                version = project.version
+
+                if (project.hasProperty('devVersionSuffix')) {
+                    version = "${version}.${devVersionSuffix}"
+                }
+                if (project.hasProperty('mavenSnapshotsRepoUrl')) {
+                    version = "${version}-SNAPSHOT"
+                }
+
+                pom {
+                    licenses {
+                        license {
+                            name = 'Private License'
+                            url = 'https://raw.githubusercontent.com/gini/gini-vision-lib-android/master/LICENSE.md'
+                            distribution = 'repo'
+                        }
+                    }
+                    organization {
+                        name = 'Gini GmbH'
+                        url = 'https://www.gini.net/'
                     }
                 }
-                organization {
-                    name 'Gini GmbH'
-                    url 'https://www.gini.net/'
-                }
             }
+        }
 
-            pom.whenConfigured { pom ->
-                pom.dependencies.forEach { dep ->
-                    if (dep.getArtifactId().startsWith("gini-")) {
-                        dep.setGroupId(groupId)
+        repositories {
+            if (project.hasProperty('mavenOpenRepoUrl')) {
+                maven {
+                    name = "open"
+                    url = mavenOpenRepoUrl
+                    credentials {
+                        username = project.hasProperty('repoUser') ? repoUser : 'invalidUserName'
+                        password = project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
                     }
                 }
             }
-
             if (project.hasProperty('mavenSnapshotsRepoUrl')) {
-                repository(url: mavenSnapshotsRepoUrl) {
-                    authentication(
-                            userName: project.hasProperty('repoUser') ? repoUser : "invalidUserName",
-                            password: project.hasProperty('repoPassword') ? repoPassword : "invalidPassword"
-                    )
+                maven {
+                    name = "snapshots"
+                    url = mavenSnapshotsRepoUrl
+                    credentials {
+                        username = project.hasProperty('repoUser') ? repoUser : 'invalidUserName'
+                        password = project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
+                    }
                 }
             }
-
-            if (project.hasProperty('mavenRepoUrl')) {
-                repository(url: mavenRepoUrl) {
-                    authentication(
-                            userName: project.hasProperty('repoUser') ? repoUser : 'invalidUserName',
-                            password: project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
-                    )
-                }
-            }
-
             if (project.hasProperty('mavenLocalRepoUrl')) {
-                repository(url: mavenLocalRepoUrl) {
-                    authentication(
-                            userName: project.hasProperty('repoUser') ? repoUser : 'invalidUserName',
-                            password: project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
-                    )
+                maven {
+                    name = "local"
+                    url = mavenLocalRepoUrl
                 }
             }
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip

--- a/screenapiexample/build.gradle
+++ b/screenapiexample/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     }
 
     // For backward compatibility
-    implementation('net.gini:gini-android-sdk:2.3.0@aar') {
+    implementation('net.gini:gini-android-sdk:2.9.0@aar') {
         transitive = true
     }
 


### PR DESCRIPTION
Please review after #322.

Migrate to gradle 7 and replace the old maven plugin with the new `maven-publish` plugin for publishing releases to our own maven repository.

Also update the Android Gradle Plugin to the latest version (7.0.0) and use the required Java 11 to run gradle.

For creating javadoc we use AGP 4.2.2 and Java 8. With Java 11 (which is required for AGP 7.0.0) the Javadoc plugin of Gradle is broken and no javadoc is created.

### Ticket 
https://ginis.atlassian.net/browse/PIA-1192
