### PR TITLE
Release version 4.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ app/build.gradle:
 
 ```
 dependencies {
-    implementation 'net.gini:gini-vision-lib:4.2.0'
+    implementation 'net.gini:gini-vision-lib:4.2.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,9 +56,9 @@ task printLibraryVersion {
 }
 
 ext {
-    compileSdkVersion = 30
+    compileSdkVersion = 31
     minSdkVersion = 19
-    targetSdkVersion = 30
+    targetSdkVersion = 31
     versionCode = libVersionCode
     versionName = libVersionName
 }
@@ -91,13 +91,13 @@ ext.deps = [
         mockito                    : 'org.mockito:mockito-core:2.24.5',
         mockitoAndroid             : 'org.mockito:mockito-android:2.24.5',
         mockitoKotlin              : 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0',
-        androidxTestCore           : 'androidx.test:core:1.3.0',
-        androidxTestJUnit          : 'androidx.test.ext:junit:1.1.2',
-        androidxTestRunner         : 'androidx.test:runner:1.3.0',
-        androidxTestRules          : 'androidx.test:rules:1.3.0',
-        androidxTestOrchestrator   : 'androidx.test:orchestrator:1.3.0',
-        androidxTestEspressoCore   : 'androidx.test.espresso:espresso-core:3.3.0',
-        androidxTestEspressoIntents: 'androidx.test.espresso:espresso-intents:3.3.0',
+        androidxTestCore           : 'androidx.test:core:1.4.0',
+        androidxTestJUnit          : 'androidx.test.ext:junit:1.1.3',
+        androidxTestRunner         : 'androidx.test:runner:1.4.0',
+        androidxTestRules          : 'androidx.test:rules:1.4.0',
+        androidxTestOrchestrator   : 'androidx.test:orchestrator:1.4.0',
+        androidxTestEspressoCore   : 'androidx.test.espresso:espresso-core:3.4.0',
+        androidxTestEspressoIntents: 'androidx.test.espresso:espresso-intents:3.4.0',
         androidxTestUiAutomator    : 'androidx.test.uiautomator:uiautomator:2.2.0',
         androidxMultidex           : 'androidx.multidex:multidex:2.0.1',
         robolectric                : 'org.robolectric:robolectric:4.5-alpha-3'

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,13 @@ allprojects {
             url 'https://repo.gini.net/nexus/content/repositories/snapshots'
         }
         mavenCentral()
+        // For bolts-android 1.5.0 used by gini-android-sdk
+        //noinspection JcenterRepositoryObsolete
+        jcenter()
+        // For bolts-tasks and bolts-applinks 1.4.1-SNAPSHOT (which they should have released as version 1.5.0)
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
 }
 

--- a/componentapiexample/build.gradle
+++ b/componentapiexample/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     }
 
     // For backward compatibility
-    implementation('net.gini:gini-android-sdk:2.9.0@aar') {
+    implementation('net.gini:gini-android-sdk:2.9.1@aar') {
         transitive = true
     }
 

--- a/componentapiexample/src/main/AndroidManifest.xml
+++ b/componentapiexample/src/main/AndroidManifest.xml
@@ -39,7 +39,8 @@
         android:largeHeap="true">
         <activity
             android:name=".MainActivity"
-            android:theme="@style/AppThemeCompat">
+            android:theme="@style/AppThemeCompat"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/exampleShared/build.gradle
+++ b/exampleShared/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation 'com.karumi:dexter:6.0.2'
 
     // For backward compatibility
-    implementation('net.gini:gini-android-sdk:2.9.0@aar') {
+    implementation('net.gini:gini-android-sdk:2.9.1@aar') {
         transitive = true
     }
 

--- a/ginivision-accounting-network/README.md
+++ b/ginivision-accounting-network/README.md
@@ -50,8 +50,8 @@ app/build.gradle:
 
 ```
 dependencies {
-    implementation 'net.gini:gini-vision-lib:4.2.0'
-    implementation 'net.gini:gini-vision-accounting-network-lib:4.2.0'
+    implementation 'net.gini:gini-vision-lib:4.2.1'
+    implementation 'net.gini:gini-vision-accounting-network-lib:4.2.1'
 }
 ```
 

--- a/ginivision-accounting-network/build.gradle
+++ b/ginivision-accounting-network/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation deps.androidxAnnotations
     implementation project(path: ':ginivision')
-    api('net.gini:gini-android-sdk:2.9.0@aar') {
+    api('net.gini:gini-android-sdk:2.9.1@aar') {
         transitive = true
     }
 

--- a/ginivision-network/README.md
+++ b/ginivision-network/README.md
@@ -48,8 +48,8 @@ app/build.gradle:
 
 ```
 dependencies {
-    implementation 'net.gini:gini-vision-lib:4.2.0'
-    implementation 'net.gini:gini-vision-network-lib:4.2.0'
+    implementation 'net.gini:gini-vision-lib:4.2.1'
+    implementation 'net.gini:gini-vision-network-lib:4.2.1'
 }
 ```
 

--- a/ginivision-network/build.gradle
+++ b/ginivision-network/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation deps.androidxAnnotations
     implementation project(path: ':ginivision')
-    api('net.gini:gini-android-sdk:2.9.0@aar') {
+    api('net.gini:gini-android-sdk:2.9.1@aar') {
         transitive = true
     }
 

--- a/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisScreenPresenter.java
+++ b/ginivision/src/main/java/net/gini/android/vision/analysis/AnalysisScreenPresenter.java
@@ -349,7 +349,7 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
                                 }
                                     getAnalysisFragmentListenerOrNoOp()
                                             .onExtractionsAvailable(getMapOrEmpty(resultHolder.getExtractions()));
-
+                                break;
                             case NO_NETWORK_SERVICE:
                                 getAnalysisFragmentListenerOrNoOp().onAnalyzeDocument(
                                         getFirstDocument());

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
 # mavenReleasesRepoUrl=https://repo.i.gini.net/nexus/content/repositories/releases
 # mavenOpenRepoUrl=https://repo.i.gini.net/nexus/content/repositories/open
 groupId=net.gini
-version=4.2.0
+version=4.2.1
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/screenapiexample/build.gradle
+++ b/screenapiexample/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     }
 
     // For backward compatibility
-    implementation('net.gini:gini-android-sdk:2.9.0@aar') {
+    implementation('net.gini:gini-android-sdk:2.9.1@aar') {
         transitive = true
     }
 

--- a/screenapiexample/src/main/AndroidManifest.xml
+++ b/screenapiexample/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
         android:label="@string/app_name"
         android:largeHeap="true"
         android:theme="@style/AppTheme">
-        <activity android:name="net.gini.android.vision.screen.MainActivity">
+        <activity android:name="net.gini.android.vision.screen.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
* Fixes analysis screen listener's `onAnalyzeDocument()` being called after `onExtractionsAvailable()`. Now if `onExtractionsAvailable()` was called then `onAnalyzeDocument()` won't be called.
* Updates the Gini API SDK to version [2.9.1](https://github.com/gini/gini-sdk-android/releases/tag/2.9.1) in the default networking implementations (`gini-vision-network-lib` and `gini-vision-accounting-network-lib`).
* Targets Android 12.