### PR TITLE
Release 4.3.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,8 @@ pipeline {
                     allOf {
                         branch 'master'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -54,8 +54,8 @@ pipeline {
                     allOf {
                         branch 'master'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -79,8 +79,8 @@ pipeline {
                     allOf {
                         branch 'master'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -99,8 +99,8 @@ pipeline {
                     allOf {
                         branch 'master'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -121,8 +121,8 @@ pipeline {
                     allOf {
                         branch 'master'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -151,8 +151,8 @@ pipeline {
                     allOf {
                         branch 'master'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -173,8 +173,8 @@ pipeline {
                     allOf {
                         branch 'master'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -195,8 +195,8 @@ pipeline {
                     allOf {
                         branch 'master'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -216,8 +216,8 @@ pipeline {
                     allOf {
                         branch 'master'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -249,8 +249,8 @@ pipeline {
         stage('Release Documentation') {
             when {
                 expression {
-                    def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                    return !tag.isEmpty()
+                    def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                    return status == 0
                 }
                 expression {
                     boolean publish = false
@@ -287,8 +287,8 @@ pipeline {
         stage('Release Library') {
             when {
                 expression {
-                    def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                    return !tag.isEmpty()
+                    def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                    return status == 0
                 }
                 expression {
                     boolean publish = false

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ app/build.gradle:
 
 ```
 dependencies {
-    implementation 'net.gini:gini-vision-lib:4.2.2'
+    implementation 'net.gini:gini-vision-lib:4.3.0'
 }
 ```
 

--- a/ginivision-accounting-network/README.md
+++ b/ginivision-accounting-network/README.md
@@ -50,8 +50,8 @@ app/build.gradle:
 
 ```
 dependencies {
-    implementation 'net.gini:gini-vision-lib:4.2.2'
-    implementation 'net.gini:gini-vision-accounting-network-lib:4.2.2'
+    implementation 'net.gini:gini-vision-lib:4.3.0'
+    implementation 'net.gini:gini-vision-accounting-network-lib:4.3.0'
 }
 ```
 

--- a/ginivision-network/README.md
+++ b/ginivision-network/README.md
@@ -48,8 +48,8 @@ app/build.gradle:
 
 ```
 dependencies {
-    implementation 'net.gini:gini-vision-lib:4.2.2'
-    implementation 'net.gini:gini-vision-network-lib:4.2.2'
+    implementation 'net.gini:gini-vision-lib:4.3.0'
+    implementation 'net.gini:gini-vision-network-lib:4.3.0'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
 # mavenReleasesRepoUrl=https://repo.i.gini.net/nexus/content/repositories/releases
 # mavenOpenRepoUrl=https://repo.i.gini.net/nexus/content/repositories/open
 groupId=net.gini
-version=4.2.2
+version=4.3.0
 
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
* Updates the Gini API SDK to version [2.10.0](https://github.com/gini/gini-sdk-android/releases/tag/2.10.0).
* Allows setting a custom [TrustManager](https://developer.android.com/reference/javax/net/ssl/TrustManager) implementation in the default networking implementations (`gini-vision-network-lib` and `gini-vision-accounting-network-lib`) to have full control over which remote certificates to trust.